### PR TITLE
Fix mouse pointer over interaction particles 

### DIFF
--- a/code/modules/interaction_particle/interaction_particle.dm
+++ b/code/modules/interaction_particle/interaction_particle.dm
@@ -2,7 +2,7 @@
 	name = "You shouldn't see this!"
 	icon = 'goon/icons/mob/interact.dmi'
 	icon_state = "interact"
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	alpha = 180
 	plane = GAME_PLANE_UPPER_FOV_HIDDEN
 	layer = ABOVE_ALL_MOB_LAYER

--- a/code/modules/interaction_particle/interaction_particle.dm
+++ b/code/modules/interaction_particle/interaction_particle.dm
@@ -2,6 +2,7 @@
 	name = "You shouldn't see this!"
 	icon = 'goon/icons/mob/interact.dmi'
 	icon_state = "interact"
+	mouse_opacity = 0
 	alpha = 180
 	plane = GAME_PLANE_UPPER_FOV_HIDDEN
 	layer = ABOVE_ALL_MOB_LAYER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stops the mouse pointer from seeing the interaction hand effect (and by extension, it appearing in the right click menu)

## Why It's Good For The Game

You shouldn't see this.

## Changelog

:cl:
fix: Interaction hand icon will no longer be visible in the right click menu
/:cl: