### PR TITLE
Fix bug with damage

### DIFF
--- a/code/__DEFINES/stat.dm
+++ b/code/__DEFINES/stat.dm
@@ -13,7 +13,11 @@
 #define HEALTH_THRESHOLD_CRIT 0 //! Soft crit
 #define HEALTH_THRESHOLD_FULLCRIT -100 //! Hard crit
 #define HEALTH_THRESHOLD_DEAD -200
-#define HEALTH_LOSS_TO_DIE ((HEALTH_THRESHOLD_DEAD *-1)) //! The amount of health you need to lose to die.
+
+/// The amount of damage a mob can take past that which would kill it, per damage type.
+#define HEALTH_OVERKILL_DAMAGE_PER_TYPE 0
+/// The maximum amount of damage a mob can take per damage type (carbon brute/burn excluded). This will always result in just enough to kill you if overkill is 0.
+#define HEALTH_LOSS_PER_TYPE_CAP(mob) (mob.maxHealth + ((-1 * HEALTH_THRESHOLD_DEAD) + HEALTH_OVERKILL_DAMAGE_PER_TYPE))
 
 #define HEALTH_THRESHOLD_NEARDEATH -150 //Not used mechanically, but to determine if someone is so close to death they hear the other side
 

--- a/code/__DEFINES/stat.dm
+++ b/code/__DEFINES/stat.dm
@@ -13,6 +13,8 @@
 #define HEALTH_THRESHOLD_CRIT 0 //! Soft crit
 #define HEALTH_THRESHOLD_FULLCRIT -100 //! Hard crit
 #define HEALTH_THRESHOLD_DEAD -200
+#define HEALTH_LOSS_TO_DIE ((HEALTH_THRESHOLD_DEAD *-1)) //! The amount of health you need to lose to die.
+#define maxHealth * 3 (HEALTH_LOSS_TO_DIE + 100) //! The damage cap per damage type. Is equal to the amount of damage required to die, and some extra.
 
 #define HEALTH_THRESHOLD_NEARDEATH -150 //Not used mechanically, but to determine if someone is so close to death they hear the other side
 

--- a/code/__DEFINES/stat.dm
+++ b/code/__DEFINES/stat.dm
@@ -14,7 +14,6 @@
 #define HEALTH_THRESHOLD_FULLCRIT -100 //! Hard crit
 #define HEALTH_THRESHOLD_DEAD -200
 #define HEALTH_LOSS_TO_DIE ((HEALTH_THRESHOLD_DEAD *-1)) //! The amount of health you need to lose to die.
-#define maxHealth * 3 (HEALTH_LOSS_TO_DIE + 100) //! The damage cap per damage type. Is equal to the amount of damage required to die, and some extra.
 
 #define HEALTH_THRESHOLD_NEARDEATH -150 //Not used mechanically, but to determine if someone is so close to death they hear the other side
 

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -143,7 +143,7 @@
 		suicide_log()
 
 		//put em at -175
-		adjustOxyLoss(max(maxHealth * 3 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+		adjustOxyLoss(max(HEALTH_LOSS_PER_TYPE_CAP(src) - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(FALSE)
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
 
@@ -162,7 +162,7 @@
 		suicide_log()
 
 		//put em at -175
-		adjustOxyLoss(max(maxHealth * 3 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+		adjustOxyLoss(max(HEALTH_LOSS_PER_TYPE_CAP(src) - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(FALSE)
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
 

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -143,7 +143,7 @@
 		suicide_log()
 
 		//put em at -175
-		adjustOxyLoss(max(maxHealth * 3 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+		adjustOxyLoss(max((HEALTH_THRESHOLD_DEAD * -1) - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(FALSE)
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
 
@@ -162,7 +162,7 @@
 		suicide_log()
 
 		//put em at -175
-		adjustOxyLoss(max(maxHealth * 3 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+		adjustOxyLoss(max((HEALTH_THRESHOLD_DEAD * -1) - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(FALSE)
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
 

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -143,7 +143,7 @@
 		suicide_log()
 
 		//put em at -175
-		adjustOxyLoss(max((HEALTH_THRESHOLD_DEAD * -1) - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+		adjustOxyLoss(max(maxHealth * 3 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(FALSE)
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
 
@@ -162,7 +162,7 @@
 		suicide_log()
 
 		//put em at -175
-		adjustOxyLoss(max((HEALTH_THRESHOLD_DEAD * -1) - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+		adjustOxyLoss(max(maxHealth * 3 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(FALSE)
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
 

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -143,7 +143,7 @@
 		suicide_log()
 
 		//put em at -175
-		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+		adjustOxyLoss(max(maxHealth * 3 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(FALSE)
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
 
@@ -162,7 +162,7 @@
 		suicide_log()
 
 		//put em at -175
-		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+		adjustOxyLoss(max(maxHealth * 3 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(FALSE)
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
 

--- a/code/modules/mob/living/basic/health_adjustment.dm
+++ b/code/modules/mob/living/basic/health_adjustment.dm
@@ -9,7 +9,7 @@
 /mob/living/basic/proc/adjust_health(amount, updating_health = TRUE, forced = FALSE)
 	. = FALSE
 	if(forced || !(status_flags & GODMODE))
-		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 2), DAMAGE_PRECISION)
+		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 3), DAMAGE_PRECISION)
 		if(updating_health)
 			updatehealth()
 		. = amount

--- a/code/modules/mob/living/basic/health_adjustment.dm
+++ b/code/modules/mob/living/basic/health_adjustment.dm
@@ -9,7 +9,7 @@
 /mob/living/basic/proc/adjust_health(amount, updating_health = TRUE, forced = FALSE)
 	. = FALSE
 	if(forced || !(status_flags & GODMODE))
-		bruteloss = round(clamp(bruteloss + amount, 0, (HEALTH_THRESHOLD_DEAD * -1)), DAMAGE_PRECISION)
+		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 3), DAMAGE_PRECISION)
 		if(updating_health)
 			updatehealth()
 		. = amount

--- a/code/modules/mob/living/basic/health_adjustment.dm
+++ b/code/modules/mob/living/basic/health_adjustment.dm
@@ -9,7 +9,7 @@
 /mob/living/basic/proc/adjust_health(amount, updating_health = TRUE, forced = FALSE)
 	. = FALSE
 	if(forced || !(status_flags & GODMODE))
-		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 3), DAMAGE_PRECISION)
+		bruteloss = round(clamp(bruteloss + amount, 0, (HEALTH_THRESHOLD_DEAD * -1)), DAMAGE_PRECISION)
 		if(updating_health)
 			updatehealth()
 		. = amount

--- a/code/modules/mob/living/basic/health_adjustment.dm
+++ b/code/modules/mob/living/basic/health_adjustment.dm
@@ -9,7 +9,7 @@
 /mob/living/basic/proc/adjust_health(amount, updating_health = TRUE, forced = FALSE)
 	. = FALSE
 	if(forced || !(status_flags & GODMODE))
-		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 3), DAMAGE_PRECISION)
+		bruteloss = round(clamp(bruteloss + amount, 0, HEALTH_LOSS_PER_TYPE_CAP(src)), DAMAGE_PRECISION)
 		if(updating_health)
 			updatehealth()
 		. = amount

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -168,7 +168,7 @@
 /mob/living/proc/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE, required_status)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	bruteloss = clamp((bruteloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, (HEALTH_THRESHOLD_DEAD * -1))
+	bruteloss = clamp((bruteloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -180,7 +180,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return
 	. = oxyloss
-	oxyloss = clamp((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, (HEALTH_THRESHOLD_DEAD * -1))
+	oxyloss = clamp((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
 	if(updating_health)
 		updatehealth()
 
@@ -200,7 +200,7 @@
 /mob/living/proc/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	toxloss = clamp((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, (HEALTH_THRESHOLD_DEAD * -1))
+	toxloss = clamp((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -219,7 +219,7 @@
 /mob/living/proc/adjustFireLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	fireloss = clamp((fireloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, (HEALTH_THRESHOLD_DEAD * -1))
+	fireloss = clamp((fireloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -230,7 +230,7 @@
 /mob/living/proc/adjustCloneLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && ( (status_flags & GODMODE) || HAS_TRAIT(src, TRAIT_NOCLONELOSS)) )
 		return FALSE
-	cloneloss = clamp((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, (HEALTH_THRESHOLD_DEAD * -1))
+	cloneloss = clamp((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
 	if(updating_health)
 		updatehealth()
 	return amount

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -168,7 +168,7 @@
 /mob/living/proc/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE, required_status)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	bruteloss = clamp((bruteloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
+	bruteloss = clamp((bruteloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, HEALTH_LOSS_PER_TYPE_CAP(src))
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -180,7 +180,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return
 	. = oxyloss
-	oxyloss = clamp((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
+	oxyloss = clamp((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, HEALTH_LOSS_PER_TYPE_CAP(src))
 	if(updating_health)
 		updatehealth()
 
@@ -200,7 +200,7 @@
 /mob/living/proc/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	toxloss = clamp((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
+	toxloss = clamp((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, HEALTH_LOSS_PER_TYPE_CAP(src))
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -219,7 +219,7 @@
 /mob/living/proc/adjustFireLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	fireloss = clamp((fireloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
+	fireloss = clamp((fireloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, HEALTH_LOSS_PER_TYPE_CAP(src))
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -230,7 +230,7 @@
 /mob/living/proc/adjustCloneLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && ( (status_flags & GODMODE) || HAS_TRAIT(src, TRAIT_NOCLONELOSS)) )
 		return FALSE
-	cloneloss = clamp((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
+	cloneloss = clamp((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, HEALTH_LOSS_PER_TYPE_CAP(src))
 	if(updating_health)
 		updatehealth()
 	return amount

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -168,7 +168,7 @@
 /mob/living/proc/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE, required_status)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	bruteloss = clamp((bruteloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
+	bruteloss = clamp((bruteloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, (HEALTH_THRESHOLD_DEAD * -1))
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -180,7 +180,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return
 	. = oxyloss
-	oxyloss = clamp((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
+	oxyloss = clamp((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, (HEALTH_THRESHOLD_DEAD * -1))
 	if(updating_health)
 		updatehealth()
 
@@ -200,7 +200,7 @@
 /mob/living/proc/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	toxloss = clamp((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
+	toxloss = clamp((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, (HEALTH_THRESHOLD_DEAD * -1))
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -219,7 +219,7 @@
 /mob/living/proc/adjustFireLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	fireloss = clamp((fireloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
+	fireloss = clamp((fireloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, (HEALTH_THRESHOLD_DEAD * -1))
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -230,7 +230,7 @@
 /mob/living/proc/adjustCloneLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && ( (status_flags & GODMODE) || HAS_TRAIT(src, TRAIT_NOCLONELOSS)) )
 		return FALSE
-	cloneloss = clamp((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
+	cloneloss = clamp((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, (HEALTH_THRESHOLD_DEAD * -1))
 	if(updating_health)
 		updatehealth()
 	return amount

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -168,7 +168,7 @@
 /mob/living/proc/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE, required_status)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	bruteloss = clamp((bruteloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
+	bruteloss = clamp((bruteloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -180,7 +180,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return
 	. = oxyloss
-	oxyloss = clamp((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
+	oxyloss = clamp((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
 	if(updating_health)
 		updatehealth()
 
@@ -200,7 +200,7 @@
 /mob/living/proc/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	toxloss = clamp((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
+	toxloss = clamp((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -219,7 +219,7 @@
 /mob/living/proc/adjustFireLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	fireloss = clamp((fireloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
+	fireloss = clamp((fireloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
 	if(updating_health)
 		updatehealth()
 	return amount
@@ -230,7 +230,7 @@
 /mob/living/proc/adjustCloneLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && ( (status_flags & GODMODE) || HAS_TRAIT(src, TRAIT_NOCLONELOSS)) )
 		return FALSE
-	cloneloss = clamp((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
+	cloneloss = clamp((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 3)
 	if(updating_health)
 		updatehealth()
 	return amount

--- a/code/modules/mob/living/simple_animal/damage_procs.dm
+++ b/code/modules/mob/living/simple_animal/damage_procs.dm
@@ -9,7 +9,7 @@
 /mob/living/simple_animal/proc/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = FALSE
 	if(forced || !(status_flags & GODMODE))
-		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 3), DAMAGE_PRECISION)
+		bruteloss = round(clamp(bruteloss + amount, 0, HEALTH_LOSS_PER_TYPE_CAP(src)), DAMAGE_PRECISION)
 		if(updating_health)
 			updatehealth()
 		. = amount

--- a/code/modules/mob/living/simple_animal/damage_procs.dm
+++ b/code/modules/mob/living/simple_animal/damage_procs.dm
@@ -9,7 +9,7 @@
 /mob/living/simple_animal/proc/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = FALSE
 	if(forced || !(status_flags & GODMODE))
-		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 3), DAMAGE_PRECISION)
+		bruteloss = round(clamp(bruteloss + amount, 0, (HEALTH_THRESHOLD_DEAD * -1)), DAMAGE_PRECISION)
 		if(updating_health)
 			updatehealth()
 		. = amount

--- a/code/modules/mob/living/simple_animal/damage_procs.dm
+++ b/code/modules/mob/living/simple_animal/damage_procs.dm
@@ -9,7 +9,7 @@
 /mob/living/simple_animal/proc/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = FALSE
 	if(forced || !(status_flags & GODMODE))
-		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 2), DAMAGE_PRECISION)
+		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 3), DAMAGE_PRECISION)
 		if(updating_health)
 			updatehealth()
 		. = amount

--- a/code/modules/mob/living/simple_animal/damage_procs.dm
+++ b/code/modules/mob/living/simple_animal/damage_procs.dm
@@ -9,7 +9,7 @@
 /mob/living/simple_animal/proc/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = FALSE
 	if(forced || !(status_flags & GODMODE))
-		bruteloss = round(clamp(bruteloss + amount, 0, (HEALTH_THRESHOLD_DEAD * -1)), DAMAGE_PRECISION)
+		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 3), DAMAGE_PRECISION)
 		if(updating_health)
 			updatehealth()
 		. = amount

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -213,7 +213,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	playsound(loc,'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
 	mychild.revive(full_heal = TRUE, admin_revive = TRUE)
 	if(boosted)
-		mychild.maxHealth = mychild.maxHealth * 3
+		mychild.maxHealth = mychild.maxHealth * 2
 		mychild.health = mychild.maxHealth
 		notify_ghosts("\A [mychild] has been challenged in \the [get_area(src)]!", source = mychild, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Lavaland Elite challenged")
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -213,7 +213,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	playsound(loc,'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
 	mychild.revive(full_heal = TRUE, admin_revive = TRUE)
 	if(boosted)
-		mychild.maxHealth = mychild.maxHealth * 2
+		mychild.maxHealth = mychild.maxHealth * 3
 		mychild.health = mychild.maxHealth
 		notify_ghosts("\A [mychild] has been challenged in \the [get_area(src)]!", source = mychild, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Lavaland Elite challenged")
 

--- a/code/modules/unit_tests/combat.dm
+++ b/code/modules/unit_tests/combat.dm
@@ -68,3 +68,20 @@
 	TEST_ASSERT(pre_attack_hit, "Pre-attack signal was not fired")
 	TEST_ASSERT(attack_hit, "Attack signal was not fired")
 	TEST_ASSERT(post_attack_hit, "Post-attack signal was not fired")
+
+/datum/unit_test/non_standard_damage/Run()
+	var/mob/living/carbon/human/man = allocate(/mob/living/carbon/human)
+
+	var/old_dam
+	man.adjustOxyLoss(HEALTH_LOSS_PER_TYPE_CAP(man))
+	old_dam = man.getOxyLoss()
+	TEST_ASSERT(man.stat == DEAD, "Victim did not die when taking [HEALTH_LOSS_PER_TYPE_CAP(man)] oxygen damage.")
+	man.adjustOxyLoss(1)
+	TEST_ASSERT(man.getOxyLoss() == old_dam, "Victim took oxygen damage past the cap.")
+	man.revive(TRUE, TRUE)
+
+	man.adjustToxLoss(HEALTH_LOSS_PER_TYPE_CAP(man))
+	old_dam = man.getOxyLoss()
+	TEST_ASSERT(man.stat == DEAD, "Victim did not die when taking [HEALTH_LOSS_PER_TYPE_CAP(man)] toxin damage.")
+	man.adjustToxLoss(1)
+	TEST_ASSERT(man.getOxyLoss() == old_dam, "Victim took toxin damage past the cap.")

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -126,7 +126,7 @@
 	target.visible_message(span_danger("[chassis] is drilling [target] with [src]!"), \
 						span_userdanger("[chassis] is drilling you with [src]!"))
 	log_combat(user, target, "drilled", "[name]", "Combat mode: [user.combat_mode ? "On" : "Off"])(DAMTYPE: [uppertext(damtype)])")
-	if(target.stat == DEAD && target.getBruteLoss() >= target.maxHealth *3)
+	if(target.stat == DEAD && target.getBruteLoss() >= HEALTH_LOSS_PER_TYPE_CAP(target))
 		log_combat(user, target, "gibbed", name)
 		if(LAZYLEN(target.butcher_results) || LAZYLEN(target.guaranteed_butcher_results))
 			var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -126,7 +126,7 @@
 	target.visible_message(span_danger("[chassis] is drilling [target] with [src]!"), \
 						span_userdanger("[chassis] is drilling you with [src]!"))
 	log_combat(user, target, "drilled", "[name]", "Combat mode: [user.combat_mode ? "On" : "Off"])(DAMTYPE: [uppertext(damtype)])")
-	if(target.stat == DEAD && target.getBruteLoss() >= (HEALTH_THRESHOLD_DEAD * 1))
+	if(target.stat == DEAD && target.getBruteLoss() >= target.maxHealth *3)
 		log_combat(user, target, "gibbed", name)
 		if(LAZYLEN(target.butcher_results) || LAZYLEN(target.guaranteed_butcher_results))
 			var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -126,7 +126,7 @@
 	target.visible_message(span_danger("[chassis] is drilling [target] with [src]!"), \
 						span_userdanger("[chassis] is drilling you with [src]!"))
 	log_combat(user, target, "drilled", "[name]", "Combat mode: [user.combat_mode ? "On" : "Off"])(DAMTYPE: [uppertext(damtype)])")
-	if(target.stat == DEAD && target.getBruteLoss() >= (target.maxHealth * 2))
+	if(target.stat == DEAD && target.getBruteLoss() >= (target.maxHealth * 3))
 		log_combat(user, target, "gibbed", name)
 		if(LAZYLEN(target.butcher_results) || LAZYLEN(target.guaranteed_butcher_results))
 			var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -126,7 +126,7 @@
 	target.visible_message(span_danger("[chassis] is drilling [target] with [src]!"), \
 						span_userdanger("[chassis] is drilling you with [src]!"))
 	log_combat(user, target, "drilled", "[name]", "Combat mode: [user.combat_mode ? "On" : "Off"])(DAMTYPE: [uppertext(damtype)])")
-	if(target.stat == DEAD && target.getBruteLoss() >= (target.maxHealth * 3))
+	if(target.stat == DEAD && target.getBruteLoss() >= (HEALTH_THRESHOLD_DEAD * 1))
 		log_combat(user, target, "gibbed", name)
 		if(LAZYLEN(target.butcher_results) || LAZYLEN(target.guaranteed_butcher_results))
 			var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Currently, values like oxyloss and toxloss, are clamped at mob.maxHealth * 2. This works perfectly fine on TG, if your mob max HP is exactly 100. Why is that? Well, TG's death point is -100. 100 * 2 = 200 which is also the difference between maxHealth and HEALTH_THRESHHOLD_DEAD.

But, what if your mob has more than 100 max hp? Well, then shit starts to kind of break. 

If your mob has 500 hp, you can take a 400 tox/oxy damage past the point of death.
If your mob has 1000 hp, you can take 900 tox/oxy damage past the point of death.

This sounds fine on paper, until you realise that it scales exponentially, and the default mobs like players don't take any damage past the point of death.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can now die from only one damage type again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
