### PR TITLE
Fixes a petulent little runtime with messenger programs

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -248,6 +248,7 @@
 		/obj/item/storage/fancy/cigarettes,
 		/obj/item/storage/pill_bottle,
 		/obj/item/stack/medical,
+		/obj/item/stack/gauze,
 		/obj/item/flashlight/pen,
 		/obj/item/extinguisher/mini,
 		/obj/item/reagent_containers/hypospray,

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -351,17 +351,10 @@
 
 
 	if (ringer_status)
-		if(!computer)
-			message_admins("Messenger Program exists with no computer, [ADMIN_VV(src)]");
-			var/message = "Messenger Program with no computer."
-			if(QDELETED(src))
-				message += " \[Messenger is qdeleted!\]"
-			if(QDELETED(holder))
-				if(isnull(holder))
-					message += " \[Messenger is not in a harddrive!\]"
-				else
-					message += " \[Messenger harddrive is qdeleting!\]"
-			CRASH(message)
+		if(!holder.holder)
+			return //We aren't actually in a computer, SSpackets might have gotten severely gummed up or smth.
+		//otherwise, fix the computer var and run.
+		computer = holder.holder
 		computer.ring(ringtone)
 
 /datum/computer_file/program/messenger/Topic(href, href_list)


### PR DESCRIPTION
:cl:
fix: Silicon 'PDAs' will now properly ring.
add: Medibelts can store Gauze now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
