### PR TITLE
[EXPERIMENTAL] Free up alt-click functionality by moving it to a verb called Examine Contents

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -410,9 +410,6 @@
 		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_CLICK_ALT, user) & COMPONENT_CANCEL_CLICK_ALT)
 		return
-	var/turf/T = get_turf(src)
-	if(T && (isturf(loc) || isturf(src)) && user.TurfAdjacent(T) && !HAS_TRAIT(user, TRAIT_MOVE_VENTCRAWLING))
-		user.set_listed_turf(T)
 
 ///The base proc of when something is right clicked on when alt is held - generally use alt_click_secondary instead
 /atom/proc/alt_click_on_secondary(atom/A)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -457,7 +457,6 @@
  */
 /mob/verb/examinate(atom/examinify as mob|obj|turf in view()) //It used to be oview(12), but I can't really say why
 	set name = "Examine"
-	set category = "IC"
 
 	if(isturf(examinify) && !(sight & SEE_TURFS) && !(examinify in view(client ? client.view : world.view, src)))
 		// shift-click catcher may issue examinate() calls for out-of-sight turfs
@@ -505,6 +504,30 @@
 	to_chat(src, "<div class='examine_block'><span class='infoplain'>[result.Join()]</span></div>") //PARIAH EDIT CHANGE
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, examinify)
 
+/mob/verb/click_on(atom/clicked as mob|obj|turf in view())
+	set name = "Click On"
+	set category = "Object"
+
+	if(client && !(clicked in view(client.view, src)))
+		return FALSE
+	client?.Click(clicked, get_turf(clicked))
+
+/mob/verb/right_click_on(atom/clicked as mob|obj|turf in view())
+	set name = "Right Click On"
+	set category = "Object"
+
+	var/static/right_click_param = list2params(list(RIGHT_CLICK = 1))
+
+	if(client && !(clicked in view(client.view, src)))
+		return FALSE
+
+	client?.Click(clicked, get_turf(clicked), params = right_click_param)
+
+/mob/verb/examine_contents(turf/clicked as turf in view())
+	set name = "Examine Contents"
+
+	if(clicked && usr.TurfAdjacent(clicked))
+		usr.set_listed_turf(clicked)
 
 /mob/proc/blind_examine_check(atom/examined_thing)
 	return TRUE //The non-living will always succeed at this check.
@@ -614,7 +637,6 @@
  */
 /mob/verb/pointed(atom/A as mob|obj|turf in view())
 	set name = "Point To"
-	set category = "Object"
 
 	if(client && !(A in view(client.view, src)))
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Also adds `Click On` and `Right Click On` verbs because why not.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Alt Click no longer examines turf contents
add: You can now use the "Examine Contents" verb to examine turf contents
add: Click On and Right Click On added to the verb list.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
