### PR TITLE
Optimize get_hearers_in_view()

### DIFF
--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -114,7 +114,7 @@
 	//1. view() only constructs lists of atoms with the mob primitive type and
 	//2. the mobs returned by view are fast typechecked to only iterate through /mob/oranges_ear mobs, which guarantees at most one per turf
 	//on a whole this can outperform iterating through all movables in view() by ~2x especially when hearables are a tiny percentage of movables in view
-	for(var/mob/oranges_ear/ear in view(view_radius, center_turf))
+	for(var/mob/oranges_ear/ear in hearers(view_radius, center_turf))
 		. += ear.references
 
 	for(var/mob/oranges_ear/remaining_ear as anything in assigned_oranges_ears)//we need to clean up our mess

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -104,23 +104,17 @@
 
 	var/list/assigned_oranges_ears = SSspatial_grid.assign_oranges_ears(hearables_from_grid)
 
-	var/old_luminosity = center_turf.luminosity
-	center_turf.luminosity = 6 //man if only we had an inbuilt dview()
-
 	//this is the ENTIRE reason all this shit is worth it due to how view() works and can be optimized
 	//view() constructs lists of viewed atoms by default and specifying a specific type of atom to look for limits the lists it constructs to those of that
 	//primitive type and then when the view operation is completed the output is then typechecked to only iterate through objects in view with the same
-	//typepath. by assigning one /mob/oranges_ear to every turf with hearable atoms on it and giving them references to each one means that:
-	//1. view() only constructs lists of atoms with the mob primitive type and
-	//2. the mobs returned by view are fast typechecked to only iterate through /mob/oranges_ear mobs, which guarantees at most one per turf
-	//on a whole this can outperform iterating through all movables in view() by ~2x especially when hearables are a tiny percentage of movables in view
+	//typepath. by assigning one /mob/oranges_ear to every turf with hearable atoms on it and giving them references to each one means that
+	//hearers() can be used over view(), which is a huge speed increase.
 	for(var/mob/oranges_ear/ear in hearers(view_radius, center_turf))
 		. += ear.references
 
 	for(var/mob/oranges_ear/remaining_ear as anything in assigned_oranges_ears)//we need to clean up our mess
 		remaining_ear.unassign()
 
-	center_turf.luminosity = old_luminosity
 	return .
 
 /**


### PR DESCRIPTION
### Explanation
One of the hottest procs in the game. The way it works is it uses the spatial grid to grab all hearers in a given range. Then, it assigns mobs called ears to every turf that contains a hearer. Then, it uses view() to determine who should actually hear the message based on sight. 

There's a pretty simple optimization here, given to us by Dantom back in the dark ages. `hearers()`. `hearers()` is a *very* fast proc that returns all mobs in view, ignoring darkness. We can't replace Ears with this entirely, because SS13/TGMC have objects that need to be aware of hearing, like Radios. But this is still a massive improvement.

### Benchmark
Benchmarked using Lohikar's closed-source benchmarking tools. Left-to-right:  Average Iterations, Harmonic Average Iterations, Standard Deviation, Standard Deviation As Percent.

![image](https://github.com/tgstation/TerraGov-Marine-Corps/assets/75460809/9def7c26-6a33-4a25-be2b-424d4c1c23fb)
The Code:
```
WORLD(5, 5, 1)
/mob/foo

/proc/_hearers()
  for(var/mob/foo/M in hearers(locate(3, 3, 1)))
    return

/proc/_view()
  for(var/mob/M in view(locate(3, 3, 1)))
    return

MAIN
  for(var/turf/T in world)
    new /mob/foo(T)
    new /obj(T)
    new /obj(T)
    new /obj(T)
  
  BEGIN_BENCH(2)
    BENCH_PHASE("view", _view())
    BENCH_PHASE("hearers", _hearers())
  END_BENCH
  ```
## Why It's Good For The Game
Speed is good.
## Changelog
:cl:
code: Saved a large amount of tick time in sound.
/:cl: