### PR TITLE
Port of /tg/'s wanted poster fix

### DIFF
--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -107,7 +107,7 @@
 			qdel(src)
 		else
 			to_chat(user, span_notice("You carefully remove the poster from the wall."))
-			roll_and_drop(user.loc)
+			roll_and_drop(Adjacent(user) ? get_turf(user) : loc)
 
 /obj/structure/sign/poster/attack_hand(mob/user, list/modifiers)
 	. = ..()
@@ -124,10 +124,10 @@
 	R.add_fingerprint(user)
 	qdel(src)
 
-/obj/structure/sign/poster/proc/roll_and_drop(loc)
+/obj/structure/sign/poster/proc/roll_and_drop(atom/location)
 	pixel_x = 0
 	pixel_y = 0
-	var/obj/item/poster/P = new poster_item_type(loc, src)
+	var/obj/item/poster/P = new poster_item_type(location, src)
 	forceMove(P)
 	return P
 
@@ -151,22 +151,18 @@
 
 	var/obj/structure/sign/poster/D = P.poster_structure
 
-	var/temp_loc = get_turf(user)
 	flick("poster_being_set",D)
 	D.forceMove(src)
 	qdel(P) //delete it now to cut down on sanity checks afterwards. Agouri's code supports rerolling it anyway
 	playsound(D.loc, 'sound/items/poster_being_created.ogg', 100, TRUE)
 
-	if(do_after(user, src, PLACE_SPEED))
-		if(!D || QDELETED(D))
-			return
+	var/turf/user_drop_location  = get_turf(user)
+	if(!do_after(user, D, PLACE_SPEED, extra_checks = CALLBACK(D, /obj/structure/sign/poster.proc/snowflake_wall_turf_check, src)))
+		to_chat(user, span_notice("The poster falls down!"))
+		D.roll_and_drop(user_drop_location)
 
-		if(iswallturf(src) && user && user.loc == temp_loc) //Let's check if everything is still there
-			to_chat(user, span_notice("You place the poster!"))
-			return
-
-	to_chat(user, span_notice("The poster falls down!"))
-	D.roll_and_drop(get_turf(user))
+/obj/structure/sign/poster/proc/snowflake_wall_turf_check(atom/hopefully_still_a_wall_turf)
+	return iswallturf(hopefully_still_a_wall_turf)
 
 // Various possible posters follow
 

--- a/code/game/objects/effects/wanted_poster.dm
+++ b/code/game/objects/effects/wanted_poster.dm
@@ -21,8 +21,12 @@
 	postHeaderText = "MISSING" // MAX 7 Characters
 	postHeaderColor = "#0000FF"
 
-/obj/item/poster/wanted/Initialize(mapload, icon/person_icon, wanted_name, description, headerText)
-	. = ..(mapload, new /obj/structure/sign/poster/wanted(src, person_icon, wanted_name, description, headerText, postHeaderColor, background, postName, postDesc))
+
+/obj/item/poster/wanted/Initialize(mapload, icon/person_icon, wanted_name, description, headerText, posterHeaderColor)
+	if(posterHeaderColor)
+		postHeaderColor = posterHeaderColor
+	var/obj/structure/sign/poster/wanted/wanted_poster = new (src, person_icon, wanted_name, description, headerText, postHeaderColor, background, postName, postDesc)
+	. = ..(mapload, wanted_poster)
 	name = "[postName] ([wanted_name])"
 	desc = "[postDesc] [wanted_name]."
 	postHeaderText = headerText
@@ -33,6 +37,7 @@
 	var/postDesc
 	var/posterHeaderText
 	var/posterHeaderColor
+	var/icon/original_icon //cache the passed icon incase we ever get torn down and need to regenerate it.
 
 	poster_item_type = /obj/item/poster/wanted
 
@@ -51,6 +56,7 @@
 	desc = description
 
 	person_icon = icon(person_icon, dir = SOUTH)//copy the image so we don't mess with the one in the record.
+	original_icon = icon(person_icon) //cache this incase it gets torn down
 	var/icon/the_icon = icon("icon" = 'icons/obj/poster_wanted.dmi', "icon_state" = background)
 	person_icon.Shift(SOUTH, 7)
 	person_icon.Crop(7,4,26,30)
@@ -87,11 +93,9 @@
 		poster_icon.Blend(letter_icon, ICON_OVERLAY)
 		startX = startX + 4
 
-/obj/structure/sign/poster/wanted/roll_and_drop(turf/location)
-	var/obj/item/poster/wanted/P = ..(location)
-	P.name = "[postName] ([wanted_name])"
-	P.desc = "[postDesc] [wanted_name]."
-	P.postHeaderText = posterHeaderText
-	P.postHeaderColor = posterHeaderColor
-	return P
-
+/obj/structure/sign/poster/wanted/roll_and_drop(atom/location)
+	pixel_x = 0
+	pixel_y = 0
+	var/obj/item/poster/rolled_poster = new poster_item_type(location, original_icon, wanted_name, desc, posterHeaderText, posterHeaderColor)
+	forceMove(rolled_poster)
+	return rolled_poster

--- a/code/game/objects/effects/wanted_poster.dm
+++ b/code/game/objects/effects/wanted_poster.dm
@@ -25,7 +25,8 @@
 /obj/item/poster/wanted/Initialize(mapload, icon/person_icon, wanted_name, description, headerText, posterHeaderColor)
 	if(posterHeaderColor)
 		postHeaderColor = posterHeaderColor
-	var/obj/structure/sign/poster/wanted/wanted_poster = new (src, person_icon, wanted_name, description, headerText, postHeaderColor, background, postName, postDesc)
+	var/obj/structure/sign/poster/wanted/wanted_poster = new (
+		src, person_icon, wanted_name, description, headerText, postHeaderColor, background, postName, postDesc)
 	. = ..(mapload, wanted_poster)
 	name = "[postName] ([wanted_name])"
 	desc = "[postDesc] [wanted_name]."

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -407,7 +407,7 @@
 			F.attach(src, user)
 		return TRUE
 	//Poster stuff
-	else if(istype(W, /obj/item/poster))
+	else if(istype(W, /obj/item/poster) && Adjacent(user)) //no tk memes.
 		place_poster(W,user)
 		return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/69956 by ShizCalev
contraband.dm hasn't been included (although it has some related code) yet, it's 3AM and I'd need to go over it in better detail to port what's relevant due to files being different.
Currently the PR seems to fix https://github.com/DaedalusDock/daedalusdock/issues/188 as shown here:
![image](https://user-images.githubusercontent.com/107515217/223310212-724cb437-4b74-4113-85ee-fd0c2ca9ddc0.png)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ShizCalev
fix: Wanted/missing posters are no longer broken.
fix: Telekinesis no longer teleports removed posters
/:cl:


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
