### PR TITLE
grab fixes

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -332,6 +332,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Is a medbot healing you
 #define TRAIT_MEDIBOTCOMINGTHROUGH "medbot"
 #define TRAIT_PASSTABLE "passtable"
+#define TRAIT_PASSMOB "passmob"
 /// Makes you immune to flashes
 #define TRAIT_NOFLASH "noflash"
 /// prevents xeno huggies implanting skeletons

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -400,11 +400,11 @@
 	if(QDELING(src))
 		CRASH("Illegal Move()! on [type]")
 
-	if(!moving_from_pull)
-		recheck_grabs(z_allowed = TRUE)
-
 	if(!loc || !newloc)
 		return FALSE
+
+	if(!moving_from_pull)
+		recheck_grabs(z_allowed = TRUE)
 
 	if(direct & (UP|DOWN))
 		if(!can_z_move(direct, null, z_movement_flags))
@@ -1338,3 +1338,14 @@
 /atom/movable/wash(clean_types)
 	. = ..()
 	germ_level = 0
+
+/atom/movable/proc/add_passmob(source)
+	if(!source)
+		return
+	ADD_TRAIT(src, TRAIT_PASSMOB, source)
+	pass_flags |= PASSMOB
+
+/atom/movable/proc/remove_passmob(source)
+	REMOVE_TRAIT(src, TRAIT_PASSMOB, source)
+	if(!HAS_TRAIT(src, TRAIT_PASSMOB))
+		pass_flags &= ~PASSMOB

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -509,6 +509,8 @@
 	moving_from_pull = FALSE
 	forcemove_should_maintain_grab = FALSE
 
+	update_offsets()
+
 /**
  * Called after a successful Move(). By this point, we've already moved.
  * Arguments:

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -112,8 +112,10 @@
 
 	if(anchored)
 		ADD_TRAIT(M, TRAIT_NO_FLOATING_ANIM, BUCKLED_TRAIT)
+
 	if(!length(buckled_mobs))
 		RegisterSignal(src, COMSIG_MOVABLE_SET_ANCHORED, PROC_REF(on_set_anchored))
+
 	M.set_buckled(src)
 	buckled_mobs |= M
 	M.throw_alert(ALERT_BUCKLED, /atom/movable/screen/alert/buckled)
@@ -123,6 +125,7 @@
 	M.setDir(dir)
 
 	post_buckle_mob(M)
+	M.update_offsets()
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_BUCKLE, M, force)
 	return TRUE
@@ -149,16 +152,21 @@
 		CRASH("[buckled_mob] called unbuckle_mob() for source while having buckled as [buckled_mob.buckled].")
 	if(!force && !buckled_mob.can_buckle_to)
 		return
+
 	. = buckled_mob
+
 	buckled_mob.set_buckled(null)
 	buckled_mob.set_anchored(initial(buckled_mob.anchored))
 	buckled_mob.clear_alert(ALERT_BUCKLED)
 	buckled_mob.set_glide_size(DELAY_TO_GLIDE_SIZE(buckled_mob.total_multiplicative_slowdown()))
 	buckled_mobs -= buckled_mob
+
 	if(anchored)
 		REMOVE_TRAIT(buckled_mob, TRAIT_NO_FLOATING_ANIM, BUCKLED_TRAIT)
+
 	if(!length(buckled_mobs))
 		UnregisterSignal(src, COMSIG_MOVABLE_SET_ANCHORED)
+
 	SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, buckled_mob, force)
 
 	if(can_fall)
@@ -166,6 +174,7 @@
 			buckled_mob.zFall()
 
 	post_unbuckle_mob(.)
+	buckled_mob.update_offsets()
 
 	if(!QDELETED(buckled_mob) && !buckled_mob.currently_z_moving && isturf(buckled_mob.loc)) // In the case they unbuckled to a flying movable midflight.
 		buckled_mob.zFall()

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -124,7 +124,7 @@
 		return ..()
 
 	if(!Adjacent(L))
-		user.move_grabbed_atoms_towards(get_turf(src))
+		grab.move_victim_towards(get_turf(src))
 		return ..()
 
 	if(user.combat_mode)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -222,6 +222,9 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		return
 	if(user == victim)
 		return
+	if(grab.current_grab.same_tile)
+		return
+
 	user.move_grabbed_atoms_towards(src)
 
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -225,7 +225,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if(grab.current_grab.same_tile)
 		return
 
-	user.move_grabbed_atoms_towards(src)
+	grab.move_victim_towards(src)
 
 
 /**

--- a/code/modules/grab/grab_living.dm
+++ b/code/modules/grab/grab_living.dm
@@ -1,6 +1,7 @@
 /mob/living/proc/can_grab(atom/movable/target, target_zone, use_offhand)
 	if(throwing || !(mobility_flags & MOBILITY_PULL))
 		return FALSE
+
 	if(!ismob(target) && target.anchored)
 		to_chat(src, span_warning("\The [target] won't budge!"))
 		return FALSE
@@ -20,10 +21,16 @@
 
 	for(var/obj/item/hand_item/grab/G in target.grabbed_by)
 		if(G.assailant != src)
+			if(G.assailant.move_force > move_force || (G.assailant.move_force == move_force && G.current_grab.damage_stage >= AGGRESSIVE_GRAB))
+				to_chat(src, span_warning("[G.assailant]'s grip is too strong."))
+				return FALSE
+
 			continue
+
 		if(!target_zone || !ismob(target))
 			to_chat(src, span_warning("You already have a grip on \the [target]!"))
 			return FALSE
+
 		if(G.target_zone == target_zone)
 			var/obj/item/bodypart/BP = G.get_targeted_bodypart()
 			if(BP)
@@ -72,6 +79,11 @@
 		if(original_target != src && ismob(original_target))
 			to_chat(original_target, span_warning("\The [src] tries to grab you, but fails!"))
 		return null
+
+	for(var/obj/item/hand_item/grab/competing_grab in target.grabbed_by)
+		if(competing_grab.assailant.move_force < move_force)
+			to_chat(competing_grab.assailant, span_alert("[target] is ripped from your grip by [src]."))
+			qdel(competing_grab)
 
 	SEND_SIGNAL(src, COMSIG_LIVING_START_GRAB, target, grab)
 	SEND_SIGNAL(target, COMSIG_ATOM_GET_GRABBED, src, grab)

--- a/code/modules/grab/grab_living.dm
+++ b/code/modules/grab/grab_living.dm
@@ -21,7 +21,7 @@
 
 	for(var/obj/item/hand_item/grab/G in target.grabbed_by)
 		if(G.assailant != src)
-			if(G.assailant.move_force > move_force || (G.assailant.move_force == move_force && G.current_grab.damage_stage >= AGGRESSIVE_GRAB))
+			if(G.assailant.pull_force > pull_force || (G.assailant.pull_force == pull_force && G.current_grab.damage_stage > GRAB_PASSIVE))
 				to_chat(src, span_warning("[G.assailant]'s grip is too strong."))
 				return FALSE
 

--- a/code/modules/grab/grab_living.dm
+++ b/code/modules/grab/grab_living.dm
@@ -81,7 +81,7 @@
 		return null
 
 	for(var/obj/item/hand_item/grab/competing_grab in target.grabbed_by)
-		if(competing_grab.assailant.move_force < move_force)
+		if(competing_grab.assailant.pull_force < pull_force)
 			to_chat(competing_grab.assailant, span_alert("[target] is ripped from your grip by [src]."))
 			qdel(competing_grab)
 

--- a/code/modules/grab/grab_movable.dm
+++ b/code/modules/grab/grab_movable.dm
@@ -40,29 +40,7 @@
 /// Move grabbed atoms towards a destination
 /mob/living/proc/move_grabbed_atoms_towards(atom/destination)
 	for(var/obj/item/hand_item/grab/G in active_grabs)
-		var/atom/movable/pulling = G.affecting
-		if(pulling.anchored || pulling.move_resist > move_force || !pulling.Adjacent(src, src, pulling))
-			qdel(G)
-			continue
-
-		if(isliving(pulling))
-			var/mob/living/pulling_mob = pulling
-			if(pulling_mob.buckled && pulling_mob.buckled.buckle_prevents_pull) //if they're buckled to something that disallows pulling, prevent it
-				qdel(G)
-				continue
-
-		if(destination == loc && pulling.density)
-			continue
-
-		var/move_dir = get_dir(pulling.loc, destination)
-		if(!Process_Spacemove(move_dir))
-			continue
-
-		// At this point the move was successful
-		pulling.Move(get_step(pulling.loc, move_dir), move_dir, glide_size)
-
-		pulling.update_offsets()
-
+		G.move_victim_towards(destination)
 
 /atom/movable/proc/update_offsets()
 	var/last_pixel_x = pixel_x

--- a/code/modules/grab/grab_movable.dm
+++ b/code/modules/grab/grab_movable.dm
@@ -57,19 +57,9 @@
 		if(L.buckled)
 			grabbed_by += L.buckled.grabbed_by
 
-	if(isturf(loc))
-		if(length(grabbed_by))
-			for(var/obj/item/hand_item/grab/G in grabbed_by)
-				var/grab_dir = get_dir(G.assailant, src)
-				if(grab_dir && G.current_grab.shift != 0)
-					if(grab_dir & WEST)
-						new_pixel_x = min(new_pixel_x+G.current_grab.shift, base_pixel_x+G.current_grab.shift)
-					else if(grab_dir & EAST)
-						new_pixel_x = max(new_pixel_x-G.current_grab.shift, base_pixel_x-G.current_grab.shift)
-					if(grab_dir & NORTH)
-						new_pixel_y = max(new_pixel_y-G.current_grab.shift, base_pixel_y-G.current_grab.shift)
-					else if(grab_dir & SOUTH)
-						new_pixel_y = min(new_pixel_y+G.current_grab.shift, base_pixel_y+G.current_grab.shift)
+	if(isturf(loc) && length(grabbed_by))
+		for(var/obj/item/hand_item/grab/G in grabbed_by)
+			G.current_grab.get_grab_offsets(G, get_dir(G.assailant, G.affecting), &new_pixel_x, &new_pixel_y)
 
 	if(last_pixel_x != new_pixel_x || last_pixel_y != new_pixel_y)
 		animate(src, pixel_x = new_pixel_x, pixel_y = new_pixel_y, 3, 1, (LINEAR_EASING|EASE_IN))

--- a/code/modules/grab/grab_movable.dm
+++ b/code/modules/grab/grab_movable.dm
@@ -52,6 +52,11 @@
 	var/list/grabbed_by = list()
 
 	grabbed_by += src.grabbed_by
+
+	if(length(buckled_mobs))
+		for(var/mob/M as anything in buckled_mobs)
+			M.update_offsets()
+
 	if(isliving(src))
 		var/mob/living/L = src
 		if(L.buckled)

--- a/code/modules/grab/grab_object.dm
+++ b/code/modules/grab/grab_object.dm
@@ -397,3 +397,9 @@
 	. = affecting.Move(get_step(affecting.loc, move_dir), move_dir, glide_size)
 	if(.)
 		affecting.update_offsets()
+
+/// Removes any grabs applied to the affected movable that aren't src
+/obj/item/hand_item/grab/proc/remove_competing_grabs()
+	for(var/obj/item/hand_item/grab/other_grab in affecting.grabbed_by - src)
+		to_chat(other_grab.assailant, span_alert("[affecting] is ripped from your grip by [assailant]."))
+		qdel(other_grab)

--- a/code/modules/grab/grab_object.dm
+++ b/code/modules/grab/grab_object.dm
@@ -272,6 +272,7 @@
 	var/datum/grab/downgrab = current_grab.downgrade(src)
 	if(!downgrab)
 		return
+
 	if(is_grab_unique(current_grab))
 		current_grab.remove_unique_grab_effects(src)
 

--- a/code/modules/grab/grab_object.dm
+++ b/code/modules/grab/grab_object.dm
@@ -251,8 +251,6 @@
 
 	COOLDOWN_START(src, upgrade_cd, current_grab.upgrade_cooldown)
 
-	adjust_position()
-	update_appearance()
 	leave_forensic_traces()
 
 	if(QDELETED(src))
@@ -263,6 +261,9 @@
 
 	if(is_grab_unique(current_grab))
 		current_grab.apply_unique_grab_effects(src)
+
+	adjust_position()
+	update_appearance()
 
 /obj/item/hand_item/grab/proc/downgrade(silent)
 	var/datum/grab/downgrab = current_grab.downgrade(src)

--- a/code/modules/grab/grabs/grab_normal.dm
+++ b/code/modules/grab/grabs/grab_normal.dm
@@ -42,7 +42,9 @@
 		if(do_after(assailant, affecting, action_cooldown - 1, DO_PUBLIC, display = image('icons/hud/do_after.dmi', "harm")))
 			G.action_used()
 			affecting.visible_message(span_danger("\The [assailant] pins \the [affecting] to the ground!"))
-			affecting.Knockdown(1 SECOND) // This can only be performed with an aggressive grab, which ensures that once someone is knocked down, they stay down/
+			affecting.Paralyze(1 SECOND) // This can only be performed with an aggressive grab, which ensures that once someone is knocked down, they stay down.
+			affecting.move_from_pull(G.assailant, get_turf(G.assailant))
+			affecting.update_offsets() // Re-center the target
 			return TRUE
 
 		affecting.visible_message(span_warning("\The [assailant] fails to pin \the [affecting] to the ground."))

--- a/code/modules/grab/grabs/grab_normal.dm
+++ b/code/modules/grab/grabs/grab_normal.dm
@@ -44,7 +44,6 @@
 			affecting.visible_message(span_danger("\The [assailant] pins \the [affecting] to the ground!"))
 			affecting.Paralyze(1 SECOND) // This can only be performed with an aggressive grab, which ensures that once someone is knocked down, they stay down.
 			affecting.move_from_pull(G.assailant, get_turf(G.assailant))
-			affecting.update_offsets() // Re-center the target
 			return TRUE
 
 		affecting.visible_message(span_warning("\The [assailant] fails to pin \the [affecting] to the ground."))

--- a/code/modules/grab/grabs/grab_struggle.dm
+++ b/code/modules/grab/grabs/grab_struggle.dm
@@ -43,6 +43,7 @@
 
 	#ifdef UNIT_TESTS
 	var/upgrade_cooldown = 0
+	sleep(world.tick_lag)
 	#endif
 
 	var/datum/callback/user_incapacitated_callback = CALLBACK(src, PROC_REF(resolve_struggle_check), G)

--- a/code/modules/grab/grabs/grab_struggle.dm
+++ b/code/modules/grab/grabs/grab_struggle.dm
@@ -41,6 +41,10 @@
 /datum/grab/normal/struggle/proc/resolve_struggle(obj/item/hand_item/grab/G)
 	set waitfor = FALSE
 
+	#ifdef UNIT_TESTS
+	var/upgrade_cooldown = 0
+	#endif
+
 	var/datum/callback/user_incapacitated_callback = CALLBACK(src, PROC_REF(resolve_struggle_check), G)
 	if(do_after(G.assailant, G.affecting, upgrade_cooldown, DO_PUBLIC|IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE, extra_checks = user_incapacitated_callback))
 		G.done_struggle = TRUE

--- a/code/modules/grab/grabs/grab_struggle.dm
+++ b/code/modules/grab/grabs/grab_struggle.dm
@@ -41,10 +41,6 @@
 /datum/grab/normal/struggle/proc/resolve_struggle(obj/item/hand_item/grab/G)
 	set waitfor = FALSE
 
-	#ifdef UNIT_TESTS
-	var/upgrade_cooldown = 0.1 //var shadowing abuse lol
-	#endif
-
 	var/datum/callback/user_incapacitated_callback = CALLBACK(src, PROC_REF(resolve_struggle_check), G)
 	if(do_after(G.assailant, G.affecting, upgrade_cooldown, DO_PUBLIC|IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE, extra_checks = user_incapacitated_callback))
 		G.done_struggle = TRUE

--- a/code/modules/grab/grabs/grab_struggle.dm
+++ b/code/modules/grab/grabs/grab_struggle.dm
@@ -41,6 +41,10 @@
 /datum/grab/normal/struggle/proc/resolve_struggle(obj/item/hand_item/grab/G)
 	set waitfor = FALSE
 
+	#ifdef UNIT_TESTS
+	var/upgrade_cooldown = 0.1 //var shadowing abuse lol
+	#endif
+
 	var/datum/callback/user_incapacitated_callback = CALLBACK(src, PROC_REF(resolve_struggle_check), G)
 	if(do_after(G.assailant, G.affecting, upgrade_cooldown, DO_PUBLIC|IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE, extra_checks = user_incapacitated_callback))
 		G.done_struggle = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
@@ -208,7 +208,7 @@
 		return
 	hopping = TRUE
 	set_density(FALSE)
-	pass_flags |= PASSMOB
+	add_passmob(REF(src))
 	notransform = TRUE
 	var/turf/new_turf = locate((target.x + rand(-3,3)),(target.y + rand(-3,3)),target.z)
 	if(player_hop)
@@ -222,7 +222,7 @@
 /mob/living/simple_animal/hostile/jungle/leaper/proc/FinishHop()
 	set_density(TRUE)
 	notransform = FALSE
-	pass_flags &= ~PASSMOB
+	remove_passmob(REF(src))
 	hopping = FALSE
 	playsound(src.loc, 'sound/effects/meteorimpact.ogg', 100, TRUE)
 	if(target && AIStatus == AI_ON && projectile_ready && !ckey)

--- a/code/modules/tables/tables_racks.dm
+++ b/code/modules/tables/tables_racks.dm
@@ -302,7 +302,7 @@
 		user.release_grabs(pushed_mob)
 
 	else if(target.pass_flags & PASSTABLE)
-		user.move_grabbed_atoms_towards(src)
+		grab.move_victim_towards(src)
 		if (target.loc == loc)
 			user.visible_message(span_notice("[user] places [target] onto [src]."),
 				span_notice("You place [target] onto [src]."))

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -104,6 +104,7 @@
 #include "gas_transfer.dm"
 #include "gas_validation.dm"
 #include "get_turf_pixel.dm"
+#include "grabbing.dm"
 #include "greyscale_config.dm"
 #include "heretic_knowledge.dm"
 #include "heretic_rituals.dm"

--- a/code/modules/unit_tests/grabbing.dm
+++ b/code/modules/unit_tests/grabbing.dm
@@ -43,10 +43,8 @@
 
 			expected_grab_level = the_grab.current_grab.downgrab
 		else
-			TEST_ASSERT(QDELETED(the_grab), "Grab object was not qdeleted after attempting to downgrade to nothing.")
+			QDEL_NULL(the_grab)
 			break
-
-	the_grab = null
 
 /datum/unit_test/grab_contest/Run()
 	var/mob/living/carbon/human/assailant = allocate(__IMPLIED_TYPE__)

--- a/code/modules/unit_tests/grabbing.dm
+++ b/code/modules/unit_tests/grabbing.dm
@@ -1,0 +1,73 @@
+/datum/unit_test/grab_basic/Run()
+	var/mob/living/carbon/human/assailant = allocate(__IMPLIED_TYPE__)
+	var/mob/living/carbon/human/victim = allocate(__IMPLIED_TYPE__)
+
+	assailant.try_make_grab(victim)
+
+	var/obj/item/hand_item/grab/the_grab = assailant.is_grabbing(victim)
+	TEST_ASSERT(!isnull(the_grab), "Assailant failed to grab victim.")
+
+	// Test upgrading works
+	var/expected_grab_level = the_grab.current_grab.upgrab
+	assailant.set_combat_mode(TRUE)
+
+	while(expected_grab_level)
+		the_grab.attack_self(assailant)
+
+		TEST_ASSERT(!QDELETED(the_grab), "Grab object qdeleted unexpectedly.")
+		TEST_ASSERT(the_grab.current_grab == expected_grab_level, "Grab is not at the expected grab level, expected: [expected_grab_level] | got: [the_grab.current_grab || "NULL"]")
+
+		expected_grab_level = the_grab.current_grab.upgrab
+		COOLDOWN_RESET(the_grab, upgrade_cd)
+
+
+	// Test downgrading works
+	assailant.set_combat_mode(FALSE)
+	expected_grab_level = the_grab.current_grab.downgrab
+
+	while(TRUE)
+		the_grab.attack_self(assailant)
+
+		if(expected_grab_level)
+			TEST_ASSERT(!QDELETED(the_grab), "Grab object qdeleted unexpectedly.")
+			TEST_ASSERT(the_grab.current_grab == expected_grab_level, "Grab is not at the expected grab level, expected: [expected_grab_level] | got: [the_grab.current_grab || "NULL"]")
+
+			expected_grab_level = the_grab.current_grab.upgrab
+		else
+			TEST_ASSERT(QDELETED(the_grab), "Grab object was not qdeleted after attempting to downgrade to nothing.")
+			break
+
+	the_grab = null
+
+
+/datum/unit_test/grab_contest/Run()
+	var/mob/living/carbon/human/assailant = allocate(__IMPLIED_TYPE__)
+	var/mob/living/carbon/human/victim = allocate(__IMPLIED_TYPE__)
+	var/mob/living/carbon/human/competitor = allocate(__IMPLIED_TYPE__)
+
+	// Start off by making sure both basic grabs work
+	assailant.try_make_grab(victim)
+	TEST_ASSERT(assailant.is_grabbing(victim), "Assailant failed to grab victim.")
+
+	competitor.try_make_grab(victim)
+	TEST_ASSERT(competitor.is_grabbing(victim), "Competitor failed to grab victim.")
+	TEST_ASSERT(assailant.is_grabbing(victim), "Competitor grab removed initial grab.")
+
+	// Ensure that raising grab level correctly deletes opposition
+	var/obj/item/hand_item/grab/assailant_grab = assailant.is_grabbing(victim)
+	assailant.set_combat_mode(TRUE)
+	assailant_grab.attack_self(assailant)
+
+	TEST_ASSERT(!competitor.is_grabbing(victim), "Competitor is still grabbing victim after initial grabber raised to aggressive.")
+
+	// Ensure that grabbing with a higher pull force replaces the initial grab
+	competitor.pull_force = assailant.pull_force + 1
+	competitor.try_make_grab(victim)
+
+	TEST_ASSERT(competitor.is_grabbing(victim), "Competitor failed to grab victim despite having a superior pull force.")
+	TEST_ASSERT(!assailant.is_grabbing(victim), "Initial grabber still has a grip on victim despite a superior pull force taking over.")
+
+	// Ensure that a weaker pull force wont take away
+	assailant.try_make_grab(victim)
+	TEST_ASSERT(!assailant.is_grabbing(victim), "Initial grabber was able to re-grab victim despite having a weaker pull force.")
+

--- a/code/modules/unit_tests/grabbing.dm
+++ b/code/modules/unit_tests/grabbing.dm
@@ -17,12 +17,13 @@
 
 		TEST_ASSERT(!QDELETED(the_grab), "Grab object qdeleted unexpectedly.")
 
-		// Struggle grabs are special and need to be treated as such.
-		var/slept = world.time
-		UNTIL(!the_grab.done_struggle || world.time > slept + 10 SECONDS)
-		if(world.time > slept + 10 SECONDS)
-			TEST_FAIL("Struggle grab resolution took timed out")
-			return
+		if(istype(the_grab.current_grab), /datum/grab/normal/struggle)
+			// Struggle grabs are special and need to be treated as such.
+			var/slept = world.time
+			UNTIL(the_grab.done_struggle || world.time > slept + 10 SECONDS)
+			if(world.time > slept + 10 SECONDS)
+				TEST_FAIL("Struggle grab resolution took timed out")
+				return
 
 		TEST_ASSERT(the_grab.current_grab == expected_grab_level, "Grab is not at the expected grab level, expected: [expected_grab_level] | got: [the_grab.current_grab || "NULL"]")
 

--- a/code/modules/unit_tests/grabbing.dm
+++ b/code/modules/unit_tests/grabbing.dm
@@ -9,21 +9,11 @@
 	TEST_ASSERT(!isnull(the_grab), "Assailant failed to grab victim.")
 
 	// Test upgrading works
-	var/expected_grab_level = the_grab.current_grab.upgrab
+	var/expected_grab_level = GLOB.all_grabstates[/datum/grab/normal/aggressive]
 	assailant.set_combat_mode(TRUE)
 
 	while(expected_grab_level)
-		if(istype(the_grab.current_grab, /datum/grab/normal/struggle))
-			// Struggle grabs are special and need to be treated as such.
-			var/slept = REALTIMEOFDAY
-			while(!(the_grab.done_struggle || REALTIMEOFDAY > slept + 10 SECONDS))
-				sleep(world.tick_lag)
-
-			if(REALTIMEOFDAY > slept + 10 SECONDS)
-				TEST_FAIL("Struggle grab resolution timed out")
-				return
-		else
-			the_grab.attack_self(assailant)
+		the_grab.attack_self(assailant)
 
 		TEST_ASSERT(!QDELETED(the_grab), "Grab object qdeleted unexpectedly.")
 

--- a/code/modules/unit_tests/grabbing.dm
+++ b/code/modules/unit_tests/grabbing.dm
@@ -15,9 +15,11 @@
 	while(expected_grab_level)
 		if(istype(the_grab.current_grab, /datum/grab/normal/struggle))
 			// Struggle grabs are special and need to be treated as such.
-			var/slept = world.time
-			UNTIL(the_grab.done_struggle || world.time > slept + 10 SECONDS)
-			if(world.time > slept + 10 SECONDS)
+			var/slept = REALTIMEOFDAY
+			while(!(the_grab.done_struggle || REALTIMEOFDAY > slept + 10 SECONDS))
+				sleep(world.tick_lag)
+
+			if(REALTIMEOFDAY > slept + 10 SECONDS)
 				TEST_FAIL("Struggle grab resolution timed out")
 				return
 		else

--- a/code/modules/unit_tests/grabbing.dm
+++ b/code/modules/unit_tests/grabbing.dm
@@ -13,10 +13,6 @@
 	assailant.set_combat_mode(TRUE)
 
 	while(expected_grab_level)
-		the_grab.attack_self(assailant)
-
-		TEST_ASSERT(!QDELETED(the_grab), "Grab object qdeleted unexpectedly.")
-
 		if(istype(the_grab.current_grab, /datum/grab/normal/struggle))
 			// Struggle grabs are special and need to be treated as such.
 			var/slept = world.time
@@ -24,12 +20,15 @@
 			if(world.time > slept + 10 SECONDS)
 				TEST_FAIL("Struggle grab resolution took timed out")
 				return
+		else
+			the_grab.attack_self(assailant)
 
-		TEST_ASSERT(the_grab.current_grab == expected_grab_level, "Grab is not at the expected grab level, expected: [expected_grab_level] | got: [the_grab.current_grab || "NULL"]")
+		TEST_ASSERT(!QDELETED(the_grab), "Grab object qdeleted unexpectedly.")
+
+		TEST_ASSERT(the_grab.current_grab == expected_grab_level, "Upgraded grab is not at the expected grab level, expected: [expected_grab_level] | got: [the_grab.current_grab || "NULL"]")
 
 		expected_grab_level = the_grab.current_grab.upgrab
 		COOLDOWN_RESET(the_grab, upgrade_cd)
-
 
 	// Test downgrading works
 	assailant.set_combat_mode(FALSE)
@@ -40,7 +39,7 @@
 
 		if(expected_grab_level)
 			TEST_ASSERT(!QDELETED(the_grab), "Grab object qdeleted unexpectedly.")
-			TEST_ASSERT(the_grab.current_grab == expected_grab_level, "Grab is not at the expected grab level, expected: [expected_grab_level] | got: [the_grab.current_grab || "NULL"]")
+			TEST_ASSERT(the_grab.current_grab == expected_grab_level, "Downgraded grab is not at the expected grab level, expected: [expected_grab_level] | got: [the_grab.current_grab || "NULL"]")
 
 			expected_grab_level = the_grab.current_grab.upgrab
 		else

--- a/code/modules/unit_tests/grabbing.dm
+++ b/code/modules/unit_tests/grabbing.dm
@@ -18,8 +18,11 @@
 		TEST_ASSERT(!QDELETED(the_grab), "Grab object qdeleted unexpectedly.")
 
 		// Struggle grabs are special and need to be treated as such.
-		if(istype(the_grab.current_grab, /datum/grab/normal/struggle))
-			sleep(2) // Give the struggle a chance to resolve
+		var/slept = world.time
+		UNTIL(!the_grab.done_struggle || world.time > slept + 10 SECONDS)
+		if(world.time > slept + 10 SECONDS)
+			TEST_FAIL("Struggle grab resolution took timed out")
+			return
 
 		TEST_ASSERT(the_grab.current_grab == expected_grab_level, "Grab is not at the expected grab level, expected: [expected_grab_level] | got: [the_grab.current_grab || "NULL"]")
 

--- a/code/modules/unit_tests/grabbing.dm
+++ b/code/modules/unit_tests/grabbing.dm
@@ -16,6 +16,11 @@
 		the_grab.attack_self(assailant)
 
 		TEST_ASSERT(!QDELETED(the_grab), "Grab object qdeleted unexpectedly.")
+
+		// Struggle grabs are special and need to be treated as such.
+		if(istype(the_grab.current_grab, /datum/grab/normal/struggle))
+			sleep(2) // Give the struggle a chance to resolve
+
 		TEST_ASSERT(the_grab.current_grab == expected_grab_level, "Grab is not at the expected grab level, expected: [expected_grab_level] | got: [the_grab.current_grab || "NULL"]")
 
 		expected_grab_level = the_grab.current_grab.upgrab
@@ -39,7 +44,6 @@
 			break
 
 	the_grab = null
-
 
 /datum/unit_test/grab_contest/Run()
 	var/mob/living/carbon/human/assailant = allocate(__IMPLIED_TYPE__)

--- a/code/modules/unit_tests/grabbing.dm
+++ b/code/modules/unit_tests/grabbing.dm
@@ -17,7 +17,7 @@
 
 		TEST_ASSERT(!QDELETED(the_grab), "Grab object qdeleted unexpectedly.")
 
-		if(istype(the_grab.current_grab), /datum/grab/normal/struggle)
+		if(istype(the_grab.current_grab, /datum/grab/normal/struggle))
 			// Struggle grabs are special and need to be treated as such.
 			var/slept = world.time
 			UNTIL(the_grab.done_struggle || world.time > slept + 10 SECONDS)

--- a/code/modules/unit_tests/grabbing.dm
+++ b/code/modules/unit_tests/grabbing.dm
@@ -2,6 +2,7 @@
 	var/mob/living/carbon/human/assailant = allocate(__IMPLIED_TYPE__)
 	var/mob/living/carbon/human/victim = allocate(__IMPLIED_TYPE__)
 
+	victim.set_combat_mode(TRUE)
 	assailant.try_make_grab(victim)
 
 	var/obj/item/hand_item/grab/the_grab = assailant.is_grabbing(victim)

--- a/code/modules/unit_tests/grabbing.dm
+++ b/code/modules/unit_tests/grabbing.dm
@@ -18,7 +18,7 @@
 			var/slept = world.time
 			UNTIL(the_grab.done_struggle || world.time > slept + 10 SECONDS)
 			if(world.time > slept + 10 SECONDS)
-				TEST_FAIL("Struggle grab resolution took timed out")
+				TEST_FAIL("Struggle grab resolution timed out")
 				return
 		else
 			the_grab.attack_self(assailant)
@@ -41,7 +41,7 @@
 			TEST_ASSERT(!QDELETED(the_grab), "Grab object qdeleted unexpectedly.")
 			TEST_ASSERT(the_grab.current_grab == expected_grab_level, "Downgraded grab is not at the expected grab level, expected: [expected_grab_level] | got: [the_grab.current_grab || "NULL"]")
 
-			expected_grab_level = the_grab.current_grab.upgrab
+			expected_grab_level = the_grab.current_grab.downgrab
 		else
 			TEST_ASSERT(QDELETED(the_grab), "Grab object was not qdeleted after attempting to downgrade to nothing.")
 			break


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Neck-level grabs correctly move the victim.
fix: You can no longer move neck-level grab victims off your tile.
fix: Mobs buckled to a grabbed object now inherit the offset
qol: Cleaned up how repositioning grabbed movables works.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
