### PR TITLE
Fixes some wound bugs

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -467,6 +467,7 @@
 
 // /obj/item/bodypart on_mob_life() retval flag
 #define BODYPART_LIFE_UPDATE_HEALTH (1<<0)
+#define BODYPART_LIFE_UPDATE_DAMAGE_OVERLAYS (1<<1)
 
 #define MAX_REVIVE_FIRE_DAMAGE 180
 #define MAX_REVIVE_BRUTE_DAMAGE 180

--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -196,7 +196,6 @@
 
 	to_chat(user, span_warning("The acid on \the [parent_atom] burns your hand!"))
 	playsound(parent_atom, 'sound/weapons/sear.ogg', 50, TRUE)
-	user.update_damage_overlays()
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -174,8 +174,9 @@
 		return
 
 	for(var/obj/item/bodypart/L as anything in parts)
-		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len, BODYTYPE_ORGANIC))
-			M.update_damage_overlays()
+		L.heal_damage(heal_amt/parts.len, heal_amt/parts.len, BODYTYPE_ORGANIC, FALSE)
+	M.updatehealth()
+	M.update_damage_overlays()
 	return 1
 
 /datum/symptom/heal/starlight/passive_message_condition(mob/living/M)
@@ -315,8 +316,9 @@
 		to_chat(M, span_notice("The darkness soothes and mends your wounds."))
 
 	for(var/obj/item/bodypart/L in parts)
-		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len * 0.5, BODYTYPE_ORGANIC)) //more effective on brute
-			M.update_damage_overlays()
+		L.heal_damage(heal_amt/parts.len, heal_amt/parts.len * 0.5, BODYTYPE_ORGANIC, FALSE) //more effective on brute
+	M.updatehealth()
+	M.update_damage_overlays()
 	return 1
 
 /datum/symptom/heal/darkness/passive_message_condition(mob/living/M)
@@ -415,9 +417,9 @@
 		return
 
 	for(var/obj/item/bodypart/L in parts)
-		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len, BODYTYPE_ORGANIC))
-			M.update_damage_overlays()
-
+		L.heal_damage(heal_amt/parts.len, heal_amt/parts.len, BODYTYPE_ORGANIC, updating_health = FALSE)
+	M.updatehealth()
+	M.update_damage_overlays()
 	if(active_coma && M.getBruteLoss() + M.getFireLoss() == 0)
 		uncoma(M)
 
@@ -477,8 +479,10 @@
 		to_chat(M, span_notice("You feel yourself absorbing the water around you to soothe your damaged skin."))
 
 	for(var/obj/item/bodypart/L in parts)
-		if(L.heal_damage(heal_amt/parts.len * 0.5, heal_amt/parts.len, BODYTYPE_ORGANIC))
-			M.update_damage_overlays()
+		L.heal_damage(heal_amt/parts.len * 0.5, heal_amt/parts.len, BODYTYPE_ORGANIC, FALSE)
+
+	M.updatehealth()
+	M.update_damage_overlays()
 
 	return 1
 
@@ -549,8 +553,10 @@
 	if(prob(5))
 		to_chat(M, span_notice("The pain from your wounds fades rapidly."))
 	for(var/obj/item/bodypart/L in parts)
-		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len, BODYTYPE_ORGANIC))
-			M.update_damage_overlays()
+		L.heal_damage(heal_amt/parts.len, heal_amt/parts.len, BODYTYPE_ORGANIC, FALSE)
+
+	M.updatehealth()
+	M.update_damage_overlays()
 	return 1
 
 ///Plasma End
@@ -602,6 +608,7 @@
 		to_chat(M, span_notice("Your skin glows faintly, and you feel your wounds mending themselves."))
 
 	for(var/obj/item/bodypart/L in parts)
-		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len, BODYTYPE_ORGANIC))
-			M.update_damage_overlays()
+		L.heal_damage(heal_amt/parts.len, heal_amt/parts.len, BODYTYPE_ORGANIC, FALSE)
+	M.updatehealth()
+	M.update_damage_overlays()
 	return 1

--- a/code/datums/elements/kneecapping.dm
+++ b/code/datums/elements/kneecapping.dm
@@ -83,6 +83,5 @@
 		attacker.visible_message(span_warning("[attacker] swings [attacker.p_their()] [weapon] at [target]'s kneecaps!"), span_danger("You swing \the [weapon] at [target]'s kneecaps!"))
 		leg.create_wound_easy(/datum/wound/puncture/gaping, 30)
 		log_combat(attacker, target, "broke the kneecaps of", weapon)
-		target.update_damage_overlays()
 		attacker.do_attack_animation(target, used_item = weapon)
 		playsound(source = get_turf(weapon), soundin = weapon.hitsound, vol = weapon.get_clamped_volume(), vary = TRUE)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -494,8 +494,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 		else
 			to_chat(user, span_warning("You burn your hand on [src]!"))
 			var/obj/item/bodypart/affecting = C.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
-			if(affecting?.receive_damage( 0, 5 )) // 5 burn damage
-				C.update_damage_overlays()
+			affecting?.receive_damage( 0, 5 ) // 5 burn damage
 			return
 
 	if(!(interaction_flags_item & INTERACT_ITEM_ATTACK_HAND_PICKUP)) //See if we're supposed to auto pickup.

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -97,8 +97,7 @@
 			span_infoplain(span_green("You apply [src] on [C]'s [parse_zone(affecting.body_zone)]."))
 		)
 		var/previous_damage = affecting.get_damage()
-		if(affecting.heal_damage(brute, burn))
-			C.update_damage_overlays()
+		affecting.heal_damage(brute, burn)
 		post_heal_effects(max(previous_damage - affecting.get_damage(), 0), C, user)
 		return TRUE
 	to_chat(user, span_warning("[C]'s [parse_zone(affecting.body_zone)] can not be healed with [src]!"))

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -142,8 +142,8 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	if(hurt_limbs.len)
 		for(var/X in hurt_limbs)
 			var/obj/item/bodypart/affecting = X
-			if(affecting.heal_damage(heal_amt, heal_amt, BODYTYPE_ORGANIC))
-				H.update_damage_overlays()
+			affecting.heal_damage(heal_amt, heal_amt, BODYTYPE_ORGANIC)
+
 		H.visible_message(span_notice("[user] heals [H] with the power of [deity_name]!"))
 		to_chat(H, span_boldnotice("May the power of [deity_name] compel you to be healed!"))
 		playsound(src.loc, SFX_PUNCH, 25, TRUE, -1)

--- a/code/game/objects/structures/maintenance.dm
+++ b/code/game/objects/structures/maintenance.dm
@@ -77,7 +77,6 @@ at the cost of risking a vicious bite.**/
 		var/obj/item/bodypart/affecting = bite_victim.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
 		to_chat(user, span_danger("You feel a sharp pain as an unseen creature sinks it's [pick("fangs", "beak", "proboscis")] into your arm!"))
 		if(affecting?.receive_damage(30))
-			bite_victim.update_damage_overlays()
 			playsound(src,'sound/weapons/bite.ogg', 70, TRUE)
 			return
 	to_chat(user, span_warning("You find nothing of value..."))

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -148,7 +148,6 @@
 	var/obj/item/bodypart/affecting = user.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
 	affecting.receive_damage( 0, 10 ) // 10 burn damage
 	user.emote("scream")
-	user.update_damage_overlays()
 	user.dropItemToGround(src)
 
 //////////////////////////////Capturing////////////////////////////////////////////////////////

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -75,8 +75,7 @@
 					affecting = H.get_bodypart(type)
 					H.Stun(60)
 		if(affecting)
-			if(affecting.receive_damage(1, 0))
-				H.update_damage_overlays()
+			affecting.receive_damage(1, 0)
 	else if(ismouse(target))
 		var/mob/living/simple_animal/mouse/M = target
 		visible_message(span_boldannounce("SPLAT!"))

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -64,6 +64,7 @@
 
 	//Bleeding out
 	for(var/obj/item/bodypart/iter_part as anything in bodyparts)
+		var/needs_bleed_update = FALSE
 		var/iter_bleed_rate = iter_part.get_modified_bleed_rate()
 		var/bleed_amt = iter_part.bandage?.absorb_blood(iter_bleed_rate, src)
 		if(isnull(bleed_amt))
@@ -73,6 +74,11 @@
 			for(var/datum/wound/W as anything in iter_part.wounds)
 				if(W.bleeding() && W.bleed_timer > 0)
 					W.bleed_timer--
+					if(!W.bleeding())
+						needs_bleed_update = TRUE
+
+		if(needs_bleed_update)
+			iter_part.refresh_bleed_rate()
 
 		if(!bleed_amt)
 			continue
@@ -85,6 +91,7 @@
 	if(temp_bleed)
 		bleed(temp_bleed)
 		bleed_warn(temp_bleed)
+
 
 /// Has each bodypart update its bleed/wound overlay icon states
 /mob/living/carbon/proc/update_bodypart_bleed_overlays()

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -267,7 +267,6 @@
 
 ///Checks to see if any bodyparts need to be redrawn, then does so. update_limb_data = TRUE redraws the limbs to conform to the owner.
 /mob/living/carbon/proc/update_body_parts(update_limb_data)
-	update_damage_overlays()
 	update_wound_overlays()
 	update_eyes(update_limb_data)
 

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -21,14 +21,12 @@
 	switch(damagetype)
 		if(BRUTE)
 			if(BP)
-				if(BP.receive_damage(damage_amount, 0, sharpness = sharpness))
-					update_damage_overlays()
+				BP.receive_damage(damage_amount, 0, sharpness = sharpness)
 			else //no bodypart, we deal damage with a more general method.
 				adjustBruteLoss(damage_amount, forced = forced)
 		if(BURN)
 			if(BP)
-				if(BP.receive_damage(0, damage_amount, sharpness = sharpness))
-					update_damage_overlays()
+				BP.receive_damage(0, damage_amount, sharpness = sharpness)
 			else
 				adjustFireLoss(damage_amount, forced = forced)
 		if(TOX)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -644,7 +644,7 @@
 
 	//DAMAGE//
 	for(var/obj/item/bodypart/affecting in damaged)
-		affecting.receive_damage(acidity, 2*acidity)
+		affecting.receive_damage(acidity, 2*acidity, updating_health = FALSE)
 
 		if(affecting.name == BODY_ZONE_HEAD)
 			if(prob(min(acidpwr*acid_volume/10, 90))) //Applies disfigurement
@@ -655,7 +655,8 @@
 				update_body_parts()
 				ADD_TRAIT(src, TRAIT_DISFIGURED, TRAIT_GENERIC)
 
-		update_damage_overlays()
+	updatehealth()
+	update_damage_overlays()
 
 	//MELTING INVENTORY ITEMS//
 	//these items are all outside of armour visually, so melt regardless.

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1311,16 +1311,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			H.damageoverlaytemp = 20
 			var/damage_amount = forced ? damage : damage * hit_percent * brutemod * H.physiology.brute_mod
 			if(BP)
-				if(BP.receive_damage(damage_amount, 0, sharpness = sharpness))
-					H.update_damage_overlays()
+				BP.receive_damage(damage_amount, 0, sharpness = sharpness)
 			else//no bodypart, we deal damage with a more general method.
 				H.adjustBruteLoss(damage_amount)
 		if(BURN)
 			H.damageoverlaytemp = 20
 			var/damage_amount = forced ? damage : damage * hit_percent * burnmod * H.physiology.burn_mod
 			if(BP)
-				if(BP.receive_damage(0, damage_amount, sharpness = sharpness))
-					H.update_damage_overlays()
+				BP.receive_damage(0, damage_amount, sharpness = sharpness)
 			else
 				H.adjustFireLoss(damage_amount)
 		if(TOX)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -24,8 +24,7 @@
 	if(stat == DEAD)
 		stop_sound_channel(CHANNEL_HEARTBEAT)
 	else
-		var/bprv = handle_bodyparts(delta_time, times_fired)
-		if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
+		if(handle_bodyparts(delta_time, times_fired))
 			updatehealth()
 
 	check_cremation(delta_time, times_fired)

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -511,14 +511,12 @@
 		to_chat(user, span_notice("You telekinetically remove the light [fitting]."))
 	else
 		var/obj/item/bodypart/affecting = electrician.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
-		if(affecting?.receive_damage( 0, 5 )) // 5 burn damage
-			electrician.update_damage_overlays()
+		affecting?.receive_damage( 0, 5 )
 		if(HAS_TRAIT(user, TRAIT_LIGHTBULB_REMOVER))
 			to_chat(user, span_notice("You feel like you're burning, but you can push through."))
 			if(!do_after(user, src, 5 SECONDS))
 				return
-			if(affecting?.receive_damage( 0, 10 )) // 10 more burn damage
-				electrician.update_damage_overlays()
+			affecting?.receive_damage( 0, 10 ) // 10 more burn damage
 			to_chat(user, span_notice("You manage to remove the light [fitting], shattering it in process."))
 			break_light_tube()
 		else

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -110,8 +110,8 @@
 	if(hurt_limbs.len)
 		for(var/X in hurt_limbs)
 			var/obj/item/bodypart/affecting = X
-			if(affecting.heal_damage(heal_amt, heal_amt, BODYTYPE_ORGANIC))
-				blessed.update_damage_overlays()
+			affecting.heal_damage(heal_amt, heal_amt, BODYTYPE_ORGANIC)
+
 		blessed.visible_message(span_notice("[chap] heals [blessed] with the power of [GLOB.deity]!"))
 		to_chat(blessed, span_boldnotice("May the power of [GLOB.deity] compel you to be healed!"))
 		playsound(chap, SFX_PUNCH, 25, TRUE, -1)
@@ -176,8 +176,7 @@
 		return TRUE
 
 	//charge(?) and go
-	if(bodypart.heal_damage(5,5,BODYTYPE_ROBOTIC))
-		blessed.update_damage_overlays()
+	bodypart.heal_damage(5,5,BODYTYPE_ROBOTIC)
 
 	blessed.visible_message(span_notice("[chap] [did_we_charge ? "repairs" : "repairs and charges"] [blessed] with the power of [GLOB.deity]!"))
 	to_chat(blessed, span_boldnotice("The inner machinations of [GLOB.deity] [did_we_charge ? "repairs" : "repairs and charges"] you!"))
@@ -261,8 +260,8 @@
 	var/list/hurt_limbs = blessed.get_damaged_bodyparts(1, 1, BODYTYPE_ORGANIC)
 	if(hurt_limbs.len)
 		for(var/obj/item/bodypart/affecting as anything in hurt_limbs)
-			if(affecting.heal_damage(heal_amt, heal_amt, BODYTYPE_ORGANIC))
-				blessed.update_damage_overlays()
+			affecting.heal_damage(heal_amt, heal_amt, BODYTYPE_ORGANIC)
+
 		blessed.visible_message(span_notice("[chap] barters a heal for [blessed] from [GLOB.deity]!"))
 		to_chat(blessed, span_boldnotice("May the power of [GLOB.deity] compel you to be healed! Thank you for choosing [GLOB.deity]!"))
 		playsound(chap, 'sound/effects/cashregister.ogg', 60, TRUE)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -378,8 +378,6 @@
 
 	update_interaction_speed()
 
-	update_bodypart_damage_state()
-
 	update_disabled()
 
 	for(var/trait in bodypart_traits)

--- a/code/modules/surgery/bodyparts/wounds/_wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds/_wounds.dm
@@ -21,8 +21,6 @@
 	///Amount of damage the current wound type requires(less means we need to apply the next healing stage)
 	var/min_damage = 0
 
-	///Is bandaged?
-	var/bandaged = 0
 	///Is clamped?
 	var/clamped = 0
 	///Is salved?
@@ -114,7 +112,15 @@
 /datum/wound/proc/can_autoheal()
 	if(LAZYLEN(embedded_objects))
 		return FALSE
-	return (wound_damage() <= autoheal_cutoff) ? TRUE : is_treated()
+
+	switch(wound_type) //OOP is a lie. Should bruises, cuts, and punctures all share a common parent? Probably. Fuck you!
+		if (WOUND_BRUISE, WOUND_CUT, WOUND_PIERCE)
+			if(parent.bandage)
+				return wound_damage() <= initial(autoheal_cutoff)
+		if(WOUND_BURN)
+			. = salved
+
+	. ||= (wound_damage() <= autoheal_cutoff)
 
 ///Checks whether the wound has been appropriately treated
 /datum/wound/proc/is_treated()
@@ -123,7 +129,7 @@
 
 	switch(wound_type)
 		if (WOUND_BRUISE, WOUND_CUT, WOUND_PIERCE)
-			return bandaged
+			return parent.bandage
 		if (WOUND_BURN)
 			return salved
 
@@ -176,14 +182,6 @@
 			return prob(dam_coef*10)
 
 	return 0
-
-/datum/wound/proc/bandage()
-	if(bandaged)
-		return FALSE
-	bandaged = 1
-	if(parent)
-		parent.refresh_bleed_rate()
-	return TRUE
 
 /datum/wound/proc/salve()
 	if(salved)
@@ -284,7 +282,7 @@
 			this_wound_desc = "<b>bleeding</b> [this_wound_desc]"
 		else
 			this_wound_desc = "bleeding [this_wound_desc]"
-	else if(bandaged)
+	else if(parent.bandage)
 		this_wound_desc = "bandaged [this_wound_desc]"
 
 	if(germ_level > 600)

--- a/code/modules/surgery/bodyparts/wounds/burns.dm
+++ b/code/modules/surgery/bodyparts/wounds/burns.dm
@@ -4,7 +4,7 @@
 	max_bleeding_stage = 0
 
 /datum/wound/burn/bleeding()
-	return 0
+	return FALSE
 
 /datum/wound/burn/moderate
 	stages = list(

--- a/code/modules/surgery/bodyparts/wounds/cuts.dm
+++ b/code/modules/surgery/bodyparts/wounds/cuts.dm
@@ -3,11 +3,6 @@
 	bleed_threshold = 5
 	wound_type = WOUND_CUT
 
-/datum/wound/cut/bandage()
-	..()
-	if(!autoheal_cutoff)
-		autoheal_cutoff = initial(autoheal_cutoff)
-
 /datum/wound/cut/is_surgical()
 	return autoheal_cutoff == 0
 

--- a/code/modules/surgery/new_surgery/other.dm
+++ b/code/modules/surgery/new_surgery/other.dm
@@ -24,7 +24,7 @@
 
 /datum/surgery_step/fix_tendon/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = ..()
-	if(affected && (affected.bodypart_flags & BP_ARTERY_CUT))
+	if(affected && (affected.bodypart_flags & BP_TENDON_CUT))
 		return affected
 
 /datum/surgery_step/fix_tendon/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a bug that might(?) have existed that caused wounds to not stop bleeding when they should.
fix: Damage overlays should now always be in the correct state. Cannot say the same for bleeding overlays, but, cope.
fix: Tendon repair surgery works.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
