### PR TITLE
Fixes light fixture attacking

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -311,6 +311,8 @@
 	if(istype(tool, /obj/item/stock_parts/cell))
 		return FALSE
 
+	if(status != LIGHT_EMPTY)
+		return ..()
 	to_chat(user, span_userdanger("You stick \the [tool] into the light socket!"))
 	if(has_power() && (tool.flags_1 & CONDUCT_1))
 		do_sparks(3, TRUE, src)


### PR DESCRIPTION
## About The Pull Request

Intact lights can now be broken using force, instead of putting the item into the bulb socket.

## Why It's Good For The Game

I don't know when this check was removed (presumably by accident) but now it's back.

## Changelog

:cl:
fix: Fixed light fixtures having incorrect attack behavior
/:cl: