### PR TITLE
fix mutagen recipe

### DIFF
--- a/code/modules/reagents/chemistry/recipes/other.dm
+++ b/code/modules/reagents/chemistry/recipes/other.dm
@@ -34,7 +34,7 @@
 
 
 /datum/chemical_reaction/unstable_mutagen
-	results = list(/datum/reagent/toxin/mutagen)
+	results = list(/datum/reagent/toxin/mutagen = 1)
 	required_reagents = list(/datum/reagent/chlorine = 1, /datum/reagent/toxin/plasma = 1, /datum/reagent/uranium/radium = 1)
 
 /datum/chemical_reaction/plasma_solidification


### PR DESCRIPTION
:cl:
fix: Mutagen's recipe now works. For real this time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
