### PR TITLE
Update workflows for protected branches

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -50,4 +50,4 @@ jobs:
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.DD_BOT_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -24,8 +24,7 @@ jobs:
           pip install -r tools/changelog/requirements.txt
       - name: Make CL
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          #GITHUB_TOKEN: ${{ secrets.CL_TOKEN }} Use this if you have protected branches
+          GITHUB_TOKEN: ${{ secrets.DD_BOT_PAT || secrets.GITHUB_TOKEN }}
           GIT_EMAIL: "action@github.com"
           GIT_NAME: "Changelog Generation"
         run: python tools/changelog/generate_cl.py

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -44,4 +44,4 @@ jobs:
         pr_body: "This pull request updates the TGS DMAPI to the latest version. Please note any breaking or unimplemented changes before merging."
         pr_label: "Tools"
         pr_allow_empty: false
-        github_token: ${{ secrets.COMFY_ORANGE_PAT }}
+        github_token: ${{ secrets.DD_BOT_PAT }}


### PR DESCRIPTION
No code changes so no CL, allows the repo secret `DD_BOT_PAT` to be set to bypass protected branch checks.


~~The role system is one of github's more obnoxious paid features...~~