### PR TITLE
Reorganizes the top right button cluster

### DIFF
--- a/_maps/metastation.json
+++ b/_maps/metastation.json
@@ -3,6 +3,7 @@
 	"map_name": "MetaStation",
 	"map_path": "map_files/MetaStation",
 	"map_file": "MetaStation.dmm",
+	"webmap_id": "DaedalusMeta",
 	"shuttles": {
 		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -662,3 +662,7 @@
 	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/flag/show_job_estimation
+
+/// Unique slug for the webmap
+/datum/config_entry/string/webmap_community
+	default = "DaedalusDock"

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -17,6 +17,7 @@
 	var/map_name = "Meta Station"
 	var/map_path = "map_files/MetaStation"
 	var/map_file = "MetaStation.dmm"
+	var/webmap_id = "DaedalusMeta"
 
 	var/traits = null
 	var/space_ruin_levels = 7
@@ -132,6 +133,10 @@
 	else
 		log_world("map_file missing from json!")
 		return
+
+	webmap_id = json["webmap_id"]
+	if(!webmap_id)
+		log_mapping("Map is missing a webmap ID.")
 
 	if (islist(json["shuttles"]))
 		var/list/L = json["shuttles"]

--- a/code/modules/tgs/core/core.dm
+++ b/code/modules/tgs/core/core.dm
@@ -115,6 +115,7 @@
 			return result
 
 /world/TgsTestMerges()
+	RETURN_TYPE(/list)
 	var/datum/tgs_api/api = TGS_READ_GLOBAL(tgs)
 	if(api)
 		var/result = api.TestMerges()

--- a/config/config.txt
+++ b/config/config.txt
@@ -24,6 +24,9 @@ SERVERSQLNAME daedalusdock
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
 STATIONNAME Daedalus Outpost
 
+## Community slug for AffectedArc's Web Map
+#WEBMAP_COMMUNITY DaedalusDock
+
 ## Hub subtitle: A line of text inserted under the server name. Should be no greater than 40 characters.
 HUB_SUBTITLE Now with custom lighting!
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -118,3 +118,14 @@
 		GLOB.hotkeys_tgui = new /datum/hotkeys_help()
 
 	GLOB.hotkeys_tgui.ui_interact(mob)
+
+/client/verb/webmap()
+	set name = "Open Webmap"
+	set category = "OOC"
+	if(!SSmapping.initialized)
+		to_chat_immediate(src, span_warning("Please wait until the server has fully started!"))
+	if(!SSmapping.config.webmap_id)
+		to_chat(src, "Map ID Missing from config.")
+	if(world.TgsTestMerges().len)
+		alert(src, "Notice: Test Merges are active, this map may not be fully accurate!", "Testmerge Notice", "OK")
+	src << link("https://affectedarc07.github.io/SS13WebMap/[CONFIG_GET(string/webmap_community)]/[SSmapping.config.webmap_id]")

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -149,6 +149,26 @@ window "infowindow"
 		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-pane = true
+	elem "codex_button"
+		type = BUTTON
+		pos = 445,5
+		size = 50x20
+		anchor1 = 70,0
+		anchor2 = 77,0
+		background-color = none
+		saved-params = "is-checked"
+		text = "Codex"
+		command = "Codex"
+	elem "webmap"
+		type = BUTTON
+		pos = 545,5
+		size = 75x20
+		anchor1 = 85,0
+		anchor2 = 97,0
+		background-color = none
+		saved-params = "is-checked"
+		text = "Webmap"
+		command = "webmap"
 	elem "info"
 		type = CHILD
 		pos = 0,30
@@ -162,54 +182,60 @@ window "infowindow"
 	elem "changelog"
 		type = BUTTON
 		pos = 16,5
-		size = 104x20
+		size = 79x20
 		anchor1 = 3,0
-		anchor2 = 19,0
+		anchor2 = 15,0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Changelog"
 		command = "changelog"
 	elem "rules"
 		type = BUTTON
-		pos = 120,5
-		size = 100x20
-		anchor1 = 19,0
-		anchor2 = 34,0
+		pos = 395,5
+		size = 50x20
+		anchor1 = 62,0
+		anchor2 = 70,0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Rules"
 		command = "rules"
 	elem "wiki"
 		type = BUTTON
-		pos = 220,5
-		size = 100x20
-		anchor1 = 34,0
-		anchor2 = 50,0
+		pos = 495,5
+		size = 50x20
+		anchor1 = 77,0
+		anchor2 = 85,0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Wiki"
 		command = "wiki"
 	elem "forum"
 		type = BUTTON
-		pos = 320,5
+		pos = 295,5
 		size = 100x20
-		anchor1 = 50,0
-		anchor2 = 66,0
+		anchor1 = 46,0
+		anchor2 = 62,0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Forum"
 		command = "forum"
 	elem "github"
 		type = BUTTON
-		pos = 420,5
+		pos = 195,5
 		size = 100x20
-		anchor1 = 66,0
-		anchor2 = 81,0
+		anchor1 = 30,0
+		anchor2 = 46,0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Github"
 		command = "github"
 	elem "report-issue"
 		type = BUTTON
-		pos = 520,5
+		pos = 95,5
 		size = 100x20
-		anchor1 = 81,0
-		anchor2 = 97,0
+		anchor1 = 15,0
+		anchor2 = 30,0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Report Issue"
 		command = "report-issue"


### PR DESCRIPTION
Adds Webmap button
Adds Codex button
map JSONS have a new key

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![a](https://images-ext-2.discordapp.net/external/0lVeB23thPFiu_RCgg7QfAj5nDl4WSlpgbdmg_U5It0/https/file.house/jPux.png?width=1248&height=676)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now view a map of the station with the 'Webmap' button in the top right cluster
code: Map JSONS must set the 'webmap_id' key for this to work.
add: You can now open the codex with the 'Codex' button, In the same place.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
