### PR TITLE
Fixes asset caching

### DIFF
--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -159,6 +159,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		CRASH("spritesheet [type] cannot register without a name")
 
 	if (!should_refresh() && read_from_cache())
+		fully_generated = TRUE
 		return
 
 	// If it's cached, may as well load it now, while the loading is cheap
@@ -355,7 +356,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		size[SPRSZ_STRIPPED] = null
 		sheet_copy.Insert(I, icon_state=sprite_name)
 		size[SPRSZ_ICON] = sheet_copy
-		
+
 		sprites[sprite_name] = list(size_id, position)
 	else
 		sizes[size_id] = size = list(1, I, null)


### PR DESCRIPTION
The asset was being loaded, seeing that fully_generated is false, so it attempts to rebuild. The rebuilding clears the existing file cache, and fucks us.

- https://github.com/tgstation/tgstation/pull/69852

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Character Creator icons will not longer appear invisible during some rounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
