### PR TITLE
Health fixes & Experimental Balance

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -7,6 +7,13 @@
 #define CHANNEL_AMBIENCE 1019
 #define CHANNEL_BUZZ 1018
 #define CHANNEL_TRAITOR 1017
+#define CHANNEL_BREATHING 1016
+
+//THIS SHOULD ALWAYS BE THE LOWEST ONE!
+//KEEP IT UPDATED
+#define CHANNEL_HIGHEST_AVAILABLE 1015
+
+#define MAX_INSTRUMENT_CHANNELS (128 * 6)
 
 ///Default range of a sound.
 #define SOUND_RANGE 17
@@ -19,13 +26,6 @@
 #define SOUND_DEFAULT_FALLOFF_DISTANCE 1 //For a normal sound this would be 1 tile of no falloff
 ///The default exponent of sound falloff
 #define SOUND_FALLOFF_EXPONENT 6
-
-//THIS SHOULD ALWAYS BE THE LOWEST ONE!
-//KEEP IT UPDATED
-
-#define CHANNEL_HIGHEST_AVAILABLE 1015
-
-#define MAX_INSTRUMENT_CHANNELS (128 * 6)
 
 //#define SOUND_MINIMUM_PRESSURE 10
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -388,7 +388,7 @@
 		owner.dropItemToGround(owner.get_active_held_item())
 
 	if(damage >= 0.6*maxHealth)
-		owner.set_slurring_if_lower(2 SECONDS)
+		owner.set_slurring_if_lower(10 SECONDS)
 
 	if(damage >= (maxHealth * high_threshold))
 		if(owner.body_position == STANDING_UP)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -139,8 +139,8 @@
 		AIR_UPDATE_VALUES(breath)
 		loc.assume_air(breath)
 
-	var/static/sound/breathing = sound('sound/voice/breathing.ogg', volume = 50)
-	if(!forced && . && COOLDOWN_FINISHED(src, breath_sound_cd) && environment?.returnPressure() < SOUND_MINIMUM_PRESSURE)
+	var/static/sound/breathing = sound('sound/voice/breathing.ogg', volume = 50, channel = CHANNEL_BREATHING)
+	if(shock_stage >= 10 || (!forced && . && COOLDOWN_FINISHED(src, breath_sound_cd) && environment?.returnPressure() < SOUND_MINIMUM_PRESSURE))
 		src << breathing
 		COOLDOWN_START(src, breath_sound_cd, 3.5 SECONDS)
 

--- a/code/modules/mob/living/carbon/pain.dm
+++ b/code/modules/mob/living/carbon/pain.dm
@@ -45,7 +45,7 @@
 	if(!def_zone) // Distribute to all bodyparts evenly if no bodypart
 		var/list/not_full = bodyparts.Copy()
 		var/list/parts = not_full.Copy()
-		var/amount_remaining = round(amount)
+		var/amount_remaining = round(amount/2)
 		while(amount_remaining > 0 && length(not_full))
 			if(!length(parts))
 				parts += not_full

--- a/code/modules/mob/living/carbon/pain.dm
+++ b/code/modules/mob/living/carbon/pain.dm
@@ -170,23 +170,26 @@
 		return
 
 	if(shock_stage == SHOCK_TIER_1)
-		pain_message(PAIN_STRING, 10 - CHEM_EFFECT_MAGNITUDE(src, CE_PAINKILLER)/3)
+		pain_message(PAIN_STRING, shock_stage - CHEM_EFFECT_MAGNITUDE(src, CE_PAINKILLER)/3)
 
-	if(shock_stage >= SHOCK_TIER_2)
+	if(shock_stage >= SHOCK_TIER_2 && prob(shock_stage - 10))
 		if(shock_stage == SHOCK_TIER_2 && organs_by_slot[ORGAN_SLOT_EYES])
 			visible_message("<b>[src]</b> is having trouble keeping [p_their()] eyes open.")
-		if(prob(30))
-			blur_eyes(3)
-			set_timed_status_effect(10 SECONDS, /datum/status_effect/speech/stutter, only_if_higher = TRUE)
+		blur_eyes(5)
+		set_timed_status_effect(10 SECONDS, /datum/status_effect/speech/stutter, only_if_higher = TRUE)
 
 	if(shock_stage == SHOCK_TIER_3)
 		pain_message(PAIN_STRING, shock_stage - CHEM_EFFECT_MAGNITUDE(src, CE_PAINKILLER)/3)
 
-	if(shock_stage >= SHOCK_TIER_4 && prob(2))
+	else if(shock_stage >= SHOCK_TIER_3)
+		if(prob(20))
+			set_timed_status_effect(5 SECONDS, /datum/status_effect/speech/stutter, only_if_higher = TRUE)
+
+	if(shock_stage >= SHOCK_TIER_4 && prob(5))
 		pain_message(PAIN_STRING, shock_stage - CHEM_EFFECT_MAGNITUDE(src, CE_PAINKILLER)/3)
 		Knockdown(2 SECONDS)
 
-	if(shock_stage >= SHOCK_TIER_5 && prob(5))
+	if(shock_stage >= SHOCK_TIER_5 && prob(10))
 		pain_message(PAIN_STRING, shock_stage - CHEM_EFFECT_MAGNITUDE(src, CE_PAINKILLER)/3)
 		Knockdown(2 SECONDS)
 
@@ -203,7 +206,7 @@
 #undef PAIN_STRING
 
 /mob/living/carbon/proc/handle_pain()
-	if(stat)
+	if(stat == DEAD)
 		return
 
 	var/pain = getPain()
@@ -214,12 +217,15 @@
 		remove_movespeed_modifier(/datum/movespeed_modifier/pain)
 
 	if(pain >= maxHealth)
-		if(stat == CONSCIOUS && !HAS_TRAIT(src, TRAIT_FAKEDEATH))
+		if(!stat && !HAS_TRAIT(src, TRAIT_FAKEDEATH))
 			visible_message(
-				"<b>[src]</b> slumps over, too weak to continue fighting...",
+				span_danger("<b>[src]</b> slumps over, too weak to continue fighting...",)
 				span_danger("You give into the pain.")
 			)
-		Sleeping(10 SECONDS)
+		Unconscious(10 SECONDS)
+		return
+
+	if(stat == UNCONSCIOUS)
 		return
 
 	if(!COOLDOWN_FINISHED(src, pain_cd) && !prob(5))

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -664,7 +664,7 @@
 	if(!LAZYLEN(contained_organs) || !(brute || burn))
 		return FALSE
 
-	var/organ_damage_threshold = 5
+	var/organ_damage_threshold = 10
 	if(sharpness & SHARP_POINTY)
 		organ_damage_threshold *= 0.5
 

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -23,7 +23,7 @@
 				span_userdanger("[messages[2]]"),
 				span_hear("[messages[3]]")
 			)
-		if(!(bodypart_flags & BP_NO_PAIN) && !HAS_TRAIT(limb_owner, TRAIT_NO_PAINSHOCK) && prob(50))
+		if(!(bodypart_flags & BP_NO_PAIN) && !HAS_TRAIT(limb_owner, TRAIT_NO_PAINSHOCK) && prob(80))
 			INVOKE_ASYNC(owner, TYPE_PROC_REF(/mob/living/carbon, pain_emote), PAIN_AMT_AGONIZING, TRUE)
 
 	// We need to create a stump *now* incase the limb being dropped destroys it or otherwise changes it.
@@ -39,8 +39,8 @@
 	limb_owner.mind?.add_memory(MEMORY_DISMEMBERED, list(DETAIL_LOST_LIMB = src, DETAIL_PROTAGONIST = limb_owner), story_value = STORY_VALUE_AMAZING)
 
 	// At this point the limb has been removed from it's parent mob.
+	limb_owner.apply_pain(60, body_zone, "OH GOD MY [uppertext(plaintext_zone)]!!!", TRUE)
 	drop_limb()
-	adjustPain(60)
 
 	limb_owner.update_equipment_speed_mods() // Update in case speed affecting item unequipped by dismemberment
 	var/turf/owner_location = limb_owner.loc
@@ -88,13 +88,11 @@
 
 	if(dismember_type == DROPLIMB_BLUNT)
 		limb_owner.spray_blood(direction, 2)
-		var/obj/effect/decal/cleanable/gore
 		if(IS_ORGANIC_LIMB(src))
-			gore = new /obj/effect/decal/cleanable/blood/gibs(get_turf(limb_owner))
+			new /obj/effect/decal/cleanable/blood/gibs(get_turf(limb_owner))
 		else
-			gore = new /obj/effect/decal/cleanable/robot_debris(get_turf(limb_owner))
+			new /obj/effect/decal/cleanable/robot_debris(get_turf(limb_owner))
 
-		gore.throw_at(get_edge_target_turf(src, direction), rand(1,3), 5)
 		drop_contents()
 		qdel(src)
 

--- a/code/modules/surgery/bodyparts/stump.dm
+++ b/code/modules/surgery/bodyparts/stump.dm
@@ -38,6 +38,7 @@
 
 
 	stump.name = "stump of \a [name]"
+	stump.plaintext_zone = "stump of \a [plaintext_zone]"
 	stump.artery_name = "mangled [artery_name]"
 	return stump
 

--- a/code/modules/surgery/bodyparts/wounds/_wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds/_wounds.dm
@@ -367,16 +367,16 @@
 			if(!clean)
 				gore_sound = "[!IS_ORGANIC_LIMB(src) ? "tortured metal" : "ripping tendons and flesh"]"
 				return list(
-						"\The [owner]'s [src.name] flies off in an arc!",
-						"Your [src.name] goes flying off!",
+						"\The [owner]'s [src.plaintext_zone] flies off in an arc!",
+						"Your [src.plaintext_zone] goes flying off!",
 						"You hear a terrible sound of [gore_sound]."
 					)
 
 		if(DROPLIMB_BURN)
 			gore = "[!IS_ORGANIC_LIMB(src) ? "": " of burning flesh"]"
 			return list(
-					"\The [owner]'s [src.name] flashes away into ashes!",
-					"Your [src.name] flashes away into ashes!",
+					"\The [owner]'s [src.plaintext_zone] flashes away into ashes!",
+					"Your [src.plaintext_zone] flashes away into ashes!",
 					"You hear a crackling sound[gore]."
 				)
 
@@ -384,7 +384,7 @@
 			gore = "[!IS_ORGANIC_LIMB(src) ? "": " in shower of gore"]"
 			gore_sound = "[!IS_ORGANIC_LIMB(src) ? "rending sound of tortured metal" : "sickening splatter of gore"]"
 			return list(
-					"\The [owner]'s [src.name] explodes[gore]!",
-					"Your [src.name] explodes[gore]!",
+					"\The [owner]'s [src.plaintext_zone] explodes[gore]!",
+					"Your [src.plaintext_zone] explodes[gore]!",
 					"You hear the [gore_sound]."
 				)

--- a/code/modules/surgery/new_surgery/_surgery_step.dm
+++ b/code/modules/surgery/new_surgery/_surgery_step.dm
@@ -177,7 +177,7 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		//. -= round(H.shock_stage * 0.5)
+		. -= round(H.shock_stage / 2)
 		if(H.eye_blurry)
 			. -= 20
 		if(H.eye_blind)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -78,10 +78,10 @@
 	if(pulse)
 		handle_heartbeat()
 		if(pulse == PULSE_2FAST && prob(1))
-			applyOrganDamage(0.5, updating_health = FALSE)
+			applyOrganDamage(0.25, updating_health = FALSE)
 			. = TRUE
 		if(pulse == PULSE_THREADY && prob(5))
-			applyOrganDamage(0.5, updating_health = FALSE)
+			applyOrganDamage(0.35, updating_health = FALSE)
 			. = TRUE
 
 /obj/item/organ/heart/proc/handle_pulse()

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -119,7 +119,7 @@
 			applyOrganDamage(-0.2, updating_health = FALSE)
 			. = TRUE
 
-	if(damage > 10 && DT_PROB(damage/6, delta_time)) //the higher the damage the higher the probability
+	if(damage > 10 && DT_PROB(damage/4, delta_time)) //the higher the damage the higher the probability
 		to_chat(liver_owner, span_warning("You feel a dull pain in your abdomen."))
 
 	if(owner.blood_volume < BLOOD_VOLUME_NORMAL)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -359,6 +359,7 @@
 			owner.bleed(1)
 
 		else if(prob(4))
+			to_chat(owner, span_warning(pick("I can't breathe...", "Air!", "It's getting hard to breathe.")))
 			spawn(-1)
 				owner.emote("gasp")
 			owner.losebreath = max(round(damage/2), owner.losebreath)


### PR DESCRIPTION

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: When you are knocked out from pain, you will stay knocked out until you recover enough.
qol: When you are entering shock, you will hear your heartbeat.
qol: Reduced time gap between pain messages.
qol: Pain message time gap will scale inversely proportional to the amount of pain you're in.
qol: Added more effects to earlier shock stages.
qol: Added a chat message for gasping caused by lung damage.
balance: Increased damage required to damage organs from external wounds.
balance: Reduced heart damage taken from irregular heartbeats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
