### PR TITLE
Allow lone op disk nag to be disabled

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -400,7 +400,12 @@
 /datum/config_entry/flag/lone_op_nag/ValidateAndSet(str_val)
 	var/old_val = config_entry_value
 	. = ..()
-	if(config_entry_value && !old_val)
-		//Make them start processing again
+	if(config_entry_value != old_val)
+		//Re-fuck their processing
 		for(var/obj/item/disk/nuclear/dick in SSpoints_of_interest.real_nuclear_disks)
-			START_PROCESSING(SSobj, dick)
+			if(config_entry_value)
+				//Set true, Make them process
+				START_PROCESSING(SSobj, dick)
+			else
+				//Set false, kill:tm:
+				STOP_PROCESSING(SSobj, dick)

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -392,3 +392,15 @@
 	default = 1
 	min_val = 0
 	integer = FALSE
+
+/// Enable the disk secure nag system?
+/datum/config_entry/flag/lone_op_nag
+	default = FALSE
+
+/datum/config_entry/flag/lone_op_nag/ValidateAndSet(str_val)
+	var/old_val = config_entry_value
+	. = ..()
+	if(config_entry_value && !old_val)
+		//Make them start processing again
+		for(var/obj/item/disk/nuclear/dick in SSpoints_of_interest.real_nuclear_disks)
+			START_PROCESSING(SSobj, dick)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -703,6 +703,10 @@ This is here to make the tiles around the station mininuke change when it's arme
 		STOP_PROCESSING(SSobj, src)
 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
 
+	if(!CONFIG_GET(flag/lone_op_nag))
+		STOP_PROCESSING(SSobj, src)
+		return
+
 	var/turf/new_turf = get_turf(src)
 
 	if (is_secured())

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -692,7 +692,8 @@ This is here to make the tiles around the station mininuke change when it's arme
 	if(!fake)
 		SSpoints_of_interest.make_point_of_interest(src)
 		last_disk_move = world.time
-		START_PROCESSING(SSobj, src)
+		if(CONFIG_GET(flag/lone_op_nag))
+			START_PROCESSING(SSobj, src)
 
 /obj/item/disk/nuclear/ComponentInitialize()
 	. = ..()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -470,3 +470,6 @@ MAXFINE 2000
 
 ## How many played hours of DRONE_REQUIRED_ROLE required to be a Maintenance Done
 #DRONE_ROLE_PLAYTIME 14
+
+## Enabling this config will cause an unsecured nuke disk to increase the chance of a Lone Nuclear Operative spawning.
+#LONE_OP_NAG


### PR DESCRIPTION
Will reenable on config reload

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows the disk security system to be safely disabled and reenabled via config.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lowpop nag, and the way this works is so cheap it doesn't really matter.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
config: Lone Op disk security nagging can now be configured.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
