### PR TITLE
Fixes runtimes

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -113,7 +113,7 @@ SUBSYSTEM_DEF(garbage)
 		if(LAZYLEN(I.extra_details))
 			entry["Deleted Metadata"] = I.extra_details
 
-	log_qdel("", del_log)
+	log_qdel(jointext(del_log, "\n"))
 
 /datum/controller/subsystem/garbage/fire()
 	//the fact that this resets its processing each fire (rather then resume where it left off) is intentional.

--- a/code/datums/weakrefs.dm
+++ b/code/datums/weakrefs.dm
@@ -1,8 +1,8 @@
 /// Creates a weakref to the given input.
 /// See /datum/weakref's documentation for more information.
 /proc/WEAKREF(datum/input)
-	if(!QDELETED(input) && istype(input))
-		if(istype(input, /datum/weakref))
+	if(istype(input) && !QDELETED(input))
+		if(isweakref(input))
 			return input
 
 		if(!input.weak_reference)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -29,10 +29,11 @@
 /mob/living/carbon/gib(no_brain, no_organs, no_bodyparts, safe_gib = FALSE)
 	add_memory_in_range(src, 7, MEMORY_GIBBED, list(DETAIL_PROTAGONIST = src), STORY_VALUE_AMAZING, memory_flags = MEMORY_CHECK_BLINDNESS)
 	if(safe_gib) // If you want to keep all the mob's items and not have them deleted
-		for(var/obj/item/W in src)
+		for(var/obj/item/W in get_equipped_items(TRUE) | held_items)
 			if(dropItemToGround(W))
 				if(prob(50))
 					step(W, pick(GLOB.alldirs))
+
 	var/atom/Tsec = drop_location()
 	for(var/mob/M in src)
 		M.forceMove(Tsec)


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix massive amount of runtimes thrown from mouse dragging out of the mouse pane.
fix: Fixed "safe" gibbing attempting to remove bodyparts and organs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
