### PR TITLE
Fix interaction between SS_KEEP_TIMING and SS_HIBERNATE

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -550,11 +550,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 					break
 			if(!enter_queue)
 				SS.hibernating = TRUE
+				SS.update_nextfire()
 				continue
-
-			if(SS.hibernating)
-				hibernating = FALSE
-				SS.update_nextfire(reset_time = TRUE)
 
 		SS.enqueue()
 	. = 1

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -552,6 +552,10 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 				SS.hibernating = TRUE
 				continue
 
+			if(SS.hibernating)
+				hibernating = FALSE
+				SS.update_nextfire(reset_time = TRUE)
+
 		SS.enqueue()
 	. = 1
 

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -186,8 +186,6 @@
 /// (we loop thru a linked list until we get to the end or find the right point)
 /// (this lets us sort our run order correctly without having to re-sort the entire already sorted list)
 /datum/controller/subsystem/proc/enqueue()
-	hibernating = FALSE
-
 	var/SS_priority = priority
 	var/SS_flags = flags
 	var/datum/controller/subsystem/queue_node

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -186,6 +186,8 @@
 /// (we loop thru a linked list until we get to the end or find the right point)
 /// (this lets us sort our run order correctly without having to re-sort the entire already sorted list)
 /datum/controller/subsystem/proc/enqueue()
+	hibernating = FALSE
+
 	var/SS_priority = priority
 	var/SS_flags = flags
 	var/datum/controller/subsystem/queue_node


### PR DESCRIPTION
> i don't know if it even triggers for your usecases, but for keep_timing subsystems, they will see the hibernated ticks as "missed" ticks and run faster when they have work to "make up" for those missed ticks

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: MrStonedOne
fix: Fixed a bug with subsystems that caused some subsystems to fire faster than intended after having no work for some time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
