### PR TITLE
Browser datums no longer force HTML 4.1

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -70,7 +70,8 @@
 	for (file in scripts)
 		head_content += "<script type='text/javascript' src='[SSassets.transport.get_asset_url(file)]'></script>"
 
-	return {"<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+	return {"
+<!DOCTYPE html>
 <html>
 	<head>
 		<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>


### PR DESCRIPTION
Shouldn't change anything user facing. I hope.