### PR TITLE
makes verb callbacks not execute if the original client disconnected

### DIFF
--- a/code/controllers/subsystem/verb_manager.dm
+++ b/code/controllers/subsystem/verb_manager.dm
@@ -89,12 +89,14 @@ SUBSYSTEM_DEF(verb_manager)
 		incoming_callback.user = WEAKREF(incoming_callback.object)
 		var/datum/callback/new_us = CALLBACK(arglist(list(GLOBAL_PROC, GLOBAL_PROC_REF(_queue_verb)) + args.Copy()))
 		return world.push_usr(incoming_callback.object, new_us)
-#endif
 
-	//debatable whether this is needed, this is just to try and ensure that you dont use this to queue stuff that isnt from player input.
-	if(QDELETED(usr))
+#else
+
+	if(QDELETED(usr) || isnull(usr.client))
 		stack_trace("_queue_verb() returned false because it wasnt called from player input!")
 		return FALSE
+
+#endif
 
 	if(!istype(subsystem_to_use))
 		stack_trace("_queue_verb() returned false because it was given an invalid subsystem to queue for!")

--- a/code/datums/verb_callbacks.dm
+++ b/code/datums/verb_callbacks.dm
@@ -1,4 +1,5 @@
 ///like normal callbacks but they also record their creation time for measurement purposes
+///they also require the same usr/user that made the callback to both still exist and to still have a client in order to execute
 /datum/callback/verb_callback
 	///the tick this callback datum was created in. used for testing latency
 	var/creation_time = 0
@@ -6,3 +7,23 @@
 /datum/callback/verb_callback/New(thingtocall, proctocall, ...)
 	creation_time = DS2TICKS(world.time)
 	. = ..()
+
+#ifndef UNIT_TESTS
+/datum/callback/verb_callback/Invoke(...)
+	var/mob/our_user = user?.resolve()
+	if(QDELETED(our_user) || isnull(our_user.client))
+		return
+	var/mob/temp = usr
+	. = ..()
+	usr = temp
+
+/datum/callback/verb_callback/InvokeAsync(...)
+	var/mob/our_user = user?.resolve()
+	if(QDELETED(our_user) || isnull(our_user.client))
+		return
+	var/mob/temp = usr
+	. = ..()
+	usr = temp
+#endif
+
+


### PR DESCRIPTION
- https://github.com/tgstation/tgstation/pull/79964

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: KylerAce
code: verb callbacks will no longer execute if the original client disconnected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
