### PR TITLE
Fixes two-handed items and runtimes

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -1,4 +1,4 @@
-///called on /living when attempting to pick up an item, from base of /mob/living/put_in_hand_check(): (obj/item/I)
+///called on /living when attempting to pick up an item, from base of /mob/living/can_put_in_hand(): (obj/item/I)
 #define COMSIG_LIVING_TRY_PUT_IN_HAND "living_try_put_in_hand"
 	/// Can't pick up
 	#define COMPONENT_LIVING_CANT_PUT_IN_HAND (1<<0)

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -127,7 +127,6 @@
 /atom/movable/screen/plane_master/above_lighting
 	name = "above lighting plane master"
 	plane = ABOVE_LIGHTING_PLANE
-	appearance_flags = PLANE_MASTER //should use client color
 	blend_mode = BLEND_OVERLAY
 
 ///Contains space parallax
@@ -144,7 +143,6 @@
 /atom/movable/screen/plane_master/pipecrawl
 	name = "pipecrawl plane master"
 	plane = PIPECRAWL_IMAGES_PLANE
-	appearance_flags = PLANE_MASTER
 	blend_mode = BLEND_OVERLAY
 
 /atom/movable/screen/plane_master/pipecrawl/Initialize(mapload)
@@ -158,7 +156,6 @@
 /atom/movable/screen/plane_master/camera_static
 	name = "camera static plane master"
 	plane = CAMERA_STATIC_PLANE
-	appearance_flags = PLANE_MASTER
 	blend_mode = BLEND_OVERLAY
 
 /atom/movable/screen/plane_master/o_light_visual
@@ -172,7 +169,6 @@
 /atom/movable/screen/plane_master/runechat
 	name = "runechat plane master"
 	plane = RUNECHAT_PLANE
-	appearance_flags = PLANE_MASTER
 	blend_mode = BLEND_OVERLAY
 	render_relay_plane = RENDER_PLANE_NON_GAME
 

--- a/code/datums/ai/generic/generic_behaviors.dm
+++ b/code/datums/ai/generic/generic_behaviors.dm
@@ -169,11 +169,9 @@
 	var/obj/item/target = target_ref.resolve()
 
 	if(!(target in living_pawn.held_items))
-		if(!living_pawn.put_in_hand_check(target))
+		if(!living_pawn.put_in_hands(target))
 			finish_action(controller, FALSE, target, hunger_timer_key)
 			return
-
-		living_pawn.put_in_hands(target)
 
 	target.melee_attack_chain(living_pawn, living_pawn)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -622,12 +622,9 @@ DEFINE_INTERACTABLE(/obj/item)
 		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src))
 			return
 
-	. = FALSE
-	pickup(user)
 
-	if(!user.put_in_active_hand(src, FALSE, was_in_storage))
-		user.dropItemToGround(src)
-		return TRUE
+	// Return FALSE if the item is picked up.
+	return !user.pickup_item(src, ignore_anim = was_in_storage)
 
 /obj/item/proc/allow_attack_hand_drop(mob/user)
 	return TRUE
@@ -921,9 +918,9 @@ DEFINE_INTERACTABLE(/obj/item)
 			else if(slot)
 				user.update_clothing(slot)
 
-			// if the item requires two handed, drop the item on unwield
-			if(HAS_TRAIT(src, TRAIT_NEEDS_TWO_HANDS))
-				user.dropItemToGround(src, force=TRUE)
+		// if the item requires two handed, drop the item on unwield
+		if(HAS_TRAIT(src, TRAIT_NEEDS_TWO_HANDS))
+			user.dropItemToGround(src, force=TRUE)
 
 		// Show message if requested
 		if(show_message)

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -221,7 +221,7 @@
 	if(damage && attack_type == PROJECTILE_ATTACK && hit_projectile.damage_type != STAMINA && prob(15))
 		return TRUE
 
-/obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK)
+/obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK, block_success = TRUE)
 	. = ..()
 	if(!.)
 		return

--- a/code/game/objects/items/offhand.dm
+++ b/code/game/objects/items/offhand.dm
@@ -36,8 +36,8 @@
 
 /obj/item/offhand/proc/deleteme(datum/source, mob/user)
 	SIGNAL_HANDLER
-
-	qdel(src)
+	if(!QDELETED(src))
+		qdel(src)
 
 /obj/item/offhand/proc/try_swap_hands(datum/source, obj/item/held_item)
 	SIGNAL_HANDLER

--- a/code/modules/antagonists/highlander/highlander.dm
+++ b/code/modules/antagonists/highlander/highlander.dm
@@ -73,9 +73,8 @@
 	sword = new(H)
 	if(!GLOB.highlander_controller)
 		sword.flags_1 |= ADMIN_SPAWNED_1 //To prevent announcing
-	sword.pickup(H) //For the stun shielding
-	H.put_in_hands(sword)
 
+	H.pickup_item(sword)
 
 	var/obj/item/bloodcrawl/antiwelder = new(H)
 	antiwelder.name = "compulsion of honor"

--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -73,14 +73,12 @@
 		return FALSE
 
 	var/obj/item/toy/singlecard/selected_card = draw(user, choice)
-	selected_card.pickup(user)
-	user.put_in_hands(selected_card)
+	user.pickup_item(selected_card)
 
 	if(cards.len == 1)
 		user.temporarilyRemoveItemFromInventory(src, TRUE)
 		var/obj/item/toy/singlecard/last_card = draw(user)
-		last_card.pickup(user)
-		user.put_in_hands(last_card)
+		user.pickup_item(last_card)
 		qdel(src) // cardhand is empty now so delete it
 
 /obj/item/toy/cards/cardhand/proc/check_menu(mob/living/user)

--- a/code/modules/cards/deck/deck.dm
+++ b/code/modules/cards/deck/deck.dm
@@ -153,8 +153,8 @@
 		return
 	if(flip_card)
 		card.Flip()
-	card.pickup(user)
-	user.put_in_hands(card)
+
+	user.pickup_item(card)
 	user.balloon_alert_to_viewers("draws a card")
 
 /obj/item/toy/cards/deck/attack_hand_secondary(mob/living/user, list/modifiers)

--- a/code/modules/cards/singlecard.dm
+++ b/code/modules/cards/singlecard.dm
@@ -173,8 +173,7 @@
 
 		if(!isturf(loc)) // make a cardhand in our active hand
 			user.temporarilyRemoveItemFromInventory(src, TRUE)
-			new_cardhand.pickup(user)
-			user.put_in_active_hand(new_cardhand)
+			user.pickup_item(new_cardhand)
 		return
 
 	if(istype(item, /obj/item/toy/cards/cardhand)) // insert into cardhand

--- a/code/modules/client/preferences/monochrome_ghost.dm
+++ b/code/modules/client/preferences/monochrome_ghost.dm
@@ -11,6 +11,8 @@
 		return
 
 	if(value && !M.started_as_observer)
+		if(locate(/datum/client_colour/ghostmono) in M.client_colours)
+			return
 		M.add_client_colour(/datum/client_colour/ghostmono)
 	else
 		M.remove_client_colour(/datum/client_colour/ghostmono)

--- a/code/modules/grab/grabs/grab_normal.dm
+++ b/code/modules/grab/grabs/grab_normal.dm
@@ -115,7 +115,7 @@
 	return FALSE
 
 /datum/grab/normal/resolve_openhand_attack(obj/item/hand_item/grab/G)
-	if(!G.assailant.combat_mode)
+	if(!G.assailant.combat_mode || G.assailant == G.affecting)
 		return FALSE
 	if(G.target_zone == BODY_ZONE_HEAD)
 		if(G.assailant.zone_selected == BODY_ZONE_PRECISE_EYES)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -220,7 +220,8 @@ Works together with spawning an observer, noted above.
 		ghost.mind = null
 
 	if(!admin_ghost)
-		ghost.add_client_colour(/datum/client_colour/ghostmono)
+		if(!ghost.client?.prefs || ghost.client.prefs.read_preference(/datum/preference/toggle/monochrome_ghost))
+			ghost.add_client_colour(/datum/client_colour/ghostmono)
 
 	return ghost
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -371,7 +371,7 @@
 
 	to_chat(src, span_notice("Automatic announcements [chosen_channel == "None" ? "will not use the radio." : "set to [chosen_channel]."]"))
 
-/mob/living/silicon/put_in_hand_check() // This check is for borgs being able to receive items, not put them in others' hands.
+/mob/living/silicon/can_put_in_hand(I, hand_index)
 	return FALSE
 
 /mob/living/silicon/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) //Secbots won't hunt silicon units

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -330,7 +330,7 @@
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
 	. = ..()
-	if(ismopable(attack_target))
+	if(ismopable(attack_target) || istype(attack_target, /obj/effect/decal/cleanable/blood))
 		mode = BOT_CLEANING
 		update_icon_state()
 		var/turf/T = get_turf(attack_target)
@@ -346,6 +346,7 @@
 		playsound(src, 'sound/effects/spray2.ogg', 50, TRUE, -6)
 		attack_target.acid_act(75, 10)
 		target = null
+
 	else if(istype(attack_target, /mob/living/basic/cockroach) || ismouse(attack_target))
 		var/mob/living/living_target = attack_target
 		if(!living_target.stat)

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -95,9 +95,9 @@
 		if(isitem(grabbed_atom) && (mod.wearer in next_turf))
 			var/obj/item/grabbed_item = grabbed_atom
 			clear_grab()
-			grabbed_item.pickup(mod.wearer)
-			mod.wearer.put_in_hands(grabbed_item)
+			mod.wearer.pickup_item(grabbed_item)
 		return
+
 	var/pixel_x_change = 0
 	var/pixel_y_change = 0
 	var/direction = get_dir(grabbed_atom, next_turf)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -440,7 +440,7 @@
 
 	holder.remove_reagent(/datum/reagent/toxin/mindbreaker, 5)
 
-	C.adjustToxLoss(5 * removed, updating_health = FALSE) // It used to be incredibly deadly due to an oversight. Not anymore!
+	C.adjustToxLoss(3 * removed, updating_health = FALSE) // It used to be incredibly deadly due to an oversight. Not anymore!
 	APPLY_CHEM_EFFECT(C, CE_PAINKILLER, 20)
 	APPLY_CHEM_EFFECT(C, CE_STIMULANT, 10)
 	return TRUE

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -233,7 +233,7 @@
 	base_icon_state = "stimpen"
 	volume = 30
 	amount_per_transfer_from_this = 30
-	list_reagents = list(/datum/reagent/medicine/synaptizine = 8, /datum/reagent/medicine/dermaline = 8, /datum/reagent/medicine/meralyne = 8, /datum/reagent/medicine/leporazine = 6)
+	list_reagents = list(/datum/reagent/medicine/synaptizine = 4, /datum/reagent/medicine/dermaline = 8, /datum/reagent/medicine/meralyne = 8, /datum/reagent/medicine/leporazine = 6)
 
 /obj/item/reagent_containers/hypospray/medipen/survival/inject(mob/living/affected_mob, mob/user)
 	if(DOING_INTERACTION(user, DOAFTER_SOURCE_SURVIVALPEN))

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -244,7 +244,7 @@ DEFINE_INTERACTABLE(/obj/machinery/rnd/production)
 	if(!(D in internal_disk.read(DATA_IDX_DESIGNS)))
 		CRASH("Tried to print a design we don't have! Potential exploit?")
 
-	playsound(src, 'goon/sounds/button.ogg')
+	playsound(src, 'goon/sounds/button.ogg', 100)
 	update_appearance(UPDATE_OVERLAYS)
 	add_to_queue(D, amount, D.dangerous_construction)
 	return TRUE

--- a/modular_pariah/master_files/code/game/gamemodes/objective.dm
+++ b/modular_pariah/master_files/code/game/gamemodes/objective.dm
@@ -1,7 +1,8 @@
 // For modularity, we hook into the update_explanation_text to be sure we have a target to register.
 /datum/objective/assassinate/update_explanation_text()
-	RegisterSignal(target, COMSIG_LIVING_DEATH, PROC_REF(register_target_death))
+	RegisterSignal(target, COMSIG_LIVING_DEATH, PROC_REF(register_target_death), TRUE)
 	return ..()
+
 /datum/objective/assassinate/proc/register_target_death(mob/living/dead_guy, gibbed)
 	SIGNAL_HANDLER
 	completed = TRUE


### PR DESCRIPTION

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Two-handed items function better.
fix: Fixed a sound not playing from fabricators.
fix: Cleanbots no longer get stuck spraying acid on specific blood decals.
fix: The monochrome ghost vision pref actually works (lol).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
