### PR TITLE
Fixes facial hair gradient and GetVoice()

### DIFF
--- a/code/modules/client/preferences/species_features/basic.dm
+++ b/code/modules/client/preferences/species_features/basic.dm
@@ -67,6 +67,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "facial_hair_gradient"
 	relevant_species_trait = FACEHAIR
+	sub_preference = /datum/preference/color/facial_hair_gradient
 
 /datum/preference/choiced/facial_hair_gradient/init_possible_values()
 	return assoc_to_keys(GLOB.facial_hair_gradients_list)

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -10,7 +10,7 @@
 	return ..()
 
 /mob/living/carbon/human/GetVoice()
-	if(wear_mask && !wear_mask.up)
+	if(istype(wear_mask) && !wear_mask.up)
 		if(HAS_TRAIT(wear_mask, TRAIT_REPLACES_VOICE))
 			if(wear_id)
 				var/obj/item/card/id/idcard = wear_id.GetID()


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Facial Hair Gradients can now be color picked again
fix: Wearing a non-mask object in your mask slot won't break your radio.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
