### PR TITLE
Mass Hallucinations now say which one occurred

### DIFF
--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -5,42 +5,88 @@
 	max_occurrences = 2
 	min_players = 1
 
+
 /datum/round_event/mass_hallucination
 	fakeable = FALSE
+
+	/// 'normal' sound keys, index by them to get the friendly name.
+	var/static/list/sound_pool = list(
+		"airlock" = "Door",
+		"airlock_pry" = "Door Prying",
+		"console" = "Computer",
+		"explosion" = "Explosion",
+		"far_explosion" = "Distant Explosion",
+		"mech" = "Mech Walking",
+		"glass" = "Glass Breaking",
+		"alarm" = "Alarm",
+		"beepsky" = "Securiton",
+		"wall_decon" = "Wall Deconstruction",
+		"door_hack" = "Door Hacking",
+		"tesla" = "Tesla Ball"
+		)
+	/// 'Weird' sound keys, index by them to get the friendly name.
+	var/static/list/rare_sound_pool = list(
+		"phone" = "Phone",
+		"hallelujah" = "Holy",
+		"highlander" = "Scottish Pride",
+		"hyperspace" = "Shuttle Undocking",
+		"game_over" = "Game Over",
+		"creepy" = "Disembodied Voice",
+		"tesla" = "Tesla Ball" //No, I don't know why this is duplicated.
+		)
+	/// Fake 'Station Message' keys, index by them to get the friendly name.
+	var/static/list/stationmessage_pool = list(
+		"ratvar" = "Ratvar Summoning",
+		"shuttle_dock" = "Emergency Shuttle Dock Announcement",
+		"blob_alert" = "Level 5 Biohazard Announcement",
+		"malf_ai" = "Rampant AI Alert",
+		"meteors" = "Meteor Announcement",
+		"supermatter" = "Supermatter Delamination Sensation"
+	)
+	/// Pool for generic hallucinations. Types can't key lists, so we need to invert the accesses.
+	var/static/list/generic_pool = list(
+		"Fake bolted airlocks" = /datum/hallucination/bolts,
+		"Imagined messages" = /datum/hallucination/chat,
+		"Fake minor message" = /datum/hallucination/message,
+		"Fake gas flood" = /datum/hallucination/fake_flood,
+		"Fake combat noises" = /datum/hallucination/battle,
+		"Imaginary spontaneous combustion" = /datum/hallucination/fire,
+		"Self Delusion" = /datum/hallucination/self_delusion,
+		"Fake Death" = /datum/hallucination/death,
+		"Delusions" = /datum/hallucination/delusion,
+		"Imaginary Bubblegum" = /datum/hallucination/oh_yeah
+	)
+
 
 /datum/round_event/mass_hallucination/start()
 	switch(rand(1,4))
 		if(1) //same sound for everyone
-			var/sound = pick("airlock","airlock_pry","console","explosion","far_explosion","mech","glass","alarm","beepsky","mech","wall_decon","door_hack","tesla")
+			var/picked_sound = pick(sound_pool)
 			for(var/mob/living/carbon/C in GLOB.alive_mob_list)
 				if(C.z in SSmapping.levels_by_trait(ZTRAIT_CENTCOM))//not for admin/ooc stuff
 					continue
-				new /datum/hallucination/sounds(C, TRUE, sound)
+				new /datum/hallucination/sounds(C, TRUE, picked_sound)
+			deadchat_broadcast("[span_bold("Mass Hallucination")]: [sound_pool[picked_sound]] sounds.")
 		if(2)
-			var/weirdsound = pick("phone","hallelujah","highlander","hyperspace","game_over","creepy","tesla")
+			var/weirdsound = pick(rare_sound_pool)
 			for(var/mob/living/carbon/C in GLOB.alive_mob_list)
 				if(C.z in SSmapping.levels_by_trait(ZTRAIT_CENTCOM))//not for admin/ooc stuff
 					continue
 				new /datum/hallucination/weird_sounds(C, TRUE, weirdsound)
+			deadchat_broadcast("[span_bold("Mass Hallucination")]: Weird [rare_sound_pool[weirdsound]] sounds.")
 		if(3)
-			var/stationmessage = pick("ratvar","shuttle_dock","blob_alert","malf_ai","meteors","supermatter")
+			var/stationmessage = pick(stationmessage_pool)
 			for(var/mob/living/carbon/C in GLOB.alive_mob_list)
 				if(C.z in SSmapping.levels_by_trait(ZTRAIT_CENTCOM))//not for admin/ooc stuff
 					continue
 				new /datum/hallucination/stationmessage(C, TRUE, stationmessage)
+			deadchat_broadcast("[span_bold("Mass Hallucination")]: Fake [stationmessage_pool[stationmessage]].")
 		if(4 to 6)
-			var/picked_hallucination = pick( /datum/hallucination/bolts,
-												/datum/hallucination/chat,
-												/datum/hallucination/message,
-												/datum/hallucination/bolts,
-												/datum/hallucination/fake_flood,
-												/datum/hallucination/battle,
-												/datum/hallucination/fire,
-												/datum/hallucination/self_delusion,
-												/datum/hallucination/death,
-												/datum/hallucination/delusion,
-												/datum/hallucination/oh_yeah)
+			var/picked_hallucination = pick(generic_pool)
+			//You can't index lists in the type part of new calls
+			var/type_holder = generic_pool[picked_hallucination]
 			for(var/mob/living/carbon/C in GLOB.alive_mob_list)
 				if(C.z in SSmapping.levels_by_trait(ZTRAIT_CENTCOM))//not for admin/ooc stuff
 					continue
-				new picked_hallucination(C, TRUE)
+				new type_holder(C, TRUE)
+			deadchat_broadcast("[span_bold("Mass Hallucination")]: [picked_hallucination].")

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -10,7 +10,7 @@
 	fakeable = FALSE
 
 	/// 'normal' sound keys, index by them to get the friendly name.
-	var/static/list/sound_pool = list(
+	var/list/sound_pool = list(
 		"airlock" = "Door",
 		"airlock_pry" = "Door Prying",
 		"console" = "Computer",
@@ -25,7 +25,7 @@
 		"tesla" = "Tesla Ball"
 		)
 	/// 'Weird' sound keys, index by them to get the friendly name.
-	var/static/list/rare_sound_pool = list(
+	var/list/rare_sound_pool = list(
 		"phone" = "Phone",
 		"hallelujah" = "Holy",
 		"highlander" = "Scottish Pride",
@@ -35,7 +35,7 @@
 		"tesla" = "Tesla Ball" //No, I don't know why this is duplicated.
 		)
 	/// Fake 'Station Message' keys, index by them to get the friendly name.
-	var/static/list/stationmessage_pool = list(
+	var/list/stationmessage_pool = list(
 		"ratvar" = "Ratvar Summoning",
 		"shuttle_dock" = "Emergency Shuttle Dock Announcement",
 		"blob_alert" = "Level 5 Biohazard Announcement",
@@ -44,7 +44,7 @@
 		"supermatter" = "Supermatter Delamination Sensation"
 	)
 	/// Pool for generic hallucinations. Types can't key lists, so we need to invert the accesses.
-	var/static/list/generic_pool = list(
+	var/list/generic_pool = list(
 		"Fake bolted airlocks" = /datum/hallucination/bolts,
 		"Imagined messages" = /datum/hallucination/chat,
 		"Fake minor message" = /datum/hallucination/message,


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The picked shared hallucination will be sent to observers.
![](https://file.house/disr.png)


## Why It's Good For The Game

This might matter for admins, but it's more to let observers in on the joke.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Ghosts will now be told what the crew has collectively hallucinated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
