### PR TITLE
Fixes get hand offset proc

### DIFF
--- a/code/modules/interaction_particle/interaction_particle.dm
+++ b/code/modules/interaction_particle/interaction_particle.dm
@@ -70,7 +70,7 @@
 	return list(0, 0)
 
 /mob/living/carbon/get_hand_pixels()
-	var/obj/item/bodypart/hand = has_active_hand()
+	var/obj/item/bodypart/hand = has_active_hand() ? get_active_hand() : null
 	if(!hand)
 		return null
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
`has_active_hand()` is not meant to return `/obj/item/bodypart` (though it does)

## Why It's Good For The Game
Prevents possible bugs in the future (for example when someone wants a mob to always "have" an active hand.  Even if that arm was dismembered

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
