### PR TITLE
Bone breaking tweaks

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -51,11 +51,6 @@
 #define MOB_SPIRIT (1 << 9)
 #define MOB_PLANT (1 << 10)
 
-
-//Organ defines for carbon mobs
-#define ORGAN_ORGANIC 1
-#define ORGAN_ROBOTIC 2
-
 #define DEFAULT_BODYPART_ICON_ORGANIC 'icons/mob/human_parts_greyscale.dmi'
 #define DEFAULT_BODYPART_ICON_ROBOTIC 'icons/mob/augmentation/augments.dmi'
 

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -3,8 +3,7 @@
 	desc = "A nausea-inducing hunk of twisting flesh and metal."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "gland"
-	status = ORGAN_ROBOTIC
-	organ_flags = NONE
+	organ_flags = ORGAN_SYNTHETIC
 	beating = TRUE
 	/// Shows name of the gland as well as a description of what it does upon examination by abductor scientists and observers.
 	var/abductor_hint = "baseline placebo referencer"

--- a/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -22,7 +22,7 @@
 		return COMPONENT_INCOMPATIBLE
 
 	var/obj/item/organ/organ_parent = parent
-	if(organ_parent.status != ORGAN_ORGANIC || (organ_parent.organ_flags & ORGAN_SYNTHETIC))
+	if(organ_parent.organ_flags & ORGAN_SYNTHETIC)
 		return COMPONENT_INCOMPATIBLE
 
 	if(!IS_HERETIC(organ_parent.owner))

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -114,7 +114,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 
 	// By this point they are making a new heart
 	// If their current heart is organic / not synthetic, we can continue the ritual as normal
-	if(our_living_heart.status == ORGAN_ORGANIC && !(our_living_heart.organ_flags & ORGAN_SYNTHETIC))
+	if(!(our_living_heart.organ_flags & ORGAN_SYNTHETIC))
 		return TRUE
 
 	// If their current heart is not organic / is synthetic, they need an organic replacement
@@ -129,7 +129,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 			continue
 		if(!nearby_organ.useable)
 			continue
-		if(nearby_organ.status != ORGAN_ORGANIC || (nearby_organ.organ_flags & (ORGAN_SYNTHETIC|ORGAN_FAILING)))
+		if(nearby_organ.organ_flags & (ORGAN_SYNTHETIC|ORGAN_FAILING))
 			continue
 
 		selected_atoms += nearby_organ
@@ -143,7 +143,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	var/obj/item/organ/our_new_heart = user.getorganslot(our_heretic.living_heart_organ_slot)
 
 	// Our heart is robotic or synthetic - we need to replace it, and we fortunately should have one by here
-	if(our_new_heart.status != ORGAN_ORGANIC || (our_new_heart.organ_flags & ORGAN_SYNTHETIC))
+	if(our_new_heart.organ_flags & ORGAN_SYNTHETIC)
 		var/obj/item/organ/our_replacement_heart = locate(required_organ_type) in selected_atoms
 		if(our_replacement_heart)
 			// Throw our current heart out of our chest, violently

--- a/code/modules/antagonists/heretic/structures/mawed_crucible.dm
+++ b/code/modules/antagonists/heretic/structures/mawed_crucible.dm
@@ -84,7 +84,7 @@
 
 	if(istype(weapon, /obj/item/organ))
 		var/obj/item/organ/consumed = weapon
-		if(consumed.status != ORGAN_ORGANIC || (consumed.organ_flags & ORGAN_SYNTHETIC))
+		if(consumed.organ_flags & ORGAN_SYNTHETIC)
 			balloon_alert(user, "not organic!")
 			return
 		if(consumed.organ_flags & ORGAN_VITAL) // Basically, don't eat organs like brains

--- a/code/modules/atmospherics/ZAS/Plasma.dm
+++ b/code/modules/atmospherics/ZAS/Plasma.dm
@@ -35,7 +35,7 @@ GLOBAL_DATUM_INIT(contamination_overlay, /image, image('modular_pariah/master_fi
 	if(rand(1, 100) < zas_settings.plc.eye_burns * exposed_amount)
 		if(!is_eyes_covered())
 			var/obj/item/organ/eyes/E = getorganslot(ORGAN_SLOT_EYES)
-			if(E && !(E.status == ORGAN_ROBOTIC))
+			if(E && !(E.organ_flags & ORGAN_SYNTHETIC))
 				if(prob(20))
 					to_chat(src, span_warning("Your eyes burn!"))
 				E.applyOrganDamage(2.5)

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -794,7 +794,6 @@
 	desc = "An eerie metal shard surrounded by dark energies."
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	icon_state = "cursed_katana_organ"
-	status = ORGAN_ORGANIC
 	organ_flags = ORGAN_FROZEN|ORGAN_UNREMOVABLE
 	items_to_create = list(/obj/item/cursed_katana)
 	extend_sound = 'sound/items/unsheath.ogg'

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -335,7 +335,6 @@
 	name = "cortical stack"
 	desc = "A peculiarly advanced bio-electronic device that seems to hold the memories and identity of a Vox."
 	icon_state = "cortical-stack"
-	status = ORGAN_ROBOTIC
 	organ_flags = ORGAN_SYNTHETIC
 
 /obj/item/organ/brain/vox/emp_act(severity)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -60,7 +60,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
 	if(amount > 0)
-		take_overall_damage(amount, 0, updating_health, required_status)
+		take_overall_damage(amount, 0, updating_health, required_status, can_break_bones = FALSE)
 	else
 		heal_overall_damage(abs(amount), 0, required_status ? required_status : BODYTYPE_ORGANIC, updating_health)
 	return amount
@@ -214,7 +214,7 @@
 		update_damage_overlays()
 
 /// damage MANY bodyparts, in random order
-/mob/living/carbon/take_overall_damage(brute = 0, burn = 0, updating_health = TRUE, required_status)
+/mob/living/carbon/take_overall_damage(brute = 0, burn = 0, updating_health = TRUE, required_status, can_break_bones = TRUE)
 	if(status_flags & GODMODE)
 		return //godmode
 	var/list/obj/item/bodypart/parts = get_damageable_bodyparts(required_status)
@@ -228,7 +228,7 @@
 		var/burn_was = picked.burn_dam
 
 
-		update |= picked.receive_damage(brute_per_part, burn_per_part, 0, FALSE, required_status)
+		update |= picked.receive_damage(brute_per_part, burn_per_part, 0, FALSE, required_status, breaks_bones = can_break_bones)
 		brute = round(brute - (picked.brute_dam - brute_was), DAMAGE_PRECISION)
 		burn = round(burn - (picked.burn_dam - burn_was), DAMAGE_PRECISION)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -311,7 +311,7 @@
 		if(HAS_TRAIT(user, TRAIT_MEDICAL_HUD))
 			var/cyberimp_detect
 			for(var/obj/item/organ/cyberimp/CI in processing_organs)
-				if(CI.status == ORGAN_ROBOTIC && !CI.syndicate_implant)
+				if((CI.organ_flags & ORGAN_SYNTHETIC) && !CI.syndicate_implant)
 					cyberimp_detect += "[!cyberimp_detect ? "[CI.get_examine_string(user)]" : ", [CI.get_examine_string(user)]"]"
 			if(cyberimp_detect)
 				. += "<span class='notice ml-1'>Detected cybernetic modifications:</span>"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -282,7 +282,7 @@
 	C.heal_overall_damage(30 * removed, 30 * removed, updating_health = FALSE)
 	APPLY_CHEM_EFFECT(C, CE_PULSE, -2)
 	for(var/obj/item/organ/I as anything in C.processing_organs)
-		if(!(I.status & ORGAN_ROBOTIC))
+		if(!(I.organ_flags & ORGAN_SYNTHETIC))
 			I.applyOrganDamage(-20*removed)
 	return TRUE
 
@@ -304,7 +304,7 @@
 		C.heal_overall_damage(50 * removed, 50 * removed, updating_health = FALSE)
 		APPLY_CHEM_EFFECT(C, CE_PULSE, -2)
 		for(var/obj/item/organ/I as anything in C.processing_organs)
-			if(!(I.status & ORGAN_ROBOTIC))
+			if(!(I.organ_flags & ORGAN_SYNTHETIC))
 				I.applyOrganDamage(-30*removed)
 		return TRUE
 
@@ -540,7 +540,7 @@
 
 	var/mob/living/carbon/human/H = C
 	for(var/obj/item/organ/I in H.processing_organs)
-		if(!(I.status & ORGAN_ROBOTIC))
+		if(!(I.organ_flags & ORGAN_SYNTHETIC))
 			if(istype(I, /obj/item/organ/brain))
 				// if we have located an organic brain, apply side effects
 				H.adjust_confusion(2 SECONDS)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -526,11 +526,14 @@
 
 
 	//blunt damage is gud at fracturing
-	if(breaks_bones)
-		if(brute)
+	if(breaks_bones && brute)
+		if(bodypart_flags & BP_BROKEN_BONES)
 			jostle_bones(brute)
-			if((brute_dam + brute > minimum_break_damage) && prob((brute_dam + brute * (1 + !sharpness)) * BODYPART_BONES_BREAK_CHANCE_MOD))
-				break_bones()
+			if(prob(20))
+				spawn(-1)
+					owner?.emote("scream")
+		else if((brute_dam + brute > minimum_break_damage) && prob((brute_dam + brute * (1 + !sharpness)) * BODYPART_BONES_BREAK_CHANCE_MOD))
+			break_bones()
 
 
 	if(!damagable)

--- a/code/modules/surgery/bodyparts/injuries.dm
+++ b/code/modules/surgery/bodyparts/injuries.dm
@@ -32,7 +32,7 @@
 	if(owner)
 		owner.visible_message(
 			span_danger("You hear a loud cracking sound coming from \the [owner]."),
-			span_danger("Something feels like it shattered in your [name]!"),
+			span_danger("Something feels like it shattered in your [plaintext_zone]!"),
 			span_danger("You hear a sickening crack.")
 		)
 
@@ -84,18 +84,23 @@
 	if(brute_dam + force < BODYPART_MINIMUM_DAMAGE_TO_JIGGLEBONES)	//no papercuts moving bones
 		return
 
-	if(!prob(brute_dam + force))
+	if(!length(contained_organs) || !prob(brute_dam + force))
 		return
 
-	receive_damage(force, breaks_bones = FALSE) //NO RECURSIVE BONE JOSTLING
+	var/obj/item/organ/O
+	var/list/organs = shuffle(contained_organs)
+	while(!O && length(organs))
+		O = pick_n_take(organs)
+		if(O.cosmetic_only)
+			O = null
+	if(!O)
+		return
+
+	O.applyOrganDamage(rand(3,5))
+
 	if(owner)
-		owner.audible_message(
-			span_warning("A sickening noise comes from [owner]'s [plaintext_zone]!"),
-			null,
-			2,
-			span_warning("You feel something moving in your [plaintext_zone]!")
-		)
-		INVOKE_ASYNC(owner, TYPE_PROC_REF(/mob, emote), "scream")
+		to_chat(owner, span_warning("You feel something moving in your [plaintext_zone]!"))
+
 
 /// Updates the interaction speed modifier of this limb, used by Limping and similar to determine delay.
 /obj/item/bodypart/proc/update_interaction_speed()

--- a/code/modules/surgery/bodyparts/wounds/_wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds/_wounds.dm
@@ -349,7 +349,7 @@
 	return null //no wound
 
 /obj/item/bodypart/proc/attempt_dismemberment(brute as num, burn as num, sharpness)
-	if((sharpness & SHARP_EDGED) && brute >= max_damage * DROPLIMB_THRESHOLD_EDGE)
+	if((sharpness & SHARP_EDGED) && (brute + src.brute_dam) >= max_damage * DROPLIMB_THRESHOLD_EDGE)
 		if(prob(brute))
 			return dismember(DROPLIMB_EDGE, FALSE, FALSE)
 

--- a/code/modules/surgery/new_surgery/internal_organs.dm
+++ b/code/modules/surgery/new_surgery/internal_organs.dm
@@ -31,14 +31,14 @@
 	for(var/obj/item/organ/I in affected.contained_organs)
 		if(istype(I, /obj/item/organ/brain))
 			continue
-		if(!(I.status & ORGAN_ROBOTIC) && I.damage > 0)
+		if(!(I.organ_flags & ORGAN_SYNTHETIC) && I.damage > 0)
 			return TRUE
 
 /datum/surgery_step/internal/fix_organ/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/list/organs = list()
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
 	for(var/obj/item/organ/I in affected.contained_organs)
-		if(!(I.status & ORGAN_ROBOTIC) && I.damage > 0)
+		if(!(I.organ_flags & ORGAN_SYNTHETIC) && I.damage > 0)
 			organs[I.name] = I.slot
 
 	var/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in organs
@@ -75,7 +75,7 @@
 	affected.receive_damage(dam_amt, sharpness = SHARP_EDGED|SHARP_POINTY)
 
 	for(var/obj/item/organ/I in affected.contained_organs)
-		if(I.damage > 0 && !(I.status & ORGAN_ROBOTIC) && (affected.how_open() >= (affected.encased ? SURGERY_DEENCASED : SURGERY_RETRACTED)))
+		if(I.damage > 0 && !(I.organ_flags & ORGAN_SYNTHETIC) && (affected.how_open() >= (affected.encased ? SURGERY_DEENCASED : SURGERY_RETRACTED)))
 			I.applyOrganDamage(dam_amt)
 	..()
 
@@ -229,9 +229,9 @@
 	if(istype(O) && user.transferItemToLoc(O, target))
 		affected.add_cavity_item(O) //move the organ into the patient. The organ is properly reattached in the next step
 
-		if(!(O.status & ORGAN_CUT_AWAY))
+		if(!(O.organ_flags & ORGAN_CUT_AWAY))
 			stack_trace("[user] ([user.ckey]) replaced organ [O.type], which didn't have ORGAN_CUT_AWAY set, in [target] ([target.ckey])")
-			O.status |= ORGAN_CUT_AWAY
+			O.organ_flags |= ORGAN_CUT_AWAY
 	..()
 
 /datum/surgery_step/internal/replace_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -298,7 +298,6 @@
 	user.visible_message(span_notice("[user] has reattached [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with [tool]."))
 
 	if(istype(I) && affected && deprecise_zone(I.zone) == affected.body_zone && (I in affected.cavity_items))
-		I.status &= ~ORGAN_CUT_AWAY //apply fixovein
 		affected.remove_cavity_item(I)
 		I.Insert(target)
 	..()

--- a/code/modules/surgery/new_surgery/robotics.dm
+++ b/code/modules/surgery/new_surgery/robotics.dm
@@ -212,7 +212,7 @@
 	if(!affected)
 		return
 	for(var/obj/item/organ/I in affected.contained_organs)
-		if((I.status & ORGAN_ROBOTIC) && I.damage > 0)
+		if((I.organ_flags & ORGAN_SYNTHETIC) && I.damage > 0)
 			return TRUE
 	..()
 
@@ -223,7 +223,7 @@
 
 	var/list/organs = list()
 	for(var/obj/item/organ/I in affected.contained_organs)
-		if((I.status & ORGAN_ROBOTIC) && I.damage > 0)
+		if((I.organ_flags & ORGAN_SYNTHETIC) && I.damage > 0)
 			organs[I.name] = I.slot
 
 	if(!length(organs))

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -6,7 +6,6 @@
 	throwforce = 0
 	///The mob that owns this organ.
 	var/mob/living/carbon/owner = null
-	var/status = ORGAN_ORGANIC
 	///The body zone this organ is supposed to inhabit.
 	var/zone = BODY_ZONE_CHEST
 	///The organ slot this organ is supposed to inhabit. This should be unique by type. (Lungs, Appendix, Stomach, etc)
@@ -271,7 +270,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	. += span_notice("It should be inserted in the [parse_zone(zone)].")
 
 	if(organ_flags & ORGAN_FAILING)
-		if(status == ORGAN_ROBOTIC)
+		if(organ_flags & ORGAN_SYNTHETIC)
 			. += span_warning("[src] seems to be broken.")
 			return
 		. += span_warning("[src] has decayed for too long, and has turned a sickly color. It probably won't work without repairs.")
@@ -306,7 +305,17 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	var/mess = check_damage_thresholds(owner)
 	check_failing_thresholds()
 	prev_damage = damage
-	if(mess && owner && owner.stat <= SOFT_CRIT)
+	if(owner && owner.stat <= SOFT_CRIT && !(organ_flags & ORGAN_SYNTHETIC) && damage_amount > 0 && (damage_amount > 5 || prob(10)))
+		if(!mess)
+			var/obj/item/bodypart/BP = loc
+			if(!BP)
+				return
+			var/degree = ""
+			if(damage > high_threshold)
+				degree = " a lot"
+			else if(damage < low_threshold)
+				degree = " a bit"
+			mess = span_warning("Something inside your [BP.plaintext_zone] hurts[degree].")
 		to_chat(owner, mess)
 
 ///SETS an organ's damage to the amount "damage_amount", and in doing so clears or sets the failing flag, good for when you have an effect that should fix an organ if broken
@@ -446,4 +455,4 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	else if (damage > low_threshold)
 		. += tag ?"<span style='font-weight: bold; color:#ffcc33'>Mildly Damaged</span>" : "Mildly Damaged"
 
-	return status
+	return

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -57,7 +57,7 @@
 
 /obj/item/organ/cyberimp/arm/examine(mob/user)
 	. = ..()
-	if(status == ORGAN_ROBOTIC)
+	if(organ_flags & ORGAN_SYNTHETIC)
 		. += span_info("[src] is assembled in the [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm configuration. You can use a screwdriver to reassemble it.")
 
 /obj/item/organ/cyberimp/arm/screwdriver_act(mob/living/user, obj/item/screwtool)
@@ -97,7 +97,7 @@
 
 /obj/item/organ/cyberimp/arm/emp_act(severity)
 	. = ..()
-	if(. & EMP_PROTECT_SELF || status == ORGAN_ROBOTIC)
+	if(. & EMP_PROTECT_SELF || (organ_flags & ORGAN_SYNTHETIC))
 		return
 	if(prob(15/severity) && owner)
 		to_chat(owner, span_warning("The electromagnetic pulse causes [src] to malfunction!"))

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -3,7 +3,6 @@
 	name = "cybernetic implant"
 	desc = "A state-of-the-art implant that improves a baseline's functionality."
 	visual = FALSE
-	status = ORGAN_ROBOTIC
 	organ_flags = ORGAN_SYNTHETIC
 	var/implant_color = "#FFFFFF"
 	var/implant_overlay

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -221,7 +221,6 @@
 	name = "robotic eyes"
 	icon_state = "cybernetic_eyeballs"
 	desc = "Your vision is augmented."
-	status = ORGAN_ROBOTIC
 	organ_flags = ORGAN_SYNTHETIC
 
 	///Incase the eyes are removed before the timer expires

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -93,7 +93,7 @@
 	if(damage > high_threshold)
 		filter_effect -= 2
 	// Robotic organs filter better but don't get benefits from dylovene for filtering.
-	if(status & ORGAN_ROBOTIC)
+	if(organ_flags & ORGAN_SYNTHETIC)
 		filter_effect += 1
 	else if(owner.chem_effects[CE_ANTITOX])
 		filter_effect += 1

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -513,5 +513,3 @@
 	cold_level_1_threshold = 0 // Vox should be able to breathe in cold gas without issues?
 	cold_level_2_threshold = 0
 	cold_level_3_threshold = 0
-	status = ORGAN_ROBOTIC
-	organ_flags = ORGAN_SYNTHETIC

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -373,8 +373,7 @@
 /obj/item/organ/tongue/robot
 	name = "robotic voicebox"
 	desc = "A voice synthesizer that can interface with organic lifeforms."
-	status = ORGAN_ROBOTIC
-	organ_flags = NONE
+	organ_flags = ORGAN_SYNTHETIC
 	icon_state = "tonguerobot"
 	say_mod = "states"
 	attack_verb_continuous = list("beeps", "boops")


### PR DESCRIPTION
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Damaging a bodypart with a broken bone has a chance to deal damage to an organ inside.
balance: Damage that ignores armor (such as pressure damage) can no longer break bones or jostle bones.
balance: Tweaked the dismemberment formula for the 8th time
code: Removed organ/var/status
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
