### PR TITLE
Observers no longer get runechat for the radio of their orbit target

### DIFF
--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -137,7 +137,7 @@
 	if(!center_turf)
 		return
 
-	if(view_radius <= 0)//special case for if only source cares
+	if(view_radius == 0)//special case for if only source cares
 		. = list()
 		for(var/atom/movable/target as anything in center_turf)
 			var/list/hearing_contents = target.important_recursive_contents?[RECURSIVE_CONTENTS_HEARING_SENSITIVE]
@@ -180,6 +180,8 @@
 /proc/get_hearers_in_radio_ranges(list/obj/item/radio/radios)
 	. = list()
 	for(var/obj/item/radio/radio as anything in radios)
+		if(radio.canhear_range == -1)
+			continue
 		.[radio] = get_hearers_in_LOS(radio.canhear_range, radio, FALSE)
 
 ///Calculate if two atoms are in sight, returns TRUE or FALSE

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -269,7 +269,7 @@
 
 	// Ignore sounds that originate from our person (such as radios we are carrying)
 	//if (sound_loc?.speaker_location() == src && speaker == src) //Kapu Note: Correct this later.
-	if(sound_loc == src)
+	if(sound_loc == hear_location())
 		return
 
 	// Display visual above source

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -2234,3 +2234,8 @@
 
 /atom/proc/speaker_location()
 	return src
+
+///What atom is actually "Hearing".
+//Currently only changed by Observers to be hearing through their orbit target.
+/atom/proc/hear_location()
+	return src

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -14,7 +14,7 @@
 	. = ..()
 	radio = new(src)
 	radio.subspace_transmission = TRUE
-	radio.canhear_range = 0
+	radio.canhear_range = -1
 	radio.set_listening(FALSE, TRUE)
 	radio.recalculateChannels()
 

--- a/code/game/machinery/computer/chef_orders/chef_order.dm
+++ b/code/game/machinery/computer/chef_orders/chef_order.dm
@@ -19,7 +19,7 @@
 	radio = new(src)
 	radio.set_frequency(FREQ_SUPPLY)
 	radio.subspace_transmission = TRUE
-	radio.canhear_range = 0
+	radio.canhear_range = -1
 	radio.recalculateChannels()
 
 	if(!order_datums.len)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -36,7 +36,7 @@
 	///used for tracking what listening should be in the absence of things forcing it off, eg its set to listen but gets emp'd temporarily
 	var/should_be_listening = TRUE
 
-	/// Both the range around the radio in which mobs can hear what it receives and the range the radio can hear
+	/// Both the range around the radio in which mobs can hear what it receives and the range the radio can hear. If it's -1, it will not broadcast sound or listen.
 	var/canhear_range = 3
 	/// Tracks the number of EMPs currently stacked.
 	var/emped = 0

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -153,7 +153,7 @@
 	. = ..()
 	radio = new(src)
 	radio.subspace_transmission = TRUE
-	radio.canhear_range = 0
+	radio.canhear_range = -1
 	radio.recalculateChannels()
 	spark_system = new
 	spark_system.set_up(4,1,src)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -120,7 +120,7 @@
 	radio = new(src)
 	radio.keyslot = new radio_key
 	radio.subspace_transmission = TRUE
-	radio.canhear_range = 0
+	radio.canhear_range = -1
 	radio.recalculateChannels()
 
 	occupant_vis = new(null, src)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -917,3 +917,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!prefs || (client?.combo_hud_enabled && prefs.toggles & COMBOHUD_LIGHTING))
 		return ..()
 	return GLOB.ghost_lighting_options[prefs.read_preference(/datum/preference/choiced/ghost_lighting)]
+
+/mob/dead/observer/hear_location()
+	return orbit_target || ..()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -172,7 +172,7 @@
 	if(radio_key)
 		internal_radio.keyslot = new radio_key
 	internal_radio.subspace_transmission = TRUE
-	internal_radio.canhear_range = 0 // anything greater will have the bot broadcast the channel as if it were saying it out loud.
+	internal_radio.canhear_range = -1 // anything greater will have the bot broadcast the channel as if it were saying it out loud.
 	internal_radio.recalculateChannels()
 
 	//Adds bot to the diagnostic HUD system


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds `hear_location()` which by default points to `src`. Observers are `orbit_target || src`. Practical change is in the title.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Observers no longer get runechat for the radio of their orbit target
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
