### PR TITLE
Allows SSPackets to actually hibernate

### DIFF
--- a/code/controllers/subsystem/packetnets.dm
+++ b/code/controllers/subsystem/packetnets.dm
@@ -132,7 +132,7 @@ SUBSYSTEM_DEF(packets)
 			// Only cut it from the current run when it's done
 			current_networks.len--
 			// We may have generated more packets in the course of rs calls, If so, don't dequeue it.
-			if(!net.next_packet_queue.len)
+			if(!length(net.next_packet_queue))
 				queued_networks -= net
 
 		cost_networks = MC_AVERAGE(cost_networks, TICK_DELTA_TO_MS(cached_cost))

--- a/code/controllers/subsystem/packetnets.dm
+++ b/code/controllers/subsystem/packetnets.dm
@@ -109,6 +109,7 @@ SUBSYSTEM_DEF(packets)
 			///No packets no problem
 			if(!length(net.current_packet_queue))
 				current_networks.len--
+				queued_networks -= net
 				continue
 
 			for(var/datum/signal/signal as anything in net.current_packet_queue)
@@ -130,6 +131,9 @@ SUBSYSTEM_DEF(packets)
 
 			// Only cut it from the current run when it's done
 			current_networks.len--
+			// We may have generated more packets in the course of rs calls, If so, don't dequeue it.
+			if(!net.next_packet_queue.len)
+				queued_networks -= net
 
 		cost_networks = MC_AVERAGE(cost_networks, TICK_DELTA_TO_MS(cached_cost))
 		resumed = FALSE

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -23,7 +23,6 @@
 
 /datum/powernet/New()
 	SSmachines.powernets += src
-	SSpackets.queued_networks += src
 
 /datum/powernet/Destroy()
 	//Go away references, you suck!
@@ -119,5 +118,7 @@
 
 /// Pass a signal through a powernet to all connected data equipment.
 // SSpackets does this for us!
+// We just need to inform them we have something to deal with.
 /datum/powernet/proc/queue_signal(datum/signal/signal)
 	next_packet_queue += signal
+	SSpackets.queued_networks |= src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

SSpackets was incapable of hibernating since `queued_networks` was populated wrongly.

## Why It's Good For The Game
SS hibernation good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

NUFC

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
