### PR TITLE
Click-Drag can now be used to consistently manipulate inventories.

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -12,7 +12,7 @@
 		return
 	if(over == src)
 		return usr.client.Click(src, src_location, src_control, params)
-	if(!Adjacent(usr) || !over.Adjacent(usr))
+	if((!Adjacent(usr) || !over.Adjacent(usr)) && !istype(over, /atom/movable/screen))
 		return // should stop you from dragging through windows
 
 	over.MouseDrop_T(src,usr, params)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -277,7 +277,7 @@
 		return TRUE
 
 	var/obj/item/I = dropping
-	if(!(user.is_holding(I) || (I.item_flags & IN_STORAGE)))
+	if(!(user.is_holding(I) || (I.item_flags & (IN_STORAGE|IN_INVENTORY))))
 		return TRUE
 
 	var/item_index = user.get_held_index_of_item(I)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -280,7 +280,11 @@
 	if(!(user.is_holding(I) || (I.item_flags & IN_STORAGE)))
 		return TRUE
 
-	user.putItemFromInventoryInHandIfPossible(dropping, held_index)
+	var/item_index = user.get_held_index_of_item(I)
+	if(item_index)
+		user.swapHeldIndexes(item_index, held_index)
+	else
+		user.putItemFromInventoryInHandIfPossible(dropping, held_index)
 	return TRUE
 
 /atom/movable/screen/close

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -147,6 +147,23 @@
 		usr.update_held_items()
 	return TRUE
 
+/atom/movable/screen/inventory/MouseDrop_T(atom/dropped, mob/user, params)
+	if(user != hud?.mymob || !slot_id)
+		return TRUE
+	if(!isitem(dropped))
+		return TRUE
+	if(world.time <= usr.next_move)
+		return TRUE
+	if(usr.incapacitated(IGNORE_STASIS))
+		return TRUE
+	if(ismecha(usr.loc)) // stops inventory actions in a mech
+		return TRUE
+	if(!user.is_holding(dropped))
+		return TRUE
+
+	user.equip_to_slot_if_possible(dropped, slot_id, FALSE, FALSE, FALSE)
+	return TRUE
+
 /atom/movable/screen/inventory/MouseEntered(location, control, params)
 	. = ..()
 	add_overlays()
@@ -222,10 +239,13 @@
 	var/mob/user = hud?.mymob
 	if(usr != user)
 		return TRUE
+
 	if(world.time <= user.next_move)
 		return TRUE
+
 	if(user.incapacitated())
 		return TRUE
+
 	if (ismecha(user.loc)) // stops inventory actions in a mech
 		return TRUE
 
@@ -235,6 +255,32 @@
 			I.Click(location, control, params)
 	else
 		user.swap_hand(held_index)
+	return TRUE
+
+/atom/movable/screen/inventory/hand/MouseDrop_T(atom/dropping, mob/user, params)
+	if(!isitem(dropping))
+		return TRUE
+
+	if(usr != hud?.mymob)
+		return TRUE
+
+	if(world.time <= user.next_move)
+		return TRUE
+
+	if(user.incapacitated())
+		return TRUE
+
+	if(ismecha(user.loc)) // stops inventory actions in a mech
+		return TRUE
+
+	if(!user.CanReach(dropping))
+		return TRUE
+
+	var/obj/item/I = dropping
+	if(!(user.is_holding(I) || (I.item_flags & IN_STORAGE)))
+		return TRUE
+
+	user.putItemFromInventoryInHandIfPossible(dropping, held_index)
 	return TRUE
 
 /atom/movable/screen/close
@@ -406,6 +452,35 @@
 	var/obj/item/inserted = usr.get_active_held_item()
 	if(inserted)
 		storage_master.attempt_insert(inserted, usr)
+
+	return TRUE
+
+/atom/movable/screen/storage/MouseDrop_T(atom/dropping, mob/user, params)
+	var/datum/storage/storage_master = master
+
+	if(!istype(storage_master))
+		return FALSE
+
+	if(!isitem(dropping))
+		return TRUE
+
+	if(world.time <= user.next_move)
+		return TRUE
+
+	if(user.incapacitated())
+		return TRUE
+
+	if(ismecha(user.loc)) // stops inventory actions in a mech
+		return TRUE
+
+	if(!user.CanReach(dropping))
+		return TRUE
+
+	var/obj/item/I = dropping
+	if(!(user.is_holding(I) || (I.item_flags & IN_STORAGE)))
+		return TRUE
+
+	storage_master.attempt_insert(dropping, usr)
 
 	return TRUE
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -683,18 +683,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	resolve_parent.add_fingerprint(user)
 
-	if(istype(over_object, /atom/movable/screen/inventory/hand))
-		var/mob/M = resolve_parent
-		while(!ismob(M) && !isnull(M))
-			M = M.loc
 
-		if(!M?.CanReach(resolve_location))
-			return
-
-		var/atom/movable/screen/inventory/hand/hand = over_object
-		user.putItemFromInventoryInHandIfPossible(resolve_parent, hand.held_index)
-
-	else if(ismob(over_object))
+	if(ismob(over_object))
 		if(over_object != user)
 			return
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -684,8 +684,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	resolve_parent.add_fingerprint(user)
 
 	if(istype(over_object, /atom/movable/screen/inventory/hand))
+		var/mob/M = resolve_parent
+		while(!ismob(M) && !isnull(M))
+			M = M.loc
 
-		if(resolve_parent.loc != user)
+		if(!M?.CanReach(resolve_location))
 			return
 
 		var/atom/movable/screen/inventory/hand/hand = over_object

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -510,7 +510,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 
 
 	//If the item is in a storage item, take it out
-	loc.atom_storage?.attempt_remove(src, user.loc, silent = TRUE)
+	var/was_in_storage = loc.atom_storage?.attempt_remove(src, user.loc, silent = TRUE)
 	if(QDELETED(src)) //moving it out of the storage to the floor destroyed it.
 		return
 
@@ -523,7 +523,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	. = FALSE
 	pickup(user)
 	add_fingerprint(user)
-	if(!user.put_in_active_hand(src, FALSE, FALSE))
+	if(!user.put_in_active_hand(src, FALSE, was_in_storage))
 		user.dropItemToGround(src)
 		return TRUE
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -276,14 +276,18 @@
 	var/obj/item/item_A = get_item_for_held_index(index_A)
 	var/obj/item/item_B = get_item_for_held_index(index_B)
 
+	var/failed_uh_oh_abort = FALSE
 	if(!(item_A || item_B))
 		return
 	if(item_A && !temporarilyRemoveItemFromInventory(item_A))
-		return
+		failed_uh_oh_abort = TRUE
 	if(item_B && !temporarilyRemoveItemFromInventory(item_B))
-		return
+		failed_uh_oh_abort = TRUE
 
 	if((item_A && !put_in_hand(item_A, index_B)) || (item_B && !put_in_hand(item_B, index_A)))
+		failed_uh_oh_abort = TRUE
+
+	if(failed_uh_oh_abort)
 		if(item_A)
 			temporarilyRemoveItemFromInventory(item_A)
 		if(item_B)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -264,7 +264,7 @@
 	if(!temporarilyRemoveItemFromInventory(I, force_removal))
 		return FALSE
 	I.remove_item_from_storage(src)
-	if(!put_in_hand(I, hand_index))
+	if(!put_in_hand(I, hand_index, ignore_anim = TRUE))
 		qdel(I)
 		CRASH("Assertion failure: putItemFromInventoryInHandIfPossible") //should never be possible
 	return TRUE
@@ -377,8 +377,10 @@
  * Argument(s):
  * * Optional - include_pockets (TRUE/FALSE), whether or not to include the pockets and suit storage in the returned list
  */
+/mob/proc/get_equipped_items(include_pockets = FALSE)
+	return
 
-/mob/living/proc/get_equipped_items(include_pockets = FALSE)
+/mob/living/get_equipped_items(include_pockets = FALSE)
 	var/list/items = list()
 	for(var/obj/item/item_contents in contents)
 		if(item_contents.item_flags & IN_INVENTORY)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -269,6 +269,32 @@
 		CRASH("Assertion failure: putItemFromInventoryInHandIfPossible") //should never be possible
 	return TRUE
 
+/// Switches the items inside of two hand indexes.
+/mob/proc/swapHeldIndexes(index_A, index_B)
+	if(index_A == index_B)
+		return
+	var/obj/item/item_A = get_item_for_held_index(index_A)
+	var/obj/item/item_B = get_item_for_held_index(index_B)
+
+	if(!(item_A || item_B))
+		return
+	if(item_A && !temporarilyRemoveItemFromInventory(item_A))
+		return
+	if(item_B && !temporarilyRemoveItemFromInventory(item_B))
+		return
+
+	if((item_A && !put_in_hand(item_A, index_B)) || (item_B && !put_in_hand(item_B, index_A)))
+		if(item_A)
+			temporarilyRemoveItemFromInventory(item_A)
+		if(item_B)
+			temporarilyRemoveItemFromInventory(item_B)
+		if(item_A)
+			put_in_hand(item_A, index_A)
+		if(item_B)
+			put_in_hand(item_B, index_B)
+		return FALSE
+	return TRUE
+
 //The following functions are the same save for one small difference
 
 /**


### PR DESCRIPTION

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Click-Drag can now be used to move items around inventories, including swapping which hand an item is holding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
