### PR TITLE
Disposal pipes hurt mobs again

### DIFF
--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -83,6 +83,10 @@
 	if(H2 && !H2.active)
 		H.merge(H2)
 
+	for(var/mob/living/L in H)
+		var/armor = L.run_armor_check(attack_flag = BLUNT, silent = TRUE)
+		L.apply_damage(3, BRUTE, blocked = armor, spread_damage = TRUE)
+
 	H.forceMove(P)
 	return P
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pipes can once more hurt unprotected mobs that get flushed into a disposal network. Respects if the mob is hiding in something, and also takes blunt armor into account.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents people from escaping insane situations with disposal chutes, allows disposals to be used as a weapon, gives a reason to not throw yourself into a highly pressurized pneumatic machine that flings objects through dangerous pipes at high speeds.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Getting flushed into the disposal network damages mobs once more
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
