### PR TITLE
make engravings removable with a welder

### DIFF
--- a/code/datums/components/engraved.dm
+++ b/code/datums/components/engraved.dm
@@ -61,12 +61,14 @@
 
 /datum/component/engraved/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
+	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT, PROC_REF(on_tool_act))
 	//supporting component transfer means putting these here instead of initialize
 	SSpersistence.wall_engravings += src
 	ADD_TRAIT(parent, TRAIT_NOT_ENGRAVABLE, TRAIT_GENERIC)
 
 /datum/component/engraved/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_PARENT_EXAMINE)
+	UnregisterSignal(parent, COMSIG_ATOM_TOOL_ACT)
 	//supporting component transfer means putting these here instead of destroy
 	SSpersistence.wall_engravings -= src
 	REMOVE_TRAIT(parent, TRAIT_NOT_ENGRAVABLE, TRAIT_GENERIC)
@@ -81,6 +83,18 @@
 /datum/component/engraved/proc/on_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 	examine_list += span_boldnotice(engraved_description)
+	examine_list += span_notice("You can probably get this out with a <b>welding tool</b>.")
+
+/datum/component/engraved/proc/on_tool_act(mob/user, obj/item/tool)
+	if(!(tool.tooltype == TOOL_WELDER))
+		return
+
+	. = COMPONENT_BLOCK_TOOL_ATTACK
+
+	to_chat(user, span_notice("You begin to remove the engraving on [parent]."))
+	if(do_after(user, parent, 4 SECONDS, DO_PUBLIC, display = tool))
+		to_chat(user, span_notice("You remove the engraving on [parent]."))
+		qdel(src)
 
 ///returns all the information SSpersistence needs in a list to load up this engraving on a future round!
 /datum/component/engraved/proc/save_persistent()

--- a/code/datums/components/engraved.dm
+++ b/code/datums/components/engraved.dm
@@ -85,7 +85,7 @@
 	examine_list += span_boldnotice(engraved_description)
 	examine_list += span_notice("You can probably get this out with a <b>welding tool</b>.")
 
-/datum/component/engraved/proc/on_tool_act(mob/user, obj/item/tool)
+/datum/component/engraved/proc/on_tool_act(datum/source, mob/user, obj/item/tool)
 	SIGNAL_HANDLER
 	set waitfor = FALSE //Do not remove without removing the UNLINT below
 

--- a/code/datums/components/engraved.dm
+++ b/code/datums/components/engraved.dm
@@ -87,13 +87,13 @@
 
 /datum/component/engraved/proc/on_tool_act(mob/user, obj/item/tool)
 	SIGNAL_HANDLER
+	set waitfor = FALSE //Do not remove without removing the UNLINT below
 
 	. = COMPONENT_BLOCK_TOOL_ATTACK
-	spawn(-1)
-		to_chat(user, span_notice("You begin to remove the engraving on [parent]."))
-		if(do_after(user, parent, 4 SECONDS, DO_PUBLIC, display = tool))
-			to_chat(user, span_notice("You remove the engraving on [parent]."))
-			qdel(src)
+	to_chat(user, span_notice("You begin to remove the engraving on [parent]."))
+	if(UNLINT(do_after(user, parent, 4 SECONDS, DO_PUBLIC, display = tool)))
+		to_chat(user, span_notice("You remove the engraving on [parent]."))
+		qdel(src)
 
 ///returns all the information SSpersistence needs in a list to load up this engraving on a future round!
 /datum/component/engraved/proc/save_persistent()

--- a/code/datums/components/engraved.dm
+++ b/code/datums/components/engraved.dm
@@ -61,14 +61,14 @@
 
 /datum/component/engraved/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
-	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT, PROC_REF(on_tool_act))
+	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), PROC_REF(on_tool_act))
 	//supporting component transfer means putting these here instead of initialize
 	SSpersistence.wall_engravings += src
 	ADD_TRAIT(parent, TRAIT_NOT_ENGRAVABLE, TRAIT_GENERIC)
 
 /datum/component/engraved/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_PARENT_EXAMINE)
-	UnregisterSignal(parent, COMSIG_ATOM_TOOL_ACT)
+	UnregisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER))
 	//supporting component transfer means putting these here instead of destroy
 	SSpersistence.wall_engravings -= src
 	REMOVE_TRAIT(parent, TRAIT_NOT_ENGRAVABLE, TRAIT_GENERIC)
@@ -86,9 +86,8 @@
 	examine_list += span_notice("You can probably get this out with a <b>welding tool</b>.")
 
 /datum/component/engraved/proc/on_tool_act(mob/user, obj/item/tool)
-	if(!(tool.tooltype == TOOL_WELDER))
-		return
-
+	SIGNAL_HANDLER
+	set waitfor = FALSE
 	. = COMPONENT_BLOCK_TOOL_ATTACK
 
 	to_chat(user, span_notice("You begin to remove the engraving on [parent]."))

--- a/code/datums/components/engraved.dm
+++ b/code/datums/components/engraved.dm
@@ -51,13 +51,15 @@
 	engraved_wall.update_appearance()
 
 /datum/component/engraved/Destroy(force, silent)
-	. = ..()
+	if(!parent)
+		return ..()
 	parent.RemoveElement(/datum/element/art)
 	//must be here to allow overlays to be updated
 	UnregisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS)
-	if(parent && !QDELING(parent))
+	if(!QDELING(parent))
 		var/atom/parent_atom = parent
 		parent_atom.update_appearance()
+	return ..() //call this after since we null out the parent
 
 /datum/component/engraved/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))

--- a/code/datums/components/engraved.dm
+++ b/code/datums/components/engraved.dm
@@ -87,13 +87,13 @@
 
 /datum/component/engraved/proc/on_tool_act(mob/user, obj/item/tool)
 	SIGNAL_HANDLER
-	set waitfor = FALSE
-	. = COMPONENT_BLOCK_TOOL_ATTACK
 
-	to_chat(user, span_notice("You begin to remove the engraving on [parent]."))
-	if(do_after(user, parent, 4 SECONDS, DO_PUBLIC, display = tool))
-		to_chat(user, span_notice("You remove the engraving on [parent]."))
-		qdel(src)
+	. = COMPONENT_BLOCK_TOOL_ATTACK
+	spawn(-1)
+		to_chat(user, span_notice("You begin to remove the engraving on [parent]."))
+		if(do_after(user, parent, 4 SECONDS, DO_PUBLIC, display = tool))
+			to_chat(user, span_notice("You remove the engraving on [parent]."))
+			qdel(src)
 
 ///returns all the information SSpersistence needs in a list to load up this engraving on a future round!
 /datum/component/engraved/proc/save_persistent()


### PR DESCRIPTION

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Wall engravings can now be removed with a welding tool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
