### PR TITLE
You can't attack mobs without combat mode

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -181,6 +181,9 @@
 	if(signal_return & COMPONENT_SKIP_ATTACK)
 		return
 
+	if(!user.combat_mode)
+		return
+
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, M, user, params)
 
 	if(item_flags & NOBLUDGEON)

--- a/code/modules/unit_tests/novaflower_burn.dm
+++ b/code/modules/unit_tests/novaflower_burn.dm
@@ -21,6 +21,7 @@
 	// And give them the plant safe trait so we don't have to worry about attacks being cancelled
 	ADD_TRAIT(botanist, TRAIT_PLANT_SAFE, "unit_test")
 
+	botanist.set_combat_mode(TRUE)
 	// Now, let's get a smack with the novaflower and see what happens.
 	weapon.melee_attack_chain(botanist, victim)
 
@@ -31,7 +32,6 @@
 	TEST_ASSERT(victim.on_fire, "[weapon] didn't set the target on fire after an attack.")
 
 	// Lastly we should check that degredation to zero works.
-	botanist.set_combat_mode(TRUE)
 	weapon.force = 0
 	weapon.melee_attack_chain(botanist, victim)
 

--- a/code/modules/unit_tests/novaflower_burn.dm
+++ b/code/modules/unit_tests/novaflower_burn.dm
@@ -31,6 +31,7 @@
 	TEST_ASSERT(victim.on_fire, "[weapon] didn't set the target on fire after an attack.")
 
 	// Lastly we should check that degredation to zero works.
+	botanist.set_combat_mode(TRUE)
 	weapon.force = 0
 	weapon.melee_attack_chain(botanist, victim)
 


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can no longer attack mobs without being in Combat Mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
