### PR TITLE
Fix wall icons in mapmaking tools & hub entry length

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -36,6 +36,9 @@
 /// station name (the name of the station in-game)
 /datum/config_entry/string/stationname
 
+/// the line of text under server name on the hub
+/datum/config_entry/string/hub_subtitle
+
 /// Countdown between lobby and the round starting.
 /datum/config_entry/number/lobby_countdown
 	default = 120

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -17,7 +17,7 @@ GLOBAL_REAL_VAR(wall_overlays_cache) = list()
 	name = "wall"
 	desc = "A huge chunk of iron used to separate rooms."
 	icon = 'icons/turf/walls/solid_wall.dmi'
-	icon_state = null
+	icon_state = "wall-0"
 	base_icon_state = "wall"
 
 	explosion_block = 1

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -308,7 +308,6 @@ GLOBAL_VAR(restart_counter)
 	var/new_status = ""
 	if(config)
 		var/server_name = CONFIG_GET(string/servername)
-		var/website_url = CONFIG_GET(string/forumurl)
 		var/hub_subtitle = CONFIG_GET(string/hub_subtitle)
 		if(server_name)
 			new_status += "<b>[server_name]\]</b>"

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -309,15 +309,17 @@ GLOBAL_VAR(restart_counter)
 	if(config)
 		var/server_name = CONFIG_GET(string/servername)
 		var/website_url = CONFIG_GET(string/forumurl)
+		var/hub_subtitle = CONFIG_GET(string/hub_subtitle)
 		if(server_name)
 			new_status += "<b>[website_url ? server_name : "<a href=\"[website_url]\">[server_name]</a>"]</b>]"
-			new_status += " — (<a href=\"https://discord.daedalus13.net\">Discord</a>|<a href =\"https://github.com/DaedalusDock/Gameserver\">Code</a>)"
+			new_status += " — (<a href=\"https://discord.daedalus13.net\">Discord</a>)<br>"
+		if(hub_subtitle)
+			new_status += "<i>[hub_subtitle]</i><br>"
+
 
 	var/players = GLOB.clients.len
 
 	game_state = (CONFIG_GET(number/extreme_popcap) && players >= CONFIG_GET(number/extreme_popcap)) //tells the hub if we are full
-
-	new_status += "<br><i>Running custom code!</i><br>"
 	if(SSmapping.config)
 		new_status += "<br>Map: <b>[SSmapping.config.map_path == CUSTOM_MAP_PATH ? "Uncharted Territory" : SSmapping.config.map_name]</b>"
 
@@ -331,6 +333,7 @@ GLOBAL_VAR(restart_counter)
 	status = new_status
 	///The usage of "\[" without also using "\]" makes the bracket pair colorizer break, so this is here to make the rest of the file easier to read.
 	var/static/vs_appeaser = "\]\]"
+	return status
 
 /world/proc/update_hub_visibility(new_visibility)
 	if(new_visibility == GLOB.hub_visibility)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -311,7 +311,7 @@ GLOBAL_VAR(restart_counter)
 		var/website_url = CONFIG_GET(string/forumurl)
 		var/hub_subtitle = CONFIG_GET(string/hub_subtitle)
 		if(server_name)
-			new_status += "<b>[website_url ? server_name : "<a href=\"[website_url]\">[server_name]</a>"]</b>]"
+			new_status += "<b>[server_name]\]</b>"
 			new_status += " — (<a href=\"https://discord.daedalus13.net\">Discord</a>)<br>"
 		if(hub_subtitle)
 			new_status += "<i>[hub_subtitle]</i><br>"

--- a/config/config.txt
+++ b/config/config.txt
@@ -24,8 +24,8 @@ SERVERSQLNAME daedalusdock
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
 STATIONNAME Daedalus Outpost
 
-## Hub subtitle: A line of text inserted under the server name. MUST BE LESS THAN 21 CHARACTERS
-HUB_SUBTITLE Running Custom Code!
+## Hub subtitle: A line of text inserted under the server name. Should be no greater than 40 characters.
+HUB_SUBTITLE Now with custom lighting!
 
 ## Put on byond hub: Uncomment this to put your server on the byond hub.
 #HUB

--- a/config/config.txt
+++ b/config/config.txt
@@ -24,6 +24,9 @@ SERVERSQLNAME daedalusdock
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
 STATIONNAME Daedalus Outpost
 
+## Hub subtitle: A line of text inserted under the server name. MUST BE LESS THAN 21 CHARACTERS
+HUB_SUBTITLE Running Custom Code!
+
 ## Put on byond hub: Uncomment this to put your server on the byond hub.
 #HUB
 


### PR DESCRIPTION

:cl:
fix: Server hub entry will no longer be cut short
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
