### PR TITLE
Adds repeat construction to right click with stacks of materials

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -389,7 +389,7 @@
 	#define COMPONENT_SECONDARY_CONTINUE_ATTACK_CHAIN (1<<1)
 	#define COMPONENT_SECONDARY_CALL_NORMAL_ATTACK_CHAIN (1<<2)
 /// From base of [/obj/item/proc/attack_secondary()]: (atom/target, mob/user, params)
-#define COMSIG_ITEM_ATTACK_SECONDARY "item_pre_attack_secondary"
+#define COMSIG_ITEM_ATTACK_SECONDARY "item_attack_secondary"
 ///from base of obj/item/afterattack(): (atom/target, mob/user, proximity_flag, click_parameters)
 #define COMSIG_ITEM_AFTERATTACK "item_afterattack"
 ///from base of obj/item/afterattack_secondary(): (atom/target, mob/user, proximity_flag, click_parameters)

--- a/code/__DEFINES/do_afters.dm
+++ b/code/__DEFINES/do_afters.dm
@@ -2,3 +2,4 @@
 #define DOAFTER_SOURCE_MECHADRILL "doafter_mechadrill"
 #define DOAFTER_SOURCE_SURVIVALPEN "doafter_survivalpen"
 #define DOAFTER_SOURCE_GETTING_UP "doafter_gettingup"
+#define DOAFTER_SOURCE_STACKCONSTRUCTION "doafter_stackconstruction"

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -147,10 +147,6 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	source = /datum/robot_energy_storage/iron
 	tram_wall_type = /obj/structure/tramwall
 
-/obj/item/stack/sheet/iron/examine(mob/user)
-	. = ..()
-	. += span_notice("You can build a wall girder (unanchored) by right clicking on an empty floor.")
-
 /obj/item/stack/sheet/iron/narsie_act()
 	new /obj/item/stack/sheet/runed_metal(loc, amount)
 	qdel(src)
@@ -174,32 +170,6 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 /obj/item/stack/sheet/iron/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins whacking [user.p_them()]self over the head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
-
-/obj/item/stack/sheet/iron/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
-	if(istype(target, /turf/open))
-		var/turf/open/build_on = target
-		if(!user.Adjacent(build_on))
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		if(isgroundlessturf(build_on))
-			user.balloon_alert(user, "can't place it here!")
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		if(build_on.is_blocked_turf())
-			user.balloon_alert(user, "something is blocking the tile!")
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		if(get_amount() < 2)
-			user.balloon_alert(user, "not enough material!")
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		if(!do_after(user, build_on, 4 SECONDS))
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		if(build_on.is_blocked_turf())
-			user.balloon_alert(user, "something is blocking the tile!")
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		if(!use(2))
-			user.balloon_alert(user, "not enough material!")
-			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		new/obj/structure/girder/displaced(build_on)
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-	return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /*
  * Plasteel

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -531,12 +531,12 @@
 	else
 		. = ..()
 
-/obj/item/stack/sheet/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/stack/sheet/attack_secondary(atom/target, mob/living/user, params)
 	var/turf/open/build_on = target
 	if(!build_on)
 		return SECONDARY_ATTACK_CONTINUE_CHAIN
 
-	if(!proximity_flag)
+	if(!user.Adjacent(target))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	if(!last_used_recipe || user != last_user)
 		to_chat(user, span_warning("You haven't built anything yet!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Right clicking a nearby turf redoes the same construction action.
Alt Clicking now separates a stack into two.
Removes the snowflake interaction of iron sheets making unachored girders. (Which didn't even consider the construction speed up trait.)

**NB: Rods don't work at this moment** since (I believe) they have unique turf interactions for building catwalks that overrides this
Also, recipes like sheets into rods work with this which feels slightly clumsy but technically works as intended?
Some constructions are instant too which might be griefy but it's not like you couldn't move and spam it with the menu
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should make construction by hand more like the RCD.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Stacks of materials can now repeat constructions with right click.
del: Iron sheet stacks no longer make unanchored wall girders.
qol: Moved splitting stacks onto altclick instead of right clicking with an empty hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
