### PR TITLE
Generalized staple to newgame pings

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -525,7 +525,7 @@
 /datum/config_entry/string/chat_announce_new_game
 	default = null
 
-/datum/config_entry/string/chat_new_game_notifications
+/datum/config_entry/string/chat_newgame_staple
 	default = null
 
 /datum/config_entry/flag/debug_admin_hrefs

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -109,7 +109,8 @@ SUBSYSTEM_DEF(ticker)
 			for(var/client/C in GLOB.clients)
 				window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
 			to_chat(world, span_notice("<b>Welcome to [station_name()]!</b>"))
-			send2chat("New round starting on [SSmapping.config.map_name]!", CONFIG_GET(string/chat_announce_new_game))
+			var/newround_staple = CONFIG_GET(string/chat_newgame_staple)
+			send2chat("New round starting on [SSmapping.config.map_name][newround_staple ? ", [newround_staple]" : null]!", CONFIG_GET(string/chat_announce_new_game))
 			current_state = GAME_STATE_PREGAME
 			SEND_SIGNAL(src, COMSIG_TICKER_ENTER_PREGAME)
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -503,8 +503,8 @@ MINUTE_CLICK_LIMIT 400
 ## Send a message with the station name starting a new game.
 #CHAT_ANNOUNCE_NEW_GAME
 
-## Ping users who use the `notify` command when a new game starts.
-#CHAT_NEW_GAME_NOTIFICATIONS
+## Text to staple to the new game announcement message, Usually a discord role ping.
+#CHAT_NEWGAME_STAPLE <@DISCORD_ROLE_ID_HERE>
 
 ## Allow admin hrefs that don't use the new token system, will eventually be removed
 #DEBUG_ADMIN_HREFS


### PR DESCRIPTION

:cl:
config: Server owners can now staple text to the new round notice
del: This removes an already unused config entry that was intended to serve the same purpose, CHAT_NEW_GAME_NOTIFICATIONS
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
