### PR TITLE
Fix AoE flash not applying stamina damage

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -174,14 +174,14 @@
 				terrible_conversion_proc(flashed, user)
 				visible_message(span_danger("[user] blinds [flashed] with the flash!"), span_userdanger("[user] blinds you with the flash!"))
 			//easy way to make sure that you can only long stun someone who is facing in your direction
-			flashed.Disorient((7 SECONDS * (1-(deviation*0.5))), 70, paralyze = 4 SECONDS)
+			flashed.Disorient((7 SECONDS * (1-(deviation*0.5))), 90 * (1-(deviation*0.5)), paralyze = 4 SECONDS)
 		else if(user)
 			visible_message(span_warning("[user] fails to blind [flashed] with the flash!"), span_danger("[user] fails to blind you with the flash!"))
 		else
 			to_chat(flashed, span_danger("[src] fails to blind you!"))
 
 	else
-		flashed.Disorient(7 SECONDS * (1-(deviation*0.5)), paralyze = 4 SECONDS)
+		flashed.Disorient(7 SECONDS * (1-(deviation*0.5)), 90 * (1-(deviation*0.5)), paralyze = 4 SECONDS)
 
 /**
  * Handles the directionality of the attack
@@ -255,8 +255,9 @@
 /obj/item/assembly/flash/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(holder)
 		return FALSE
-	if(!AOE_flash(user = user))
-		return FALSE
+	if(AOE_flash(user = user))
+		user.changeNext_move(CLICK_CD_MELEE)
+
 
 /obj/item/assembly/flash/emp_act(severity)
 	. = ..()


### PR DESCRIPTION


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed AoE flash function
balance: AoE flash now has a cooldown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
