### PR TITLE
Base TGUI theme brightening

### DIFF
--- a/tgui/packages/tgui/styles/base.scss
+++ b/tgui/packages/tgui/styles/base.scss
@@ -7,9 +7,9 @@
 @use 'sass:math';
 
 $color-fg: #ffffff !default;
-$color-bg: #252525 !default;
+$color-bg: #444444 !default;
 $color-bg-section: rgba(0, 0, 0, 0.33) !default;
-$color-bg-grad-spread: 2% !default;
+$color-bg-grad-spread: 5% !default;
 $color-bg-start: color.adjust(
   $color-bg, $lightness: $color-bg-grad-spread) !default;
 $color-bg-end: color.adjust(

--- a/tgui/packages/tgui/styles/base.scss
+++ b/tgui/packages/tgui/styles/base.scss
@@ -7,9 +7,9 @@
 @use 'sass:math';
 
 $color-fg: #ffffff !default;
-$color-bg: #444444 !default;
-$color-bg-section: rgba(0, 0, 0, 0.33) !default;
-$color-bg-grad-spread: 5% !default;
+$color-bg: #333333 !default;
+$color-bg-section: rgba(0, 0, 0, 0.25) !default;
+$color-bg-grad-spread: 0% !default; //Dummied out at kapu's request
 $color-bg-start: color.adjust(
   $color-bg, $lightness: $color-bg-grad-spread) !default;
 $color-bg-end: color.adjust(


### PR DESCRIPTION
Significantly brightens the base TGUI theme, Up to community opinion on this one.

New (v2)
![menagerie](https://file.house/dmiP.png)
New (v1)
![Brightened Atmos Alert Console](https://images-ext-1.discordapp.net/external/G6EItgMpjgFzmcU6j8MtGWEdtH0GrMII2aV4efVqcnQ/https/file.house/kBAy.png)
Old
![Dark Atmos Alert Console](https://file.house/mLJr.png)

:cl:
imageadd: TGUI's base theme has been significantly brightened
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
