### PR TITLE
Fixes up the issue report flow

### DIFF
--- a/code/modules/tgui/tgui_alert.dm
+++ b/code/modules/tgui/tgui_alert.dm
@@ -21,10 +21,15 @@
 			return
 	// Client does NOT have tgui_input on: Returns regular input
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
-		if(length(buttons) == 2)
-			return alert(user, message, title, buttons[1], buttons[2])
-		if(length(buttons) == 3)
-			return alert(user, message, title, buttons[1], buttons[2], buttons[3])
+		switch(length(buttons))
+			if(1)
+				return alert(user, message, title, buttons[1])
+			if(2)
+				return alert(user, message, title, buttons[1], buttons[2])
+			if(3)
+				return alert(user, message, title, buttons[1], buttons[2], buttons[3])
+			/*else
+				fall back and show them a TGUI one, whether they want it or not.*/
 	var/datum/tgui_modal/alert = new(user, message, title, buttons, timeout, autofocus)
 	alert.ui_interact(user)
 	alert.wait()

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -66,14 +66,14 @@
 	if(restricted_mode || is_banned_from(ckey, "Bug Report"))
 		to_chat(src, span_warning("You are not currently allowed to make a bug report through this system."))
 		return
-	var/message = "This will start reporting an issue, gathering some information from the server and your client, before submitting it to github."
-	if(GLOB.revdata.testmerge.len)
-		message += "<br>The following experimental changes are active and may be the cause of any new or sudden issues:<br>"
-		message += GLOB.revdata.GetTestMergeInfo(FALSE)
+	if(alert(src, "This will start reporting an issue, gathering some information from the server and your client, before submitting it to github. Do you want to continue?", "Report Issue","Yes","No")!="Yes")
+		return
+	if(GLOB.revdata.testmerge.len || GLOB.Debug2)
+		if(tgalert(src, "Experimental code is enabled on the server, Please check <code>Show-Server-Revision</code> for more information.", "Report Issue","Yes","No")!="Yes")
+			return
+
 	// We still use tgalert here because some people were concerned that if someone wanted to report that tgui wasn't working
 	// then the report issue button being tgui-based would be problematic.
-	if(tgalert(src, message, "Report Issue","Yes","No")!="Yes")
-		return
 
 	// Keep a static version of the template to avoid reading file
 	var/static/issue_template = file2text(".github/ISSUE_TEMPLATE/bug_report.md")
@@ -115,7 +115,7 @@
 	Key:[ckey]\n\
 	\
 	"
-	var/issue_body = "Reporting client info: [client_info]\n\n[local_template]"
+	var/issue_body = "```\nReporting client info:\n[client_info]\n\n[local_template]```"
 	var/list/body_structure = list(
 		"title" = issue_title,
 		"body" = issue_body

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -66,10 +66,10 @@
 	if(restricted_mode || is_banned_from(ckey, "Bug Report"))
 		to_chat(src, span_warning("You are not currently allowed to make a bug report through this system."))
 		return
-	if(alert(src, "This will start reporting an issue, gathering some information from the server and your client, before submitting it to github. Do you want to continue?", "Report Issue","Yes","No")!="Yes")
+	if(alert(src, "This will start reporting an issue, gathering some information from the server and your client, before submitting it to github.", "Report Issue","Continue","Abort")!="Continue")
 		return
 	if(GLOB.revdata.testmerge.len || GLOB.Debug2)
-		if(tgalert(src, "Experimental code is enabled on the server, Please check <code>Show-Server-Revision</code> for more information.", "Report Issue","Yes","No")!="Yes")
+		if(tgalert(src, "Experimental code is enabled on the server, Please check <code>Show-Server-Revision</code> for more information.", "Report Issue","Continue","Abort")!="Continue")
 			return
 
 	// We still use tgalert here because some people were concerned that if someone wanted to report that tgui wasn't working

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -66,14 +66,11 @@
 	if(restricted_mode || is_banned_from(ckey, "Bug Report"))
 		to_chat(src, span_warning("You are not currently allowed to make a bug report through this system."))
 		return
-	if(alert(src, "This will start reporting an issue, gathering some information from the server and your client, before submitting it to github.", "Report Issue","Continue","Abort")!="Continue")
+	if(tgui_alert(src, "This will start reporting an issue, gathering some information from the server and your client, before submitting it to github.", "Report Issue","Continue","Abort")!="Continue")
 		return
 	if(GLOB.revdata.testmerge.len || GLOB.Debug2)
 		if(tgalert(src, "Experimental code is enabled on the server, Please check <code>Show-Server-Revision</code> for more information.", "Report Issue","Continue","Abort")!="Continue")
 			return
-
-	// We still use tgalert here because some people were concerned that if someone wanted to report that tgui wasn't working
-	// then the report issue button being tgui-based would be problematic.
 
 	// Keep a static version of the template to avoid reading file
 	var/static/issue_template = file2text(".github/ISSUE_TEMPLATE/bug_report.md")


### PR DESCRIPTION
Swaps out tgalert for stock alert, splits the message in 2

Wraps report info in a codeblock.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![](https://file.house/hqf4.png)
![](https://file.house/6fTK.png)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Issue reporter flow no longer overflows
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
