### PR TITLE
Changes initial spawn wave logic

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -331,12 +331,11 @@ SUBSYSTEM_DEF(ticker)
 		qdel(bomb)
 
 /datum/controller/subsystem/ticker/proc/create_characters()
-	var/list/spawn_spots = SSJob.latejoin_trackers.Copy()
+	var/list/spawn_spots = SSjob.latejoin_trackers.Copy()
 	var/list/spawn_spots_reload = spawn_spots.Copy() //In case we run out, we need something to reload from.
 	for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
-		if(!player.mind && (player.ready -= PLAYER_READY_TO_OBSERVE))
-			//Player is either not ready, or failed job selection for some reason.
-			player.new_player_panel()
+		if(!player.mind)
+			//New player has logged out.
 			continue
 
 		switch(player.ready)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -436,7 +436,7 @@ GLOBAL_LIST_INIT(job_display_order, list(
 	return "Due to extreme staffing shortages, newly promoted Acting Captain [captain.real_name] on deck!"
 
 
-/// Returns an atom where the mob should spawn in.
+/// Returns either an atom the mob should spawn in, or null, if we have no special overrides.
 /datum/job/proc/get_roundstart_spawn_point()
 	if(random_spawns_possible)
 		if(HAS_TRAIT(SSstation, STATION_TRAIT_HANGOVER))
@@ -451,7 +451,7 @@ GLOBAL_LIST_INIT(job_display_order, list(
 	if(length(GLOB.jobspawn_overrides[title]))
 		return pick(GLOB.jobspawn_overrides[title])
 
-	return get_latejoin_spawn_point()
+	return null //We don't care where we go. Let Ticker decide for us.
 
 
 /// Handles finding and picking a valid roundstart effect landmark spawn point, in case no uncommon different spawning events occur.


### PR DESCRIPTION
Players will not be seated in the same seat twice before all are filled.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Arrivals shuttles should feel less overfilled, I still want to go back and remap it but there's too many locks on Theseus right now.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Hermes Transport has instituted new seat filling algorithms to decrease lap-seating in long-range transport shuttles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
