### PR TITLE
Fixes huds & SSwardrobe bug

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -273,6 +273,7 @@
 	rest_icon.icon = ui_style
 	rest_icon.screen_loc = ui_above_movement
 	rest_icon.hud = src
+	rest_icon.update_appearance()
 	static_inventory += rest_icon
 
 	spacesuit = new /atom/movable/screen/spacesuit
@@ -293,9 +294,9 @@
 
 	pull_icon = new /atom/movable/screen/pull()
 	pull_icon.icon = ui_style
-	pull_icon.update_appearance()
 	pull_icon.screen_loc = ui_above_intent
 	pull_icon.hud = src
+	pull_icon.update_appearance()
 	static_inventory += pull_icon
 
 	zone_select = new /atom/movable/screen/zone_sel()

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -215,9 +215,14 @@
 			WARNING("Unable to equip accessory [accessory] in outfit [name]. No uniform present!")
 
 	if(l_hand)
-		H.put_in_l_hand(SSwardrobe.provide_type(l_hand, H))
+		var/obj/item/item_to_equip = SSwardrobe.provide_type(l_hand, H)
+		if(!H.put_in_l_hand(item_to_equip))
+			qdel(item_to_equip)
+
 	if(r_hand)
-		H.put_in_r_hand(SSwardrobe.provide_type(r_hand, H))
+		var/obj/item/item_to_equip = SSwardrobe.provide_type(r_hand, H)
+		if(!H.put_in_r_hand(item_to_equip))
+			qdel(item_to_equip)
 
 	if(!visualsOnly) // Items in pockets or backpack don't show up on mob's icon.
 		if(l_pocket)


### PR DESCRIPTION
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The "Rest" and "Pull" HUD icons no longer lie to users if they logged in after the mob starting resting or pulling.
fix: SSwardrobe will now delete held items it fails to equip.
fix: Vox no longer have a permanent N2 tank embedded inside them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
