### PR TITLE
tgui cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
 		"**/.yarn": true,
 		"**/.pnp.*": true
 	},
+	"prettier.prettierPath": "./tgui/.yarn/sdks/prettier/index.cjs",
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": "explicit"
 	},

--- a/tgui/.yarn/sdks/typescript/bin/tsserver
+++ b/tgui/.yarn/sdks/typescript/bin/tsserver
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-const {existsSync} = require(`fs`);
-const {createRequire} = require(`module`);
-const {resolve} = require(`path`);
+const { existsSync } = require(`fs`);
+const { createRequire } = require(`module`);
+const { resolve } = require(`path`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = '../../../../.pnp.cjs';
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = createRequire(absPnpApiPath);

--- a/tgui/packages/tgui-bench/package.json
+++ b/tgui/packages/tgui-bench/package.json
@@ -3,6 +3,7 @@
   "name": "tgui-bench",
   "version": "4.3.0",
   "dependencies": {
+    "@types/node": "^14.17.9",
     "common": "workspace:*",
     "fastify": "^3.20.2",
     "fastify-static": "^4.2.3",

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -74,7 +74,7 @@ export const SettingsGeneral = (props) => {
     matchCase,
   } = useSelector(selectSettings);
   const dispatch = useDispatch();
-  const [freeFont, setFreeFont] = useLocalState(context, 'freeFont', false);
+  const [freeFont, setFreeFont] = useLocalState('freeFont', false);
   return (
     <Section>
       <LabeledList>

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -35,7 +35,6 @@ export const NtosNetDownloader = (props) => {
     scale(downloadcompletion, 0, downloadsize) * 100,
   );
   const [selectedCategory, setSelectedCategory] = useLocalState(
-    context,
     'category',
     all_categories[0],
   );

--- a/tgui/packages/tgui/interfaces/ParticleEdit/EntriesGenerators.tsx
+++ b/tgui/packages/tgui/interfaces/ParticleEdit/EntriesGenerators.tsx
@@ -69,10 +69,7 @@ export const FloatGenerator = (props: FloatGeneratorProps) => {
   );
 };
 
-export const FloatGeneratorColor = (
-  props: FloatGeneratorColorProps,
-  context,
-) => {
+export const FloatGeneratorColor = (props: FloatGeneratorColorProps) => {
   const { act, data } = useBackend<ParticleUIData>();
   const [desc, setdesc] = useLocalState('desc', '');
   const { name, var_name, float } = props;
@@ -129,7 +126,6 @@ export const FloatGeneratorColor = (
 
 export const EntryGeneratorNumbersList = (
   props: EntryGeneratorNumbersListProps,
-  context,
 ) => {
   const { act, data } = useBackend<ParticleUIData>();
   const [desc, setdesc] = useLocalState('desc', '');

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/ghost.tsx
@@ -26,7 +26,6 @@ export const ghost_orbit: FeatureChoiced = {
   `,
   component: (
     props: FeatureValueProps<string, string, FeatureChoicedServerData>,
-    context,
   ) => {
     const { data } = useBackend<PreferencesMenuData>();
 

--- a/tgui/packages/tgui/interfaces/Uplink/GenericUplink.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/GenericUplink.tsx
@@ -112,7 +112,7 @@ export type ItemListProps = {
   handleBuy: (item: Item) => void;
 };
 
-const ItemList = (props: ItemListProps, context: any) => {
+const ItemList = (props: ItemListProps) => {
   const { compactMode, items, handleBuy } = props;
   return (
     <Stack vertical>

--- a/tgui/packages/tgui/store.js
+++ b/tgui/packages/tgui/store.js
@@ -84,6 +84,7 @@ const createStackAugmentor = (store) => (stack, error) => {
 
 /**
  * Store provider for Inferno apps.
+ * This can be removed when Inferno is removed
  */
 export class StoreProvider extends Component {
   getChildContext() {

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -8132,6 +8132,7 @@ resolve@^2.0.0-next.3:
   version: 0.0.0-use.local
   resolution: "tgui-bench@workspace:packages/tgui-bench"
   dependencies:
+    "@types/node": ^14.17.9
     common: "workspace:*"
     fastify: ^3.20.2
     fastify-static: ^4.2.3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. Fixes an issue reported with panel settings. This was caused by a stray `context` reference
2. Removes a couple other stray references
3. Fixes prettier path in settings.json
4. Fixes an unreported issue with node types in tgui-bench

![image](https://github.com/DaedalusDock/daedalusdock/assets/42397676/a12e6b24-fea7-4c5a-ad34-f2b2e269bc00)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Chat settings should no longer bluescreen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
