### PR TITLE
Fixes camera mob being unable to move down

### DIFF
--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -36,7 +36,7 @@
 	set name = "Move Down"
 	set category = "IC"
 
-	if(zstep(src, UP, ZMOVE_FEEDBACK))
+	if(zstep(src, DOWN, ZMOVE_FEEDBACK))
 		to_chat(src, span_notice("You move down."))
 
 /mob/camera/can_z_move(direction, turf/start, z_move_flags = NONE, mob/living/rider)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes moving down as camera mob

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Camera mobs (AI, Blob, etc) can move down on multi Z maps now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
