### PR TITLE
Small tweaks to atmos equipment

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -34,6 +34,8 @@
 	var/max_power_rating = 20000
 	///Percentage of power rating to use
 	var/power_setting = 20 // Start at 20 so we don't obliterate the station power supply.
+	/// How much gussy we can store in liters, this is affected by refresh_parts()
+	var/internal_volume = 400
 
 	var/interactive = TRUE // So mapmakers can disable interaction.
 	var/color_index = 1
@@ -73,9 +75,11 @@
 	for(var/obj/item/stock_parts/manipulator/man in component_parts)
 		manip_rating += man.rating
 
-	max_power_rating = initial(max_power_rating) * cap_rating / 2 //more powerful
+	max_power_rating = initial(max_power_rating) * (cap_rating / 2) //more powerful
+	internal_volume = initial(internal_volume) + (200 * bin_rating) //more air
 	heatsink_temperature = initial(heatsink_temperature) / ((manip_rating + bin_rating) / 2) //more efficient
 	set_power_level(power_setting)
+	airs[1].volume = internal_volume
 
 /obj/machinery/atmospherics/components/unary/thermomachine/update_icon_state()
 	var/colors_to_use = ""

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -79,7 +79,10 @@
 	internal_volume = initial(internal_volume) + (200 * bin_rating) //more air
 	heatsink_temperature = initial(heatsink_temperature) / ((manip_rating + bin_rating) / 2) //more efficient
 	set_power_level(power_setting)
-	airs[1].volume = internal_volume
+	if(airs[1])
+		airs[1].volume = internal_volume
+	else
+		airs[1] = new /datum/gas_mixture(200)
 
 /obj/machinery/atmospherics/components/unary/thermomachine/update_icon_state()
 	var/colors_to_use = ""

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -13,7 +13,7 @@
 	desc = "Has a valve and pump attached to it."
 
 	use_power = IDLE_POWER_USE
-	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.15
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.1
 	can_unwrench = TRUE
 	welded = FALSE
 	layer = GAS_SCRUBBER_LAYER

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -6,6 +6,7 @@
 
 	name = "air scrubber"
 	desc = "Has a valve and pump attached to it."
+
 	use_power = IDLE_POWER_USE
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.1
 


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Vent Pumps and Vent Scrubbers use 33% less power while idling.
balance: Thermomachine volume from 70 to 400 + (bin_rating * 200)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
