### PR TITLE
fix credits bug

### DIFF
--- a/code/controllers/subsystem/credits.dm
+++ b/code/controllers/subsystem/credits.dm
@@ -200,6 +200,9 @@ SUBSYSTEM_DEF(credits)
 	var/list/dead_names = list()
 	var/cast_count
 	for(var/datum/mind/M as anything in SSticker.minds)
+		if(isobserver(M.current))
+			continue
+
 		if(M.key && M.name)
 			if(!M.current || (M.current.stat == DEAD)) //Their body was destroyed or they are simply dead
 				dead_names += M.name
@@ -223,21 +226,15 @@ SUBSYSTEM_DEF(credits)
 			cast_string += "[name]<br>"
 	cast_string += "</div><br>"
 
-/mob/living/proc/get_credits_entry()
+/mob/proc/get_credits_entry()
 	var/datum/preferences/prefs = GLOB.preferences_datums[ckey(mind.key)]
-	/// initial(name) is used over this now.
-	/*var/gender_text
-	switch(gender)
-		if("male")
-			gender_text = "Himself"
-		if("female")
-			gender_text = "Herself"
-		if("neuter")
-			gender_text = "Themself"
-		if("plural")
-			gender_text = "Themselves"
-		else
-			gender_text = "Itself"*/
+	if(prefs.read_preference(/datum/preference/toggle/credits_uses_ckey))
+		return "<tr><td class='actorname'>[uppertext(ckey(mind.key))]</td><td class='actorsegue'> as </td><td class='actorrole'>[name]</td></tr>"
+	else
+		return "<tr><td class='actorname'>[uppertext(name)]</td><td class='actorsegue'> as </td><td class='actorrole'>[initial(name)]</td></tr>"
+
+/mob/living/get_credits_entry()
+	var/datum/preferences/prefs = GLOB.preferences_datums[ckey(mind.key)]
 
 	if(prefs.read_preference(/datum/preference/toggle/credits_uses_ckey))
 		return "<tr><td class='actorname'>[uppertext(ckey(mind.key))]</td><td class='actorsegue'> as </td><td class='actorrole'>[name]</td></tr>"


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Having non-living mobs (such as the AI camera) will no longer break the EOR credits roll.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
