### PR TITLE
fix fingerprints & heterochromia

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -510,7 +510,7 @@
 	registered_name = R.fields["name"]
 	registered_age = R.fields["age"] || "UNSET"
 	dna_hash = R.fields["identity"] || "UNSET"
-	fingerprint = md5(R.fields["identity"]) || "UNSET"
+	fingerprint = R.fields["fingerprint"] || "UNSET"
 	blood_type = R.fields["blood_type"] || "UNSET"
 	assignment = R.fields["trim"] || "UNSET"
 	for(var/datum/id_trim/trim as anything in SSid_access.trim_singletons_by_path)

--- a/code/modules/client/preferences/heterochromatic.dm
+++ b/code/modules/client/preferences/heterochromatic.dm
@@ -8,7 +8,7 @@
 	if (!..(preferences))
 		return FALSE
 
-	return "Heterochromia" in preferences.read_preference(/datum/preference/blob/quirks)
+	return "Heterochromia Iridum" in preferences.read_preference(/datum/preference/blob/quirks)
 
 /datum/preference/color/heterochromatic/apply_to_human(mob/living/carbon/human/target, value)
 	for(var/datum/quirk/heterochromatic/hetero_quirk in target.quirks)

--- a/code/modules/client/preferences/html_prefs/modules/quirks.dm
+++ b/code/modules/client/preferences/html_prefs/modules/quirks.dm
@@ -1,7 +1,7 @@
 /datum/preference_group/quirks
 	var/list/quirk_prefs = list(
 		"Nearsighted" = /datum/preference/choiced/glasses,
-		"Heterochromia" = /datum/preference/color/heterochromatic,
+		"Heterochromia Iridum" = /datum/preference/color/heterochromatic,
 		"Phobia" = /datum/preference/choiced/phobia
 	)
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -386,7 +386,7 @@ GLOBAL_LIST_INIT(job_display_order, list(
 			card.registered_age = H.age
 		card.blood_type = H.dna.blood_type
 		card.dna_hash = H.dna.unique_identity
-		card.fingerprint = md5(H.dna.unique_identity)
+		card.fingerprint = H.get_fingerprints(TRUE)
 		card.update_label()
 		card.update_icon()
 


### PR DESCRIPTION
Closes #910
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Heterochromia works again.
fix: The "Fingerprints" field of ID cards now uses the correct value.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
