### PR TITLE
Reactions correctly respect the `REACTION_HEAT_ARBITARY` flag

### DIFF
--- a/code/modules/reagents/chemistry/equilibrium.dm
+++ b/code/modules/reagents/chemistry/equilibrium.dm
@@ -302,12 +302,11 @@
 		message_admins("<span class='warning'>Reaction vars: PreReacted:[reacted_vol] of [step_target_vol] of total [target_vol]. delta_t [delta_t], multiplier [multiplier], delta_chem_factor [delta_chem_factor] Pfactor [product_ratio]. DeltaTime: [delta_time]</span>")
 	#endif
 
-	//Apply thermal output of reaction to beaker
-	if(reaction.reaction_flags & REACTION_HEAT_ARBITARY)
-		holder.chem_temp += clamp((reaction.thermic_constant* total_step_added*thermic_mod), 0, CHEMICAL_MAXIMUM_TEMPERATURE) //old method - for every bit added, the whole temperature is adjusted
-	else //Standard mechanics
-		var/heat_energy = reaction.thermic_constant * total_step_added * thermic_mod * SPECIFIC_HEAT_DEFAULT
-		holder.adjust_thermal_energy(heat_energy, 0, CHEMICAL_MAXIMUM_TEMPERATURE, handle_reactions = FALSE) //heat is relative to the beaker conditions
+	var/heat_energy = reaction.thermic_constant * total_step_added * thermic_mod
+	if(reaction.reaction_flags & REACTION_HEAT_ARBITARY) //old method - for every bit added, the whole temperature is adjusted
+		holder.set_temperature(clamp(holder.chem_temp + heat_energy, 0, CHEMICAL_MAXIMUM_TEMPERATURE))
+	else //Standard mechanics - heat is relative to the beaker conditions
+		holder.adjust_thermal_energy(heat_energy * SPECIFIC_HEAT_DEFAULT, 0, CHEMICAL_MAXIMUM_TEMPERATURE)
 
 	//Give a chance of sounds
 	if(prob(5))

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -40,7 +40,7 @@
 	/// How sharp the temperature exponential curve is (to the power of value)
 	var/temp_exponent_factor = 2
 
-	/// How much the temperature will change (with no intervention) (i.e. for 30u made the temperature will increase by 100, same with 300u. The final temp will always be start + this value, with the exception con beakers with different specific heats)
+	/// How much the temperature changes per unit of chem used. without REACTION_HEAT_ARBITARY flag the rate of change depends on the holder heat capacity else results are more accurate
 	var/thermic_constant = 50
 	/// Optimal/max rate possible if all conditions are perfect
 	var/rate_up_lim = 30


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
 - https://github.com/tgstation/tgstation/pull/80178
## About The Pull Request

This flag basically adjusts the temperature of the whole holder without taking into consideration its heat capacity. If the reactions thermic_constant was negative this flag would not function correctly as it would clamp the rate of change between 0 and CHEMICAL_MAX_TEMPERATURE and then apply it to the final temperature.
Now it clamps the final result(current temperature + rate of change) therefore reactions that uses this flag to cool down temps now works correctly.

https://github.com/tgstation/tgstation/issues/74667
The above point explains how the fix works. basically thermic_constant determines how much the holder temps cool down per unit of chem consumed. Cryostylane + oxygen reaction had this value at -50 which is way to low (cause it means per unit of oxygen consumed it would cool down the holder by 50 kelvin). It has been adjusted to -5 instead more reasonable.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SyncIt21
fix: Cryostylane and oxygen reaction now cools down temps. Other reactions with the REACTION_HEAT_ARBITARY flag also cools down temps correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
