### PR TITLE
rebalance softcrit/oxyloss

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -154,8 +154,8 @@
 ///Heartbeat is gone... He's dead Jim :(
 #define BEAT_NONE 0
 
-#define HUMAN_MAX_OXYLOSS 3
-#define HUMAN_CRIT_MAX_OXYLOSS (SSMOBS_DT/3)
+#define HUMAN_FAILBREATH_OXYLOSS (rand(2,4))
+#define HUMAN_CRIT_FAILBREATH_OXYLOSS (rand(3,6))
 
 #define HEAT_DAMAGE_LEVEL_1 1 //Amount of damage applied when your body temperature just passes the 360.15k safety point
 #define HEAT_DAMAGE_LEVEL_2 1.5 //Amount of damage applied when your body temperature passes the 400K point

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -703,17 +703,17 @@
 		switch(oxyloss)
 			if(10 to 20)
 				severity = 1
-			if(20 to 25)
+			if(20 to 35)
 				severity = 2
-			if(25 to 30)
+			if(35 to 50)
 				severity = 3
-			if(30 to 35)
+			if(50 to 65)
 				severity = 4
-			if(35 to 40)
+			if(65 to 80)
 				severity = 5
-			if(40 to 45)
+			if(80 to 90)
 				severity = 6
-			if(45 to INFINITY)
+			if(90 to INFINITY)
 				severity = 7
 		overlay_fullscreen("oxy", /atom/movable/screen/fullscreen/oxy, severity)
 	else

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -624,15 +624,15 @@
 /mob/living/carbon/proc/check_passout(oxyloss)
 	if(!isnum(oxyloss))
 		return
-	if(oxyloss <= 50)
-		if(getOxyLoss() > 50)
+	if(oxyloss <= 100)
+		if(getOxyLoss() > 100)
 			ADD_TRAIT(src, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT)
-	else if(getOxyLoss() <= 50)
+	else if(getOxyLoss() <= 100)
 		REMOVE_TRAIT(src, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT)
 
-/mob/living/carbon/get_organic_health()
+/mob/living/carbon/()
 	. = health
-	for (var/_limb in bodyparts)
+	for (var/_limb in boget_organic_healthdyparts)
 		var/obj/item/bodypart/limb = _limb
 		if (!IS_ORGANIC_LIMB(limb))
 			. += (limb.brute_dam * limb.body_damage_coeff) + (limb.burn_dam * limb.body_damage_coeff)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -630,9 +630,9 @@
 	else if(getOxyLoss() <= 100)
 		REMOVE_TRAIT(src, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT)
 
-/mob/living/carbon/()
+/mob/living/carbon/get_organic_health()
 	. = health
-	for (var/_limb in boget_organic_healthdyparts)
+	for (var/_limb in bodyparts)
 		var/obj/item/bodypart/limb = _limb
 		if (!IS_ORGANIC_LIMB(limb))
 			. += (limb.brute_dam * limb.body_damage_coeff) + (limb.burn_dam * limb.body_damage_coeff)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -84,9 +84,9 @@
 
 	if(!L)
 		if(health >= crit_threshold)
-			adjustOxyLoss(HUMAN_MAX_OXYLOSS + 1)
+			adjustOxyLoss(HUMAN_FAILBREATH_OXYLOSS + 1)
 		else if(!HAS_TRAIT(src, TRAIT_NOCRITDAMAGE))
-			adjustOxyLoss(HUMAN_CRIT_MAX_OXYLOSS)
+			adjustOxyLoss(HUMAN_CRIT_FAILBREATH_OXYLOSS)
 
 		failed_last_breath = TRUE
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -96,9 +96,9 @@
 		if(breather.reagents.has_reagent(crit_stabilizing_reagent, needs_metabolizing = TRUE))
 			return
 		if(breather.health >= breather.crit_threshold)
-			breather.adjustOxyLoss(HUMAN_MAX_OXYLOSS)
+			breather.adjustOxyLoss(HUMAN_FAILBREATH_OXYLOSS)
 		else if(!HAS_TRAIT(breather, TRAIT_NOCRITDAMAGE))
-			breather.adjustOxyLoss(HUMAN_CRIT_MAX_OXYLOSS)
+			breather.adjustOxyLoss(HUMAN_CRIT_FAILBREATH_OXYLOSS)
 
 		breather.failed_last_breath = TRUE
 		if(safe_oxygen_min)
@@ -301,11 +301,11 @@
 
 	if(breath_pp > 0)
 		var/ratio = safe_breath_min/breath_pp
-		suffocator.adjustOxyLoss(min(5*ratio, HUMAN_MAX_OXYLOSS)) // Don't fuck them up too fast (space only does HUMAN_MAX_OXYLOSS after all!
+		suffocator.adjustOxyLoss(min(5*ratio, HUMAN_FAILBREATH_OXYLOSS)) // Don't fuck them up too fast (space only does HUMAN_FAILBREATH_OXYLOSS after all!
 		suffocator.failed_last_breath = TRUE
 		. = true_pp*ratio/6
 	else
-		suffocator.adjustOxyLoss(HUMAN_MAX_OXYLOSS)
+		suffocator.adjustOxyLoss(HUMAN_FAILBREATH_OXYLOSS)
 		suffocator.failed_last_breath = TRUE
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Passout threshold from oxyloss from 50 to 100
balance: Oxyloss taken when failing a breath from 3 to rand(2, 4)
balance: Oxyloss taken when failing a breath in critical condition from 3.3 to rand(3,6)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
