### PR TITLE
Tweak traitor objs

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -84,10 +84,6 @@
 	integer = FALSE
 	min_val = 0
 
-/datum/config_entry/number/traitor_objectives_amount
-	default = 2
-	min_val = 0
-
 /datum/config_entry/number/brother_objectives_amount
 	default = 2
 	min_val = 0

--- a/code/modules/antagonists/malf_ai/datum_malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/datum_malf_ai.dm
@@ -60,12 +60,9 @@
 	if(prob(PROB_SPECIAL))
 		forge_special_objective()
 
-	var/objective_limit = CONFIG_GET(number/traitor_objectives_amount)
 	var/objective_count = length(objectives)
 
-	// for(in...to) loops iterate inclusively, so to reach objective_limit we need to loop to objective_limit - 1
-	// This does not give them 1 fewer objectives than intended.
-	for(var/i in objective_count to objective_limit - 1)
+	for(var/i in objective_count to 1)
 		var/datum/objective/assassinate/kill_objective = new
 		kill_objective.owner = owner
 		kill_objective.find_target()

--- a/modular_pariah/master_files/code/modules/antagonist/_common/antag_datum.dm
+++ b/modular_pariah/master_files/code/modules/antagonist/_common/antag_datum.dm
@@ -1,46 +1,38 @@
+#define EXTRA_OBJECTIVE_PROB 40
 /// Chance the traitor gets a kill objective. If this prob fails, they will get a steal objective instead.
-#define KILL_PROB 10
+#define KILL_PROB 20
 /// If a kill objective is rolled, chance that it is to destroy the AI.
 #define DESTROY_AI_PROB(denominator) (100 / denominator)
-/// If the destroy AI objective doesn't roll, chance that we'll get a maroon instead. If this prob fails, they will get a generic assassinate objective instead.
-#define MAROON_PROB 0
 
 /// Generates a complete set of traitor objectives up to the traitor objective limit, including non-generic objectives such as hijack.
 /datum/antagonist/traitor/proc/forge_traitor_objectives()
 	objectives.Cut()
 
-	var/objective_limit = CONFIG_GET(number/traitor_objectives_amount)
+	var/datum/objective/O = new /datum/objective/gimmick
+	O.owner = owner
+	objectives += O
 
-	for(var/i in 1 to objective_limit)
-		objectives += forge_single_generic_objective()
-
-
-/// Adds a generic kill or steal objective to this datum's objective list.
-/datum/antagonist/traitor/proc/forge_single_generic_objective()
-	RETURN_TYPE(/datum/objective)
-	if(prob(KILL_PROB))
-		var/list/active_ais = active_ais()
-		if(active_ais.len && prob(DESTROY_AI_PROB(GLOB.joined_player_list.len)))
-			var/datum/objective/destroy/destroy_objective = new
-			destroy_objective.owner = owner
-			destroy_objective.find_target()
-			return destroy_objective
-
-		var/datum/objective/assassinate/kill_objective = new
-		kill_objective.owner = owner
-		kill_objective.find_target()
-		return kill_objective
-
-	if(prob(90))
-		var/datum/objective/gimmick/gimmick_objective = new
-		gimmick_objective.owner = owner
-		return gimmick_objective
-	else
-		var/datum/objective/steal/steal_objective = new
-		steal_objective.owner = owner
-		steal_objective.find_target()
-		return steal_objective
+	if(prob(EXTRA_OBJECTIVE_PROB))
+		if(prob(KILL_PROB))
+			var/list/active_ais = active_ais()
+			if(active_ais.len && prob(DESTROY_AI_PROB(GLOB.joined_player_list.len)))
+				O = new /datum/objective/destroy
+				O.owner = owner
+				O.find_target()
+				objectives += O
+				return
+			O = new /datum/objective/assassinate
+			O.owner = owner
+			O.find_target()
+			objectives += O
+			return
+		else
+			O = new /datum/objective/steal
+			O.owner = owner
+			O.find_target()
+			objectives += O
+			return
 
 #undef KILL_PROB
 #undef DESTROY_AI_PROB
-#undef MAROON_PROB
+#undef EXTRA_OBJECTIVE_PROB


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Traitor gets 1 gimmick objective, and can roll 1 additional kill or steal objective randomly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
