### PR TITLE
Fix missing punctuation in bleeding message

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -155,10 +155,7 @@
 	if(HAS_TRAIT(src, TRAIT_COAGULATING)) // if we have coagulant, we're getting better quick
 		rate_of_change = ", but it's clotting up quickly!"
 	
-	if(!rate_of_change)
-		bleeding_severity += "."
-
-	to_chat(src, span_warning("[bleeding_severity][rate_of_change]"))
+	to_chat(src, span_warning("[bleeding_severity][rate_of_change || "."]"))
 	COOLDOWN_START(src, bleeding_message_cd, next_cooldown)
 
 /mob/living/carbon/human/bleed_warn(bleed_amt = 0, forced = FALSE)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -154,6 +154,9 @@
 
 	if(HAS_TRAIT(src, TRAIT_COAGULATING)) // if we have coagulant, we're getting better quick
 		rate_of_change = ", but it's clotting up quickly!"
+	
+	if(!rate_of_change)
+		bleeding_severity += "."
 
 	to_chat(src, span_warning("[bleeding_severity][rate_of_change]"))
 	COOLDOWN_START(src, bleeding_message_cd, next_cooldown)


### PR DESCRIPTION
## About The Pull Request
Fix missing punctuation in the bleeding message by adding punctuation if no rate of change is set.

## Why It's Good For The Game
It annoyed me.