### PR TITLE
Fixes Ambient Occlusion overlays getting stuck on turf change.

### DIFF
--- a/code/modules/ambient_occlusion/turf_ao.dm
+++ b/code/modules/ambient_occlusion/turf_ao.dm
@@ -57,16 +57,20 @@
 	}
 
 #define PROCESS_AO(TARGET, AO_VAR, NEIGHBORS, ALPHA, SHADOWER) \
-	if (!permit_ao || NEIGHBORS == AO_ALL_NEIGHBORS) { \
-		AO_VAR = null; \
-	} else { \
+	if (permit_ao && NEIGHBORS != AO_ALL_NEIGHBORS) { \
 		var/image/I = cache["ao-[NEIGHBORS]|[pixel_x]/[pixel_y]/[pixel_z]/[pixel_w]|[ALPHA]|[SHADOWER]"]; \
-		if (isnull(I)) { \
+		if (!I) { \
 			/* This will also add the image to the cache. */ \
 			I = make_ao_image(NEIGHBORS, TARGET.pixel_x, TARGET.pixel_y, TARGET.pixel_z, TARGET.pixel_w, ALPHA, SHADOWER); \
 		} \
 		AO_VAR = I; \
 		TARGET.add_overlay(AO_VAR); \
+	}
+
+#define CUT_AO(TARGET, AO_VAR) \
+	if (AO_VAR) { \
+		TARGET.cut_overlay(AO_VAR); \
+		AO_VAR = null; \
 	}
 
 /proc/make_ao_image(corner, px = 0, py = 0, pz = 0, pw = 0, alpha, shadower)
@@ -128,7 +132,6 @@
 	var/turf/T
 	if (z_flags & Z_MIMIC_BELOW)
 		CALCULATE_JUNCTIONS(src, ao_junction_mimic, T, (T.z_flags & Z_MIMIC_BELOW))
-
 	if (AO_SELF_CHECK(src) && !(z_flags & Z_MIMIC_NO_AO))
 		CALCULATE_JUNCTIONS(src, ao_junction, T, AO_TURF_CHECK(T))
 
@@ -148,16 +151,10 @@
 
 /turf/proc/update_ao()
 	var/list/cache = SSao.image_cache
-
-	if(ao_overlay_mimic)
-		shadower.cut_overlay(ao_overlay_mimic)
-
-	if(ao_overlay)
-		cut_overlay(ao_overlay)
-
+	CUT_AO(shadower, ao_overlay_mimic)
+	CUT_AO(src, ao_overlay)
 	if (z_flags & Z_MIMIC_BELOW)
 		PROCESS_AO(shadower, ao_overlay_mimic, ao_junction_mimic, Z_AO_ALPHA, TRUE)
-
 	if (AO_TURF_CHECK(src) && !(z_flags & Z_MIMIC_NO_AO))
 		PROCESS_AO(src, ao_overlay, ao_junction, WALL_AO_ALPHA, FALSE)
 


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: AO overlays no longer get stuck when turfs change. This was most obvious with the stellar body magnet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
