### PR TITLE
Lighting actually initializes during init

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -112,7 +112,7 @@
 			if(prob(1))
 				break_light_tube(TRUE)
 	#endif
-	addtimer(CALLBACK(src, .proc/update, FALSE), 0.1 SECONDS)
+	update(FALSE, TRUE, FALSE)
 
 /obj/machinery/light/Destroy()
 	if(my_area)
@@ -170,7 +170,7 @@
 		if(instant)
 			turn_on(trigger, play_sound)
 		else if(maploaded)
-			turn_on(trigger, play_sound)
+			turn_on(trigger)
 			maploaded = FALSE
 		else if(!turning_on)
 			turning_on = TRUE

--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -9,7 +9,7 @@
 /obj/machinery/light/built/Initialize(mapload)
 	. = ..()
 	status = LIGHT_EMPTY
-	update(0)
+	update(FALSE, FALSE, FALSE)
 
 /obj/machinery/light/no_nightlight
 	nightshift_enabled = FALSE
@@ -70,7 +70,7 @@
 /obj/machinery/light/small/built/Initialize(mapload)
 	. = ..()
 	status = LIGHT_EMPTY
-	update(0)
+	update(FALSE, FALSE, FALSE)
 
 /obj/machinery/light/small/red
 	bulb_colour = "#FF3232"

--- a/modular_pariah/modules/aesthetics/lights/code/lighting.dm
+++ b/modular_pariah/modules/aesthetics/lights/code/lighting.dm
@@ -88,7 +88,7 @@
 	firealarm = FALSE
 	update()
 
-/obj/machinery/light/Initialize(mapload = TRUE)
+/obj/machinery/light/Initialize(mapload)
 	. = ..()
 	if(on)
 		maploaded = TRUE


### PR DESCRIPTION
This really only affects coders.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
Fix: Lighting no longer has a massive delay on actually setting up lights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
