### PR TITLE
hotfix control for wielding

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -57,7 +57,7 @@
 	keybind_signal = COMSIG_KB_HUMAN_SUITEQUIP_DOWN
 
 /datum/keybinding/human/wield
-	hotkey_keys = list("X")
+	hotkey_keys = list("V")
 	name = "wield_item"
 	full_name = "Wield/Unwield item"
 	description = "Wield your held item with both hands."


### PR DESCRIPTION
:cl:
fix: Default wield hotkey no longer conflicts with other default hotkeys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
