### PR TITLE
Changes spastic to (muscle) spasms

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -377,20 +377,20 @@
 	owner.update_transform()
 	owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
 
-/datum/mutation/human/spastic
-	name = "Spastic"
+/datum/mutation/human/spasms
+	name = "Muscle Spasms"
 	desc = "Subject suffers from muscle spasms."
 	quality = NEGATIVE
 	text_gain_indication = "<span class='warning'>You flinch.</span>"
 	text_lose_indication = "<span class='notice'>Your flinching subsides.</span>"
 	difficulty = 16
 
-/datum/mutation/human/spastic/on_acquiring()
+/datum/mutation/human/spasms/on_acquiring()
 	if(..())
 		return
 	owner.apply_status_effect(/datum/status_effect/spasms)
 
-/datum/mutation/human/spastic/on_losing()
+/datum/mutation/human/spasms/on_losing()
 	if(..())
 		return
 	owner.remove_status_effect(/datum/status_effect/spasms)

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -398,13 +398,13 @@
 	name = "\improper DNA injector (Anti-Gigantism)"
 	remove_mutations = list(/datum/mutation/human/gigantism)
 
-/obj/item/dnainjector/spastic
-	name = "\improper DNA injector (Spastic)"
-	add_mutations = list(/datum/mutation/human/spastic)
+/obj/item/dnainjector/spasms
+	name = "\improper DNA injector (Muscle Spasms)"
+	add_mutations = list(/datum/mutation/human/spasms)
 
-/obj/item/dnainjector/antispastic
-	name = "\improper DNA injector (Anti-Spastic)"
-	remove_mutations = list(/datum/mutation/human/spastic)
+/obj/item/dnainjector/antispasms
+	name = "\improper DNA injector (Anti-Muscle Spasms)"
+	remove_mutations = list(/datum/mutation/human/spasms)
 
 /obj/item/dnainjector/twoleftfeet
 	name = "\improper DNA injector (Two Left Feet)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes all in-game references of "spastic" to spasms. More so a slur within the UK but it's an eyebrow raising one to put it lightly.
Should be noted that the status effect and brain traumas that do this/something similar opt to use spasms instead so it's only genetics that refers to it, so it also makes it more in line with the rest of the nomenclature
![image](https://user-images.githubusercontent.com/107515217/222775407-9e5d6e29-af38-455e-9c4e-7583b974c929.png)

