### PR TITLE
fix item attack chance

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -171,7 +171,7 @@
 	if(!I || !user)
 		return MOB_ATTACKEDBY_FAIL
 
-	var/target_area = parse_zone(deprecise_zone(user.zone_selected)) //our intended target
+	var/target_zone = deprecise_zone(user.zone_selected) //our intended target
 
 	var/obj/item/bodypart/affecting = get_bodypart(deprecise_zone(user.zone_selected))
 	if (!affecting || affecting.is_stump)
@@ -179,9 +179,9 @@
 		return MOB_ATTACKEDBY_FAIL
 
 	if(user == src)
-		affecting = get_bodypart(target_area) //stabbing yourself always hits the right target
+		affecting = get_bodypart(target_zone) //stabbing yourself always hits the right target
 	else
-		var/bodyzone_modifier = GLOB.bodyzone_gurps_mods[target_area]
+		var/bodyzone_modifier = GLOB.bodyzone_gurps_mods[target_zone]
 		var/roll = !HAS_TRAIT(user, TRAIT_PERFECT_ATTACKER) ? user.stat_roll(11, STRENGTH, SKILL_MELEE_COMBAT, (gurps_stats.get_skill(SKILL_MELEE_COMBAT) + bodyzone_modifier), 7) : SUCCESS
 		var/hit_zone
 		switch(roll)
@@ -192,14 +192,14 @@
 			if(FAILURE)
 				hit_zone = get_random_valid_zone()
 			else
-				hit_zone = target_area
+				hit_zone = target_zone
 
-		affecting = get_bodypart(hit_zone)
+		affecting = get_bodypart(target_zone)
 
 	SEND_SIGNAL(I, COMSIG_ITEM_ATTACK_ZONE, src, user, affecting)
 
 	SSblackbox.record_feedback("nested tally", "item_used_for_combat", 1, list("[I.force]", "[I.type]"))
-	SSblackbox.record_feedback("tally", "zone_targeted", 1, target_area)
+	SSblackbox.record_feedback("tally", "zone_targeted", 1, parse_zone(target_zone))
 
 	// the attacked_by code varies among species
 	return dna.species.spec_attacked_by(I, user, affecting, src)


### PR DESCRIPTION
Closes #887 
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Attacking with an item will no longer always hit the chest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
