### PR TITLE
I hate asset code

### DIFF
--- a/code/modules/asset_cache/assets/bibles.dm
+++ b/code/modules/asset_cache/assets/bibles.dm
@@ -3,7 +3,12 @@
 
 /datum/asset/spritesheet/bibles/create_spritesheets()
 	var/obj/item/storage/book/bible/holy_template = /obj/item/storage/book/bible
-	InsertAll("display", initial(holy_template.icon))
+	//FUN FACT, THIS USED TO BE A CALL TO InsertAll("display", initial(holy_template.icon))
+	//IT RESCALED *OVER 300 ICON STATES* AND WAS SINGLEHANDEDLY RESPONSIBLE FOR OVER 3 SECONDS OF ASSET TIME.
+	//KNOW WHAT YOU ARE DOING WHEN TOUCHING ASSETS OR YOU WILL BE **FUCKING LIQUIDATED**
+	var/cache_for_sanic_speed = initial(holy_template.icon)
+	for(var/bibblestate in GLOB.biblestates)
+		Insert("display-[bibblestate]", cache_for_sanic_speed, bibblestate, SOUTH)
 
 /datum/asset/spritesheet/bibles/ModifyInserted(icon/pre_asset)
 	pre_asset.Scale(224, 224) // Scale up by 7x


### PR DESCRIPTION
315 fucking icon states
goddamnit it lemon boy what the fuck were you thinking

:cl:
imagedel: prevents nearly 300 icon states from getting built and pushed to clients. You probably won't care about this.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
