### PR TITLE
Adds the 'ROBOTICS' flag for some mecha designs

### DIFF
--- a/code/game/machinery/data_disk.dm
+++ b/code/game/machinery/data_disk.dm
@@ -192,6 +192,7 @@
 		/datum/design/board/odysseus_peri,
 		/datum/design/board/gygax_main,
 		/datum/design/board/gygax_peri,
+		/datum/design/board/gygax_targ,
 		/datum/design/board/durand_main,
 		/datum/design/board/durand_peri,
 		/datum/design/board/durand_targ,

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -245,6 +245,7 @@
 	materials = list(/datum/material/iron=10000)
 	construction_time = 100
 	category = list(DCAT_MECHA_OBJ)
+	mapload_design_flags = DESIGN_FAB_ROBOTICS
 
 /datum/design/mech_laser_heavy
 	name = "Exosuit Weapon (CH-LC \"Solaris\" Laser Cannon)"
@@ -255,6 +256,7 @@
 	materials = list(/datum/material/iron=10000)
 	construction_time = 100
 	category = list(DCAT_MECHA_OBJ)
+	mapload_design_flags = DESIGN_FAB_ROBOTICS
 
 /datum/design/mech_disabler
 	name = "Exosuit Weapon (CH-DS \"Peacemaker\" Disabler)"
@@ -397,6 +399,7 @@
 	materials = list(/datum/material/iron=20000,/datum/material/silver=5000)
 	construction_time = 100
 	category = list(DCAT_MECHA_OBJ)
+	mapload_design_flags = DESIGN_FAB_ROBOTICS
 
 /datum/design/mech_proj_armor
 	name = "Exosuit Module (Reflective Armor Booster Module)"
@@ -407,6 +410,7 @@
 	materials = list(/datum/material/iron=20000,/datum/material/gold=5000)
 	construction_time = 100
 	category = list(DCAT_MECHA_OBJ)
+	mapload_design_flags = DESIGN_FAB_ROBOTICS
 
 /datum/design/mech_diamond_drill
 	name = "Exosuit Mining (Diamond Mining Drill)"


### PR DESCRIPTION
## About The Pull Request

Adds the robotics flag for some mecha designs that weren't able to be printed due to the Fabricator/RnD removal update, but were printable previously. Also fixes being unable to print the Gygax targ board.

## Why It's Good For The Game

There's probably no reason for these modules to be unprintable, as they were printable pre-Fabricator.

**100% untested, I'm just assuming this is why because the other designs /are/ printable and /don't/ have the flag.**

## Changelog


:cl:
balance: you can print mecha designs that were printable pre-update now. Namely the mech laser, heavy mech laser and mech armours. You can now print the Gygax targ board.
/:cl:
