### PR TITLE
More hunger stuff

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -423,7 +423,7 @@
 #define POCKET_STRIP_DELAY (4 SECONDS) //time taken to search somebody's pockets
 #define DOOR_CRUSH_DAMAGE 15 //the amount of damage that airlocks deal when they crush you
 
-#define HUNGER_FACTOR 0.05 //factor at which mob nutrition decreases
+#define HUNGER_FACTOR 0.01 //factor at which mob nutrition decreases
 #define ETHEREAL_CHARGE_FACTOR 0.8 //factor at which ethereal's charge decreases per second
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4) // By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -423,9 +423,6 @@
 #define POCKET_STRIP_DELAY (4 SECONDS) //time taken to search somebody's pockets
 #define DOOR_CRUSH_DAMAGE 15 //the amount of damage that airlocks deal when they crush you
 
-#define HUNGER_FACTOR 0.01 //factor at which mob nutrition decreases
-#define ETHEREAL_CHARGE_FACTOR 0.8 //factor at which ethereal's charge decreases per second
-#define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4) // By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism
 
 // Eye protection

--- a/code/__DEFINES/stat.dm
+++ b/code/__DEFINES/stat.dm
@@ -15,7 +15,10 @@
 #define SATIETY_DECAY 0.2 //Max satiety lasts 25 minutes, 600 * 5
 ///The rate at which satiation decays per second.
 #define HUNGER_DECAY 0.04
-
+///How much hunger is lost on moving (walk)
+#define HUNGER_LOSS_WALK 0.005
+///How much hunger is lost on moving (run)
+#define HUNGER_LOSS_RUN 0.01
 
 #define ETHEREAL_CHARGE_FACTOR 0.8 //factor at which ethereal's charge decreases per second
 #define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.

--- a/code/__DEFINES/stat.dm
+++ b/code/__DEFINES/stat.dm
@@ -14,7 +14,7 @@
 ///The rate at which satiation decays per second.
 #define SATIETY_DECAY 0.2 //Max satiety lasts 25 minutes, 600 * 5
 ///The rate at which satiation decays per second.
-#define HUNGER_DECAY 0.05
+#define HUNGER_DECAY 0.04
 
 
 #define ETHEREAL_CHARGE_FACTOR 0.8 //factor at which ethereal's charge decreases per second

--- a/code/__DEFINES/stat.dm
+++ b/code/__DEFINES/stat.dm
@@ -11,7 +11,14 @@
 
 //Maximum healthiness an individual can have
 #define MAX_SATIETY 600
+///The rate at which satiation decays per second.
+#define SATIETY_DECAY 0.2 //Max satiety lasts 25 minutes, 600 * 5
+///The rate at which satiation decays per second.
+#define HUNGER_DECAY 0.05
 
+
+#define ETHEREAL_CHARGE_FACTOR 0.8 //factor at which ethereal's charge decreases per second
+#define REAGENTS_METABOLISM 0.2 //How many units of reagent are consumed per second, by default.
 // bitflags for machine stat variable
 #define BROKEN (1<<0)
 #define NOPOWER (1<<1)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -262,7 +262,7 @@
 	C.reagents.metabolize(C, metabolic_boost * SSMOBS_DT, 0, can_overdose=TRUE) //this works even without a liver; it's intentional since the virus is metabolizing by itself
 	C.overeatduration = max(C.overeatduration - 4 SECONDS, 0)
 	var/lost_nutrition = 9 - (reduced_hunger * 5)
-	C.adjust_nutrition(-lost_nutrition * HUNGER_FACTOR) //Hunger depletes at 10x the normal speed
+	C.adjust_nutrition(-lost_nutrition * HUNGER_DECAY) //Hunger depletes at 10x the normal speed
 	if(prob(2))
 		to_chat(C, span_notice("You feel an odd gurgle in your stomach, as if it was working much faster than normal."))
 	return 1

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -29,7 +29,7 @@
 				nutrition_ratio = 1
 		if(satiety > 80)
 			nutrition_ratio *= 1.25
-		adjust_nutrition(-nutrition_ratio * HUNGER_FACTOR * delta_time)
+		adjust_nutrition(-nutrition_ratio * HUNGER_DECAY * delta_time)
 		blood_volume = min(blood_volume + (BLOOD_REGEN_FACTOR * nutrition_ratio * delta_time), BLOOD_VOLUME_NORMAL)
 
 	//Effects of bloodloss

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -8,6 +8,9 @@
 
 /mob/living/carbon/Move(NewLoc, direct)
 	. = ..()
+	if(!(usr == src))
+		return
+
 	if(. && !(movement_type & FLOATING)) //floating is easy
 		if(HAS_TRAIT(src, TRAIT_NOHUNGER))
 			set_nutrition(NUTRITION_LEVEL_FED - 1) //just less than feeling vigorous

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -12,9 +12,7 @@
 		if(HAS_TRAIT(src, TRAIT_NOHUNGER))
 			set_nutrition(NUTRITION_LEVEL_FED - 1) //just less than feeling vigorous
 		else if(nutrition && stat != DEAD)
-			adjust_nutrition(-(HUNGER_FACTOR/10))
-			if(m_intent == MOVE_INTENT_RUN)
-				adjust_nutrition(-(HUNGER_FACTOR/10))
+			adjust_nutrition(-(m_intent == MOVE_INTENT_WALK ? HUNGER_LOSS_WALK : HUNGER_LOSS_RUN))
 
 
 /mob/living/carbon/set_usable_legs(new_value)

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -153,7 +153,7 @@
 			human.satiety = min(human.satiety + (SATIETY_DECAY * delta_time), 0)
 			if(DT_PROB(round(-human.satiety/77), delta_time))
 				human.set_timed_status_effect(10 SECONDS, /datum/status_effect/jitter, only_if_higher = TRUE)
-			hunger_rate = 3 * HUNGER_FACTOR
+			hunger_rate = 3 * HUNGER_DECAY
 		hunger_rate *= human.physiology.hunger_mod
 		human.adjust_nutrition(-hunger_rate * delta_time)
 

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -138,7 +138,7 @@
 	// nutrition decrease and satiety
 	if (human.nutrition > 0 && human.stat != DEAD)
 		// THEY HUNGER
-		var/hunger_rate = HUNGER_FACTOR
+		var/hunger_rate = HUNGER_DECAY
 		var/datum/component/mood/mood = human.GetComponent(/datum/component/mood)
 		if(mood && mood.sanity > SANITY_DISTURBED)
 			hunger_rate *= max(1 - 0.002 * mood.sanity, 0.5) //0.85 to 0.75
@@ -146,11 +146,11 @@
 		if(human.satiety > MAX_SATIETY)
 			human.satiety = MAX_SATIETY
 		else if(human.satiety > 0)
-			human.satiety--
+			human.satiety = max(human.satiety - (SATIETY_DECAY * delta_time), 0)
 		else if(human.satiety < -MAX_SATIETY)
 			human.satiety = -MAX_SATIETY
 		else if(human.satiety < 0)
-			human.satiety++
+			human.satiety = min(human.satiety + (SATIETY_DECAY * delta_time), 0)
 			if(DT_PROB(round(-human.satiety/77), delta_time))
 				human.set_timed_status_effect(10 SECONDS, /datum/status_effect/jitter, only_if_higher = TRUE)
 			hunger_rate = 3 * HUNGER_FACTOR


### PR DESCRIPTION


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Hunger decays at a rate of 0.04/s (up from 0.01)
balance: Satiation decays at a rate of 0.2/s (before: 1/s). This means being fully satiated will last 25 minutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
