### PR TITLE
Fixes a decade old ZAS issue

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1196,12 +1196,12 @@
 	if(air_tight)
 		set_density(TRUE)
 		flags_1 |= PREVENT_CLICK_UNDER_1
-		zas_update_loc()
+		withdraw_from_zone()
 	sleep(1)
 	if(!air_tight)
 		set_density(TRUE)
 		flags_1 |= PREVENT_CLICK_UNDER_1
-		zas_update_loc()
+		withdraw_from_zone()
 	sleep(4)
 	if(dangerous_close)
 		crush()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1196,12 +1196,12 @@
 	if(air_tight)
 		set_density(TRUE)
 		flags_1 |= PREVENT_CLICK_UNDER_1
-		withdraw_from_zone()
+		zas_update_loc()
 	sleep(1)
 	if(!air_tight)
 		set_density(TRUE)
 		flags_1 |= PREVENT_CLICK_UNDER_1
-		withdraw_from_zone()
+		zas_update_loc()
 	sleep(4)
 	if(dangerous_close)
 		crush()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -69,7 +69,7 @@
 	else
 		flags_1 &= ~PREVENT_CLICK_UNDER_1
 
-	withdraw_from_zone()
+	zas_update_loc()
 	//doors only block while dense though so we have to use the proc
 	real_explosion_block = explosion_block
 	explosion_block = EXPLOSION_BLOCK_PROC
@@ -179,20 +179,25 @@
 		spark_system = null
 	return ..()
 
-/obj/machinery/door/proc/withdraw_from_zone()
-	var/turf/T = get_turf(src)
-	if(!T || !T.simulated)
+/obj/machinery/door/zas_update_loc()
+	. = ..()
+	if(!.)
 		return
-	if(!T.zone || !density || T.zone.invalid)
-		return T.zas_update_loc()
 
-	var/zone/old_zone = T.zone
-	old_zone.remove_turf(T)
+	var/turf/T = get_turf(src)
 
-	var/datum/gas_mixture/GM = unsafe_return_air()
-	old_zone.air.merge(GM)
-	GM.zero()
-	zas_update_loc()
+	if(density)
+		if(!T.zone || T.zone.invalid)
+			return
+		var/zone/old_zone = T.zone
+		old_zone.remove_turf(T)
+
+		var/datum/gas_mixture/GM = unsafe_return_air()
+		old_zone.air.merge(GM)
+		GM.zero()
+
+	else
+		T.update_air_properties()
 
 /obj/machinery/door/zas_canpass(turf/other)
 	if(QDELETED(src))
@@ -481,7 +486,7 @@
 	if(visible && !glass)
 		set_opacity(1)
 	operating = FALSE
-	withdraw_from_zone()
+	zas_update_loc()
 	update_freelook_sight()
 
 	if(!can_crush)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -69,7 +69,7 @@
 	else
 		flags_1 &= ~PREVENT_CLICK_UNDER_1
 
-	zas_update_loc()
+	withdraw_from_zone()
 	//doors only block while dense though so we have to use the proc
 	real_explosion_block = explosion_block
 	explosion_block = EXPLOSION_BLOCK_PROC
@@ -179,6 +179,21 @@
 		spark_system = null
 	return ..()
 
+/obj/machinery/door/proc/withdraw_from_zone()
+	var/turf/T = get_turf(src)
+	if(!T || !T.simulated)
+		return
+	if(!T.zone || !density || T.zone.invalid)
+		return T.zas_update_loc()
+
+	var/zone/old_zone = T.zone
+	old_zone.remove_turf(T)
+
+	var/datum/gas_mixture/GM = unsafe_return_air()
+	old_zone.air.merge(GM)
+	GM.zero()
+	zas_update_loc()
+
 /obj/machinery/door/zas_canpass(turf/other)
 	if(QDELETED(src))
 		return AIR_ALLOWED
@@ -247,14 +262,6 @@
 		else
 			do_animate("deny")
 		return
-
-/obj/machinery/door/Move()
-	var/turf/T = loc
-	. = ..()
-	if(.)
-		T.zas_update_loc()
-		zas_update_loc()
-
 
 /obj/machinery/door/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
@@ -474,7 +481,7 @@
 	if(visible && !glass)
 		set_opacity(1)
 	operating = FALSE
-	zas_update_loc()
+	withdraw_from_zone()
 	update_freelook_sight()
 
 	if(!can_crush)

--- a/code/modules/atmospherics/ZAS/Atom.dm
+++ b/code/modules/atmospherics/ZAS/Atom.dm
@@ -4,6 +4,8 @@
 
 ///Tells ZAS to mark the tile the atom is in to update.
 /atom/proc/zas_update_loc()
+	if(!SSzas.initialized)
+		return FALSE
 	var/turf/T = get_turf(src)
 	if(T?.simulated)
 		SSzas.mark_for_update(T)

--- a/code/modules/atmospherics/ZAS/Debug.dm
+++ b/code/modules/atmospherics/ZAS/Debug.dm
@@ -31,6 +31,7 @@ GLOBAL_REAL_VAR(list/zasdbgovl_dirzoneblock) = list(
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	layer = FLY_LAYER
 	vis_flags = NONE
+	appearance_flags = RESET_COLOR | RESET_TRANSFORM | RESET_ALPHA | KEEP_APART
 
 /obj/effect/zasdbg/assigned
 	icon_state = "assigned"

--- a/code/modules/atmospherics/ZAS/Turf.dm
+++ b/code/modules/atmospherics/ZAS/Turf.dm
@@ -91,7 +91,7 @@
 */
 ///Simple heuristic for determining if removing the turf from it's zone will not partition the zone (A very bad thing).
 /turf/proc/can_safely_remove_from_zone()
-	if(isnull(zone))
+	if(isnull(zone) || zone.invalid)
 		return TRUE
 
 	var/check_dirs

--- a/code/modules/atmospherics/ZAS/XGM/xgm_gas_mixture.dm
+++ b/code/modules/atmospherics/ZAS/XGM/xgm_gas_mixture.dm
@@ -1,7 +1,7 @@
 /datum/gas_mixture
 	//Associative list of gas moles.
 	//Gases with 0 moles are not tracked and are pruned by updateValues()
-	var/list/gas = list()
+	var/list/gas
 	//Temperature in Kelvin of this gas mix.
 	var/temperature = 0
 
@@ -13,7 +13,7 @@
 	var/group_multiplier = 1
 
 	//List of active tile overlays for this gas_mixture.  Updated by checkTileGraphic()
-	var/list/graphic = list()
+	var/list/graphic
 	//Cache of gas overlay objects
 	var/list/tile_overlay_cache
 
@@ -21,6 +21,8 @@
 	volume = _volume
 	temperature = _temperature
 	group_multiplier = _group_multiplier
+	gas = list()
+	graphic = list()
 
 ///Returns the volume of a specific gas within the entire zone.
 /datum/gas_mixture/proc/getGroupGas(gasid)
@@ -31,6 +33,12 @@
 ///Returns the volume of the entire zone's gas contents.
 /datum/gas_mixture/proc/getGroupMoles()
 	return total_moles * group_multiplier
+
+/datum/gas_mixture/proc/zero()
+	gas.Cut()
+	temperature = T0C
+	group_multiplier = 1
+	total_moles = 0
 
 ///Takes a gas string and the amount of moles to adjust by. Calls updateValues() if update isn't 0.
 /datum/gas_mixture/proc/adjustGas(gasid, moles, update = TRUE)

--- a/code/modules/atmospherics/ZAS/Zone.dm
+++ b/code/modules/atmospherics/ZAS/Zone.dm
@@ -168,7 +168,7 @@ Class Procs:
 	atmos_sensitive_contents = null
 	#ifdef ZASDBG
 	for(var/turf/T as anything in contents)
-		if(!T.simulated)
+		if(T.simulated)
 			T.dbg(zasdbgovl_invalid_zone)
 	#endif
 
@@ -183,13 +183,15 @@ Class Procs:
 	for(var/turf/T as anything in contents)
 		if(!T.simulated)
 			continue
-		T.update_graphic(graphic_remove = air.graphic) //we need to remove the overlays so they're not doubled when the zone is rebuilt
-		#ifdef ZASDBG
-		//T.dbg(invalid_zone)
-		#endif
+		remove_turf(T)
+		CHECK_TICK
+
+	for(var/turf/T as anything in contents)
+		if(!T.simulated)
+			continue
+
 		T.needs_air_update = 0 //Reset the marker so that it will be added to the list.
 		SSzas.mark_for_update(T)
-
 		CHECK_TICK
 
 ///Assumes a given gas mixture, dividing it amongst the zone.

--- a/code/modules/atmospherics/ZAS/zas_extras/inflatable.dm
+++ b/code/modules/atmospherics/ZAS/zas_extras/inflatable.dm
@@ -230,6 +230,26 @@
 		return
 	return TryToSwitchState(user)
 
+/obj/machinery/inflatable/door/zas_update_loc()
+	. = ..()
+	if(!.)
+		return
+
+	var/turf/T = get_turf(src)
+
+	if(density)
+		if(!T.zone || T.zone.invalid)
+			return
+		var/zone/old_zone = T.zone
+		old_zone.remove_turf(T)
+
+		var/datum/gas_mixture/GM = unsafe_return_air()
+		old_zone.air.merge(GM)
+		GM.zero()
+
+	else
+		T.update_air_properties()
+
 /obj/structure/inflatable/door/proc/TryToSwitchState(atom/user)
 	if(isSwitchingStates) return
 	if(ismob(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Said quirk is pretty simple, when an airlock closes, the turf leaves the zone and takes it's share of air with it. Sounds fine, right? Well, it's fine until that share contains dangerous gas, because then when the airlock re-opens, it reintroduces the dangerous gas to the atmosphere.

My solution was actually pretty simple. Instead of using the simple zas_update_loc helper, I wrote some wrapper code around it specifically for doors to utilize when running close(). 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Doors of all kinds will no longer "trap" dangerous gas inside when closing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
