### PR TITLE
Removes ATMO-ECOM INIT, STAT now intercepts.

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -155,7 +155,7 @@
 		return
 
 	if(("status" in signal.data)) //Send stauts and early return, I'm cargoculting the timer here.
-		addtimer(CALLBACK(src, PROC_REF(broadcast_status)), 2)
+		broadcast_status()
 		return
 
 	if("power" in signal.data)

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -154,6 +154,10 @@
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return
 
+	if(("status" in signal.data)) //Send stauts and early return, I'm cargoculting the timer here.
+		addtimer(CALLBACK(src, PROC_REF(broadcast_status)), 2)
+		return
+
 	if("power" in signal.data)
 		on = text2num(signal.data["power"])
 
@@ -184,9 +188,9 @@
 		external_pressure_bound = clamp(text2num(signal.data["set_external_pressure"]),0,MAX_PUMP_PRESSURE)
 
 	addtimer(CALLBACK(src, PROC_REF(broadcast_status)), 2)
+	update_appearance()
 
-	if(!("status" in signal.data)) //do not update_appearance
-		update_appearance()
+
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume
 	name = "large dual-port air vent"

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -144,6 +144,10 @@ Passive gate is similar to the regular pump except:
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return
 
+	if("status" in signal.data)
+		broadcast_status()
+		return
+
 	var/old_on = on //for logging
 
 	if("power" in signal.data)
@@ -157,10 +161,6 @@ Passive gate is similar to the regular pump except:
 
 	if(on != old_on)
 		investigate_log("was turned [on ? "on" : "off"] by a remote signal", INVESTIGATE_ATMOS)
-
-	if("status" in signal.data)
-		broadcast_status()
-		return
 
 	broadcast_status()
 	update_appearance()

--- a/code/modules/atmospherics/machinery/components/binary_devices/pressure_valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pressure_valve.dm
@@ -174,6 +174,10 @@
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return
 
+	if("status" in signal.data)
+		broadcast_status()
+		return
+
 	var/old_on = on //for logging
 
 	if("power" in signal.data)
@@ -187,10 +191,6 @@
 
 	if(on != old_on)
 		investigate_log("was turned [on ? "on" : "off"] by a remote signal", INVESTIGATE_ATMOS)
-
-	if("status" in signal.data)
-		broadcast_status()
-		return
 
 	broadcast_status()
 	update_appearance()

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -153,6 +153,10 @@
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return
 
+	if("status" in signal.data)
+		broadcast_status()
+		return
+
 	var/old_on = on //for logging
 
 	if("power" in signal.data)
@@ -166,10 +170,6 @@
 
 	if(on != old_on)
 		investigate_log("was turned [on ? "on" : "off"] by a remote signal", INVESTIGATE_ATMOS)
-
-	if("status" in signal.data)
-		broadcast_status()
-		return
 
 	broadcast_status()
 	update_appearance()

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -165,6 +165,10 @@
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return
 
+	if("status" in signal.data)
+		broadcast_status()
+		return //do not update_appearance
+
 	var/old_on = on //for logging
 
 	if("power" in signal.data)
@@ -180,9 +184,7 @@
 	if(on != old_on)
 		investigate_log("was turned [on ? "on" : "off"] by a remote signal", INVESTIGATE_ATMOS)
 
-	if("status" in signal.data)
-		broadcast_status()
-		return //do not update_appearance
+
 
 	broadcast_status()
 	update_appearance()

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -219,11 +219,14 @@
 	..()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/receive_signal(datum/signal/signal)
-	if(!is_operational)
+	if(!is_operational || !signal.data["tag"] || (signal.data["tag"] != id_tag) || (signal.data["sigtype"]!="command"))
 		return
-	// log_admin("DEBUG \[[world.timeofday]\]: /obj/machinery/atmospherics/components/unary/vent_pump/receive_signal([signal.debug_print()])")
-	if(!signal.data["tag"] || (signal.data["tag"] != id_tag) || (signal.data["sigtype"]!="command"))
-		return
+
+
+	// Check if we're reporting status, Early return if we are.
+	if("status" in signal.data)
+		broadcast_status()
+		return // do not update_appearance if we don't actually do anything.
 
 	COOLDOWN_RESET(src, hibernating)
 
@@ -278,14 +281,6 @@
 
 	if("adjust_external_pressure" in signal.data)
 		external_pressure_bound = clamp(external_pressure_bound + text2num(signal.data["adjust_external_pressure"]),0,ONE_ATMOSPHERE*50)
-
-	if("init" in signal.data)
-		name = signal.data["init"]
-		return
-
-	if("status" in signal.data)
-		broadcast_status()
-		return // do not update_appearance
 
 		// log_admin("DEBUG \[[world.timeofday]\]: vent_pump/receive_signal: unknown command \"[signal.data["command"]]\"\n[signal.debug_print()]")
 	broadcast_status()

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -250,6 +250,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/receive_signal(datum/signal/signal)
 	if(!is_operational || !signal.data["tag"] || (signal.data["tag"] != id_tag) || (signal.data["sigtype"]!="command"))
 		return
+
+	if("status" in signal.data)
+		broadcast_status()
+		return //do not update_appearance
+
 	COOLDOWN_RESET(src, hibernating)
 
 	var/old_quicksucc = quicksucc
@@ -282,14 +287,6 @@
 	if("set_filters" in signal.data)
 		filter_types = list()
 		add_filters(signal.data["set_filters"])
-
-	if("init" in signal.data)
-		name = signal.data["init"]
-		return
-
-	if("status" in signal.data)
-		broadcast_status()
-		return //do not update_appearance
 
 	broadcast_status()
 	update_appearance()


### PR DESCRIPTION
Unhelpful, Unused, Confusing??
Status was never set while also setting a control field, so this has no functional changes.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The `status` command returns early to save icon update costs, this has been moved before control field processing to prevent edge cases with causing changes that SHOULD result in updates, but never actually calling said updates.

`init` was both unused, and unsafe.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It was quick to do and provides more safety wrapping and prep for user packets.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: 'status' field for ATMO-ECOM packets will now inhibit processing of other control fields.
del: 'init' control field has been removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
