### PR TITLE
TGUI corners are now sharp by default

### DIFF
--- a/tgui/packages/tgui/index.js
+++ b/tgui/packages/tgui/index.js
@@ -6,6 +6,7 @@
 
 // Themes
 import './styles/main.scss';
+import './styles/themes/rounded_base.scss';
 import './styles/themes/abductor.scss';
 import './styles/themes/cardtable.scss';
 import './styles/themes/spookyconsole.scss';

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
@@ -80,6 +80,7 @@ export const CharacterPreferenceWindow = (props, context) => {
   return (
     <Window
       title="Character Preferences"
+      theme="rounded_base"
       width={920}
       height={770}
     >

--- a/tgui/packages/tgui/styles/base.scss
+++ b/tgui/packages/tgui/styles/base.scss
@@ -17,7 +17,7 @@ $color-bg-end: color.adjust(
 
 $unit: 12px;
 $font-size: 1 * $unit !default;
-$border-radius: 0.16em !default;
+$border-radius: 0em !default;
 
 @function em($px) {
   @return 1em * math.div($px, $unit);

--- a/tgui/packages/tgui/styles/themes/rounded_base.scss
+++ b/tgui/packages/tgui/styles/themes/rounded_base.scss
@@ -1,0 +1,25 @@
+//A simple theme to restore button rounding for UIs with free-floating
+//interactables.
+
+@use 'sass:color';
+@use 'sass:meta';
+
+@use '../base.scss' with (
+  $border-radius: 0.16em,
+);
+
+//We have to import a copy of every component that reads $border-radius.
+.theme-rounded_base {
+
+  @include meta.load-css('../components/Button.scss');
+  @include meta.load-css('../components/Input.scss');
+  @include meta.load-css('../components/NumberInput.scss');
+  @include meta.load-css('../components/ProgressBar.scss');
+  @include meta.load-css('../components/Tabs.scss');
+  @include meta.load-css('../components/TextArea.scss');
+  @include meta.load-css('../components/Tooltip.scss');
+
+  .Layout__content {
+    background-image: none;
+  }
+}


### PR DESCRIPTION
The preference menu by opinion looks weird with this,
 so it's excluded from this change.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

### Before
![before](https://file.house/PVWm.png)
### After
![after](https://file.house/RXp0.png)
## About The Pull Request
(most) TGUI elements no longer round off their edges.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Looks better in my opinion.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
imageadd: TGUI interfaces have had their corners un-cut.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
