### PR TITLE
Health Analyzer chem scanner rightclick purge

### DIFF
--- a/code/_onclick/hud/pai.dm
+++ b/code/_onclick/hud/pai.dm
@@ -90,8 +90,8 @@
 	var/list/modifiers = params2list(params)
 	var/mob/living/carbon/holder = get(pAI.card.loc, /mob/living/carbon)
 	if(holder)
-		if (LAZYACCESS(modifiers, RIGHT_CLICK))
-			pAI.hostscan.attack_secondary(holder, pAI)
+		if (LAZYACCESS(modifiers, CTRL_CLICK)) //This is a UI element so I don't care about the interaction overlap.
+			pAI.hostscan.attack_self(pAI)
 		else
 			pAI.hostscan.attack(holder, pAI)
 	else

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -1,7 +1,8 @@
 // Describes the three modes of scanning available for health analyzers
 #define SCANMODE_HEALTH 0
 #define SCANMODE_WOUND 1
-#define SCANMODE_COUNT 2 // Update this to be the number of scan modes if you add more
+#define SCANMODE_CHEM 2
+#define SCANMODE_COUNT 3 // Update this to be the number of scan modes if you add more
 #define SCANNER_CONDENSED 0
 #define SCANNER_VERBOSE 1
 
@@ -13,7 +14,7 @@
 	worn_icon_state = "healthanalyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	desc = "A hand-held body scanner capable of distinguishing vital signs of the subject. Has a side button to scan for chemicals, and can be toggled to scan wounds."
+	desc = "A hand-held body scanner capable of distinguishing vital signs of the subject. Can be toggled to scan for chemicals or wounds."
 	flags_1 = CONDUCT_1
 	item_flags = NOBLUDGEON
 	slot_flags = ITEM_SLOT_BELT
@@ -47,6 +48,9 @@
 			to_chat(user, span_notice("You switch the health analyzer to check physical health."))
 		if(SCANMODE_WOUND)
 			to_chat(user, span_notice("You switch the health analyzer to report extra info on wounds."))
+		if(SCANMODE_CHEM)
+			to_chat(user, span_notice("You switch the health analyzer to scan chemical contents."))
+		//If this list gets any longer please consider a LUT for the latter half of the message.
 
 /obj/item/healthanalyzer/attack(mob/living/M, mob/living/carbon/human/user)
 	flick("[icon_state]-scan", src) //makes it so that it plays the scan animation upon scanning, including clumsy scanning
@@ -73,6 +77,8 @@
 			healthscan(user, M, mode, advanced)
 		if (SCANMODE_WOUND)
 			woundscan(user, M, src)
+		if (SCANMODE_CHEM)
+			chemscan(user, victim)
 
 	add_fingerprint(user)
 
@@ -517,6 +523,7 @@
 
 #undef SCANMODE_HEALTH
 #undef SCANMODE_WOUND
+#undef SCANMODE_CHEM
 #undef SCANMODE_COUNT
 #undef SCANNER_CONDENSED
 #undef SCANNER_VERBOSE

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -78,13 +78,9 @@
 		if (SCANMODE_WOUND)
 			woundscan(user, M, src)
 		if (SCANMODE_CHEM)
-			chemscan(user, victim)
+			chemscan(user, M)
 
 	add_fingerprint(user)
-
-/obj/item/healthanalyzer/attack_secondary(mob/living/victim, mob/living/user, params)
-	chemscan(user, victim)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/healthanalyzer/add_item_context(
 	obj/item/source,

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -60,10 +60,6 @@
 	log = list()
 	scanning = FALSE
 
-/obj/item/detective_scanner/pre_attack_secondary(atom/A, mob/user, params)
-	scan(A, user)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
 /obj/item/detective_scanner/afterattack(atom/A, mob/user, params)
 	. = ..()
 	scan(A, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes an utterly baffling usage of rightclick on health analyzers.

## Why It's Good For The Game

Right click shouldn't be used as any other free keybind.

## Changelog


:cl:
qol: the Health Analyzer chem scanner has been readded to the mode cycle loop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
