### PR TITLE
Fixes uncraftable chems

### DIFF
--- a/code/modules/reagents/chemistry/goon_reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/goon_reagents/medicine_reagents.dm
@@ -3,6 +3,7 @@
 	description = "Purges alcoholic substance from the patient's body and eliminates its side effects."
 	color = "#00B4C8"
 	taste_description = "raw egg"
+	show_in_codex = TRUE
 
 
 /datum/reagent/medicine/antihol/affect_blood(mob/living/carbon/C, removed)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -185,3 +185,14 @@
 	required_reagents = list(/datum/reagent/ash = 1, /datum/reagent/consumable/salt = 1)
 	mix_message = "The mixture yields a fine black powder."
 	mix_sound = 'sound/effects/fuse.ogg'
+
+/datum/chemical_reaction/antihol
+	results = list(/datum/reagent/medicine/antihol = 2)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/medicine/activated_charcoal = 1)
+	mix_message = "A minty and refreshing smell drifts from the effervescent mixture."
+
+/datum/chemical_reaction/diphenhydramine
+	results = list(/datum/reagent/medicine/diphenhydramine = 4)
+	// Chlorine is a good enough substitute for bromine right?
+	required_reagents = list(/datum/reagent/fuel/oil = 1, /datum/reagent/carbon = 1, /datum/reagent/chlorine = 1, /datum/reagent/diethylamine = 1, /datum/reagent/consumable/ethanol = 1)
+	mix_message = "The mixture fizzes gently."

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -20,3 +20,19 @@
 /datum/chemical_reaction/toxin
 	results = list(/datum/reagent/toxin = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/mercury = 1, /datum/reagent/medicine/dylovene = 1)
+
+/datum/chemical_reaction/lipolicide
+	results = list(/datum/reagent/toxin/lipolicide = 2)
+	required_reagents = list(/datum/reagent/medicine/ephedrine = 1, /datum/reagent/diethylamine = 1, /datum/reagent/mercury = 1)
+	mix_message = "A vague smell similar to tofu rises from the mixture."
+
+/datum/chemical_reaction/anacea
+	results = list(/datum/reagent/toxin/anacea = 3)
+	required_reagents = list(/datum/reagent/medicine/haloperidol = 1, /datum/reagent/impedrezene = 1, /datum/reagent/uranium/radium = 1)
+	mix_message = "The mixture turns into a strange green ooze."
+	required_temp = 100
+	optimal_temp = 450
+	overheat_temp = 900
+	temp_exponent_factor = 1.6
+	thermic_constant = 250
+	rate_up_lim = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fixes https://github.com/DaedalusDock/daedalusdock/issues/572

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: diphenhydramine, antihol, lipolicide, and anacea are craftable again.
fix: Antihol shows up in the codex.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
