### PR TITLE
Culls slime reagent support

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -20,7 +20,6 @@
 	handle_nutrition(delta_time, times_fired)
 	if(QDELETED(src)) // Stop if the slime split during handle_nutrition()
 		return
-	reagents.remove_all(0.5 * REAGENTS_METABOLISM * reagents.reagent_list.len * delta_time) //Slimes are such snowflakes
 	handle_targets(delta_time, times_fired)
 	if(ckey)
 		return

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -100,7 +100,6 @@
 	else
 		var/datum/action/innate/slime/evolve/E = new
 		E.Grant(src)
-	create_reagents(100)
 	set_colour(new_colour)
 	. = ..()
 	set_nutrition(700)
@@ -158,22 +157,6 @@
 		icon_state = icon_dead
 	..()
 
-/**
- * Snowflake handling of reagent movespeed modifiers
- *
- * Should be moved to the reagents at some point in the future. As it is I'm in a hurry.
- */
-/mob/living/simple_animal/slime/proc/on_reagent_change(datum/reagents/holder, ...)
-	SIGNAL_HANDLER
-	remove_movespeed_modifier(/datum/movespeed_modifier/slime_reagentmod)
-	var/amount = 0
-	if(reagents.has_reagent(/datum/reagent/medicine/morphine)) // morphine slows slimes down
-		amount = 2
-	if(reagents.has_reagent(/datum/reagent/consumable/frostoil)) // Frostoil also makes them move VEEERRYYYYY slow
-		amount = 5
-	if(amount)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/slime_reagentmod, multiplicative_slowdown = amount)
-	return NONE
 
 /mob/living/simple_animal/slime/updatehealth()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -116,16 +116,6 @@
 	clear_friends()
 	return ..()
 
-/mob/living/simple_animal/slime/create_reagents(max_vol, flags)
-	. = ..()
-	RegisterSignal(reagents, list(COMSIG_REAGENTS_NEW_REAGENT, COMSIG_REAGENTS_DEL_REAGENT), PROC_REF(on_reagent_change))
-	RegisterSignal(reagents, COMSIG_PARENT_QDELETING, PROC_REF(on_reagents_del))
-
-/// Handles removing signal hooks incase someone is crazy enough to reset the reagents datum.
-/mob/living/simple_animal/slime/proc/on_reagents_del(datum/reagents/reagents)
-	SIGNAL_HANDLER
-	UnregisterSignal(reagents, list(COMSIG_REAGENTS_NEW_REAGENT, COMSIG_REAGENTS_DEL_REAGENT, COMSIG_PARENT_QDELETING))
-	return NONE
 
 /mob/living/simple_animal/slime/proc/set_colour(new_colour)
 	colour = new_colour

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -256,20 +256,12 @@
 	switch(current_cycle)
 		if(1 to 15)
 			heating = 5
-			if(isslime(C))
-				heating = rand(5, 20)
 		if(15 to 25)
 			heating = 10
-			if(isslime(C))
-				heating = rand(10, 20)
 		if(25 to 35)
 			heating = 15
-			if(isslime(C))
-				heating = rand(15, 20)
 		if(35 to INFINITY)
 			heating = 20
-			if(isslime(C))
-				heating = rand(20, 25)
 	C.adjust_bodytemperature(heating * TEMPERATURE_DAMAGE_COEFFICIENT * removed)
 	return ..()
 


### PR DESCRIPTION
Conceptual port of https://github.com/tgstation/tgstation/pull/80068
:cl: Profakos
del: Removes the slime's reagent holder. This will make them not slow down from somehow imbibing morphine or frostoil.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
