### PR TITLE
Fixes example JSON to contain duration

### DIFF
--- a/config/media/jsons/___EXAMPLE.json
+++ b/config/media/jsons/___EXAMPLE.json
@@ -5,7 +5,7 @@
 	"author" : "EXAMPLE",
 	"file" : "sounds/poacher.ogg",
 	"media_tags": ["LOBBY", "JUKEBOX"],
-	"x-comment-duration": "Duration of a given file for use in the jukebox.",
+	"x-comment-duration": "Duration of a given file for use in the jukebox in deciseconds.",
 	"duration": 260,
 	"map" : false
 }

--- a/config/media/jsons/___EXAMPLE.json
+++ b/config/media/jsons/___EXAMPLE.json
@@ -5,5 +5,7 @@
 	"author" : "EXAMPLE",
 	"file" : "sounds/poacher.ogg",
 	"media_tags": ["LOBBY", "JUKEBOX"],
+	"x-comment-duration": "Duration of a given file for use in the jukebox.",
+	"duration": 260,
 	"map" : false
 }


### PR DESCRIPTION
## About The Pull Request
Fixes the contents of the __EXAMPLE.json file for json music files to include duration by default, as it is required for files to properly play in the jukebox.

Done per @francinum 's request.

## Why It's Good For The Game

Not player facing

## Changelog

:cl: Gonenoculer5
fix: Modifies EXAMPLE.json to contain correct comment text relating to durations of music files.
/:cl:
