### PR TITLE
Surgery changes and fixes

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -11,6 +11,8 @@
 #define SURGERY_BLOODY_GLOVES (1<<6)
 /// Surgery step bloodies gloves + suit when necessary.
 #define SURGERY_BLOODY_BODY (1<<7)
+/// Surgery does not use RNG.
+#define SURGERY_CANNOT_FAIL (1<<8)
 
 /// Only one of this type of implant may be in a target
 #define IMPLANT_HIGHLANDER (1<<0)

--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -7,6 +7,10 @@
 #define SURGERY_NEEDS_RETRACTED (1<<4)
 /// Bodypart needs a broken bone AND retracted incision or large cut
 #define SURGERY_NEEDS_DEENCASEMENT (1<<5)
+/// Surgery step bloodies gloves when necessary.
+#define SURGERY_BLOODY_GLOVES (1<<6)
+/// Surgery step bloodies gloves + suit when necessary.
+#define SURGERY_BLOODY_BODY (1<<7)
 
 /// Only one of this type of implant may be in a target
 #define IMPLANT_HIGHLANDER (1<<0)
@@ -14,3 +18,4 @@
 #define IMPLANT_KNOWN (1<<1)
 /// Hides the implant from the body scanner completely
 #define IMPLANT_HIDDEN (1<<2)
+

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -69,8 +69,6 @@
 		if(!isabstract(path))
 			path = new path()
 			GLOB.surgeries_list += path
-			if(!length(path.allowed_tools))
-				stack_trace("Surgery type [path.type] has no allowed_items list.")
 
 	sort_list(GLOB.surgeries_list, GLOBAL_PROC_REF(cmp_typepaths_asc))
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -20,8 +20,8 @@
 	return GET_BLOOD_REF(path)
 
 /proc/get_blood_dna_color(list/blood_dna)
-	var/datum/blood/blood_type = blood_dna[blood_dna[length(blood_dna)]]
-	return blood_type.color
+	var/datum/blood/blood_type = blood_dna?[blood_dna[length(blood_dna)]]
+	return blood_type?.color
 
 /proc/random_eye_color()
 	switch(pick(20;"brown",20;"hazel",20;"grey",15;"blue",15;"green",1;"amber",1;"albino"))

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -247,6 +247,28 @@ GLOBAL_LIST_INIT(modulo_angle_to_dir, list(NORTH,NORTHEAST,EAST,SOUTHEAST,SOUTH,
 		if(ITEM_SLOT_LEGCUFFED)
 			return pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 
+/proc/body_zone2item_slots(zone)
+	switch(zone)
+		if(BODY_ZONE_HEAD)
+			return ITEM_SLOT_HEAD|ITEM_SLOT_MASK
+
+		if(BODY_ZONE_PRECISE_EYES)
+			return ITEM_SLOT_EYES
+
+		if(BODY_ZONE_CHEST)
+			return ITEM_SLOT_ICLOTHING|ITEM_SLOT_OCLOTHING
+
+		if(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
+			return ITEM_SLOT_ICLOTHING|ITEM_SLOT_OCLOTHING|ITEM_SLOT_GLOVES
+
+		if(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND)
+			return ITEM_SLOT_GLOVES
+
+		if(BODY_ZONE_R_LEG, BODY_ZONE_L_LEG)
+			return ITEM_SLOT_ICLOTHING|ITEM_SLOT_OCLOTHING|ITEM_SLOT_FEET
+
+		if(BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
+			return ITEM_SLOT_FEET
 //adapted from http://www.tannerhelland.com/4435/convert-temperature-rgb-algorithm-code/
 /proc/heat2colour(temp)
 	return rgb(heat2colour_r(temp), heat2colour_g(temp), heat2colour_b(temp))

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -152,7 +152,7 @@
 /mob/living/attackby(obj/item/attacking_item, mob/living/user, params)
 	if(..())
 		return TRUE
-	if (user.can_operate_on(src) && attacking_item.attempt_surgery(src, user))
+	if (user.can_perform_surgery_on(src) && attacking_item.attempt_surgery(src, user))
 		return TRUE
 
 	user.changeNext_move(attacking_item.combat_click_delay)

--- a/code/datums/components/bloodysoles.dm
+++ b/code/datums/components/bloodysoles.dm
@@ -99,7 +99,17 @@
 	if(HAS_TRAIT(parent_atom, TRAIT_LIGHT_STEP)) //the character is agile enough to don't mess their clothing and hands just from one blood splatter at floor
 		return TRUE
 
-	parent_atom.add_blood_DNA(pool.return_blood_DNA())
+	if(ishuman(parent_atom))
+		var/bloody_slots = ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING|ITEM_SLOT_FEET
+		var/mob/living/carbon/human/to_bloody = parent_atom
+		if(to_bloody.body_position == LYING_DOWN)
+			bloody_slots |= ITEM_SLOT_HEAD|ITEM_SLOT_MASK|ITEM_SLOT_GLOVES
+
+		to_bloody.add_blood_DNA_to_items(pool.return_blood_DNA(), bloody_slots)
+
+	else
+		parent_atom.add_blood_DNA(pool.return_blood_DNA())
+
 	if(pool.bloodiness <= 0)
 		qdel(pool)
 

--- a/code/datums/forensics.dm
+++ b/code/datums/forensics.dm
@@ -21,16 +21,17 @@
 	parent = null
 	return ..()
 
+/// Adds blood dna. Returns TRUE if the blood dna list expanded.
 /datum/forensics/proc/add_blood_DNA(list/dna)
 	if(!length(dna))
 		return
-
+	var/old_len = length(blood_DNA)
 	LAZYINITLIST(blood_DNA)
 	for(var/dna_hash in dna)
 		blood_DNA[dna_hash] = dna[dna_hash]
 
 	check_blood()
-	return TRUE
+	return old_len < length(blood_DNA)
 
 /datum/forensics/proc/add_trace_DNA(list/dna)
 	if(!length(dna))

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -85,6 +85,13 @@
 		if(!is_dry)
 			color = blood_color
 
+/obj/effect/decal/cleanable/blood/attack_hand(mob/living/user, list/modifiers)
+	. = ..()
+	if(ishuman(user) && blood_DNA_length())
+		var/mob/living/carbon/human/H = user
+		H.add_blood_DNA_to_items(return_blood_DNA(), ITEM_SLOT_GLOVES)
+		H.visible_message(span_notice("[user.name] runs [H.p_their()] fingers through [src]."))
+
 /obj/effect/decal/cleanable/blood/proc/get_timer()
 	drytime = world.time + dry_duration
 

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -30,7 +30,7 @@
 
 /obj/item/clothing/gloves/worn_overlays(mob/living/carbon/human/wearer, mutable_appearance/standing, isinhands = FALSE)
 	. = ..()
-	if(!isinhands)
+	if(isinhands)
 		return
 
 	if(damaged_clothes)

--- a/code/modules/codex/categories/surgery.dm
+++ b/code/modules/codex/categories/surgery.dm
@@ -61,9 +61,11 @@
 	for(var/datum/surgery_step/step as anything in GLOB.surgeries_list)
 		var/list/info = list("<ul>")
 
-		var/obj/path_or_tool = step.allowed_tools[1]
-		info += "<li>Best performed with \a [istext(path_or_tool) ? "[path_or_tool]" : "[initial(path_or_tool.name)]"].</li>"
-		if(!step.surgery_flags)
+		var/obj/path_or_tool = step.allowed_tools?[1]
+		if(path_or_tool)
+			info += "<li>Best performed with \a [istext(path_or_tool) ? "[path_or_tool]" : "[initial(path_or_tool.name)]"].</li>"
+
+		if(!(step.surgery_flags & ~(SURGERY_CANNOT_FAIL | SURGERY_BLOODY_BODY | SURGERY_BLOODY_GLOVES)))
 			info += "<li>This operation has no requirements."
 		else
 			if(step.surgery_flags & SURGERY_NO_FLESH)

--- a/code/modules/codex/categories/surgery.dm
+++ b/code/modules/codex/categories/surgery.dm
@@ -63,21 +63,21 @@
 
 		var/obj/path_or_tool = step.allowed_tools[1]
 		info += "<li>Best performed with \a [istext(path_or_tool) ? "[path_or_tool]" : "[initial(path_or_tool.name)]"].</li>"
-		if(!step.surgery_candidate_flags)
+		if(!step.surgery_flags)
 			info += "<li>This operation has no requirements."
 		else
-			if(step.surgery_candidate_flags & SURGERY_NO_FLESH)
+			if(step.surgery_flags & SURGERY_NO_FLESH)
 				info += "<li>This operation cannot be performed on organic limbs."
-			else if(step.surgery_candidate_flags & SURGERY_NO_ROBOTIC)
+			else if(step.surgery_flags & SURGERY_NO_ROBOTIC)
 				info += "<li>This operation cannot be performed on robotic limbs."
 
-			if(step.surgery_candidate_flags & SURGERY_NO_STUMP)
+			if(step.surgery_flags & SURGERY_NO_STUMP)
 				info += "<li>This operation cannot be performed on stumps."
-			if(step.surgery_candidate_flags & SURGERY_NEEDS_INCISION)
+			if(step.surgery_flags & SURGERY_NEEDS_INCISION)
 				info += "<li>This operation requires <b>[step.strict_access_requirement ? "exactly" : "atleast"]</b> an [CODEX_LINK("incision", "make incision")] or small cut.</li>"
-			else if(step.surgery_candidate_flags & (SURGERY_NEEDS_RETRACTED|SURGERY_NEEDS_DEENCASEMENT))
+			else if(step.surgery_flags & (SURGERY_NEEDS_RETRACTED|SURGERY_NEEDS_DEENCASEMENT))
 				info += "<li>This operation requires <b>[step.strict_access_requirement ? "exactly" : "atleast"]</b> a [CODEX_LINK("widened incision", "widen incision")] or large cut.</li>"
-			else if(step.surgery_candidate_flags & SURGERY_NEEDS_DEENCASEMENT)
+			else if(step.surgery_flags & SURGERY_NEEDS_DEENCASEMENT)
 				info += "<li>This operation requires the encasing bones to be [CODEX_LINK("broken", "saw through bone")].</li>"
 
 		info += "</ul>"

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -53,7 +53,7 @@
 					G.transfer_blood--
 
 		else if(M.blood_in_hands > 1)
-			old = length(M.return_blood_DNA())
+			old = length(return_blood_DNA())
 			if(add_blood_DNA(M.return_blood_DNA()) && length(return_blood_DNA()) > old)
 				M.blood_in_hands--
 

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -42,19 +42,19 @@
 
 /// Adds the fibers of M to our fiber list.
 /atom/proc/add_fibers(mob/living/carbon/human/M)
-	if(istype(M))
+	if(istype(M) && !isturf(src))
 		var/old = 0
 		if(M.gloves && istype(M.gloves, /obj/item/clothing))
 			var/obj/item/clothing/gloves/G = M.gloves
-			old = length(G.return_blood_DNA())
+			old = length(return_blood_DNA())
 
 			if(G.transfer_blood > 1) //bloodied gloves transfer blood to touched objects
-				if(add_blood_DNA(G.return_blood_DNA()) && length(G.return_blood_DNA()) > old) //only reduces the bloodiness of our gloves if the item wasn't already bloody
+				if(add_blood_DNA(G.return_blood_DNA()) && length(return_blood_DNA()) > old) //only reduces the bloodiness of our gloves if the item wasn't already bloody
 					G.transfer_blood--
 
 		else if(M.blood_in_hands > 1)
 			old = length(M.return_blood_DNA())
-			if(add_blood_DNA(M.return_blood_DNA()) && length(M.return_blood_DNA()) > old)
+			if(add_blood_DNA(M.return_blood_DNA()) && length(return_blood_DNA()) > old)
 				M.blood_in_hands--
 
 	if(isnull(forensics))

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -43,7 +43,6 @@
 /// Adds the fibers of M to our fiber list.
 /atom/proc/add_fibers(mob/living/carbon/human/M)
 	if(istype(M))
-		var/old = 0
 		if(M.gloves && istype(M.gloves, /obj/item/clothing))
 			var/obj/item/clothing/gloves/G = M.gloves
 

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -42,20 +42,16 @@
 
 /// Adds the fibers of M to our fiber list.
 /atom/proc/add_fibers(mob/living/carbon/human/M)
-	if(istype(M) && !isopenturf(src))
+	if(istype(M))
 		var/old = 0
 		if(M.gloves && istype(M.gloves, /obj/item/clothing))
 			var/obj/item/clothing/gloves/G = M.gloves
-			old = length(return_blood_DNA())
 
-			if(G.transfer_blood > 1) //bloodied gloves transfer blood to touched objects
-				if(add_blood_DNA(G.return_blood_DNA()) && length(return_blood_DNA()) > old) //only reduces the bloodiness of our gloves if the item wasn't already bloody
-					G.transfer_blood--
+			if(G.transfer_blood > 1 && add_blood_DNA(G.return_blood_DNA())) //bloodied gloves transfer blood to touched objects
+				G.transfer_blood--
 
-		else if(M.blood_in_hands > 1)
-			old = length(return_blood_DNA())
-			if(add_blood_DNA(M.return_blood_DNA()) && length(return_blood_DNA()) > old)
-				M.blood_in_hands--
+		else if(M.blood_in_hands > 1 && add_blood_DNA(M.return_blood_DNA()))
+			M.blood_in_hands--
 
 	if(isnull(forensics))
 		create_forensics()
@@ -99,6 +95,7 @@
 
 	forensics.add_trace_DNA(dna)
 
+/// Returns TRUE if new blood dna was added.
 /atom/proc/add_blood_DNA(list/dna) //ASSOC LIST DNA = BLOODTYPE
 	return FALSE
 
@@ -109,8 +106,7 @@
 	if(isnull(forensics))
 		create_forensics()
 
-	forensics.add_blood_DNA(dna)
-	return TRUE
+	return forensics.add_blood_DNA(dna)
 
 /obj/item/clothing/gloves/add_blood_DNA(list/blood_dna, list/datum/disease/diseases)
 	. = ..()
@@ -122,8 +118,7 @@
 		B = new /obj/effect/decal/cleanable/blood/splatter(src, diseases)
 
 	if(!QDELETED(B))
-		B.add_blood_DNA(blood_dna) //give blood info to the blood decal.
-		return TRUE //we bloodied the floor
+		return B.add_blood_DNA(blood_dna) //give blood info to the blood decal.
 
 /mob/living/carbon/human/add_blood_DNA(list/blood_dna, list/datum/disease/diseases)
 	return add_blood_DNA_to_items(blood_dna)

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -42,7 +42,7 @@
 
 /// Adds the fibers of M to our fiber list.
 /atom/proc/add_fibers(mob/living/carbon/human/M)
-	if(istype(M) && !isturf(src))
+	if(istype(M) && !isopenturf(src))
 		var/old = 0
 		if(M.gloves && istype(M.gloves, /obj/item/clothing))
 			var/obj/item/clothing/gloves/G = M.gloves

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -126,26 +126,52 @@
 		return TRUE //we bloodied the floor
 
 /mob/living/carbon/human/add_blood_DNA(list/blood_dna, list/datum/disease/diseases)
-	if(wear_suit)
-		wear_suit.add_blood_DNA(blood_dna)
-		update_worn_oversuit()
+	return add_blood_DNA_to_items(blood_dna)
 
-	else if(w_uniform)
-		w_uniform.add_blood_DNA(blood_dna)
-		update_worn_undersuit()
+/// Adds blood DNA to certain slots the mob is wearing
+/mob/living/carbon/human/proc/add_blood_DNA_to_items(
+	list/blood_DNA_to_add,
+	target_flags = ITEM_SLOT_ICLOTHING|ITEM_SLOT_OCLOTHING|ITEM_SLOT_GLOVES|ITEM_SLOT_HEAD|ITEM_SLOT_MASK,
+)
+	if(QDELING(src))
+		return FALSE
 
-	if(gloves)
-		var/obj/item/clothing/gloves/G = gloves
-		G.add_blood_DNA(blood_dna)
+	if(!length(blood_DNA_to_add))
+		return FALSE
 
-	else if(length(blood_dna))
+	// Don't messy up our jumpsuit if we're got a coat
+	if((obscured_slots & HIDEJUMPSUIT) || ((target_flags & ITEM_SLOT_OCLOTHING) && (wear_suit?.body_parts_covered & CHEST)))
+		target_flags &= ~ITEM_SLOT_ICLOTHING
+
+	var/dirty_hands = !!(target_flags & (ITEM_SLOT_GLOVES|ITEM_SLOT_HANDS))
+	var/dirty_feet = !!(target_flags & ITEM_SLOT_FEET)
+	var/slots_to_bloody = target_flags & ~check_obscured_slots()
+	var/list/all_worn = get_equipped_items()
+
+	for(var/obj/item/thing as anything in all_worn)
+		if(thing.slot_flags & slots_to_bloody)
+			thing.add_blood_DNA(blood_DNA_to_add)
+
+		if(thing.body_parts_covered & HANDS)
+			dirty_hands = FALSE
+
+		if(thing.body_parts_covered & FEET)
+			dirty_feet = FALSE
+
+	if(slots_to_bloody & ITEM_SLOT_HANDS)
+		for(var/obj/item/thing in held_items)
+			thing.add_blood_DNA(blood_DNA_to_add)
+
+	if(dirty_hands || dirty_feet || !length(all_worn))
 		if(isnull(forensics))
 			create_forensics()
-		forensics.add_blood_DNA(blood_dna)
+		forensics.add_blood_DNA(blood_DNA_to_add)
 
-	update_worn_gloves() //handles bloody hands overlays and updating
+		if(dirty_hands)
+			blood_in_hands = max(blood_in_hands, rand(2, 4))
+
+	update_clothing(slots_to_bloody)
 	return TRUE
-
 /*
  * Transfer all forensic evidence from [src] to [transfer_to].
  */

--- a/code/modules/grab/grab_datum.dm
+++ b/code/modules/grab/grab_datum.dm
@@ -388,7 +388,7 @@ GLOBAL_LIST_EMPTY(all_grabstates)
 		return FALSE
 
 	if (assailant.incapacitated(IGNORE_GRAB))
-		let_go(G)
+		qdel(G)
 		stack_trace("Someone resisted a grab while the assailant was incapacitated. This shouldn't ever happen.")
 		return TRUE
 
@@ -400,7 +400,7 @@ GLOBAL_LIST_EMPTY(all_grabstates)
 			return FALSE
 		else
 			affecting.visible_message(span_danger("[affecting] has broken free of [assailant]'s grip!"), vision_distance = COMBAT_MESSAGE_RANGE)
-			let_go(G)
+			qdel(G)
 			return TRUE
 
 /datum/grab/proc/size_difference(mob/living/A, mob/living/B)

--- a/code/modules/grab/grabs/grab_normal.dm
+++ b/code/modules/grab/grabs/grab_normal.dm
@@ -125,7 +125,7 @@
 		else
 			if(headbutt(G))
 				if(drop_headbutt)
-					let_go()
+					qdel(G)
 				return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -140,31 +140,6 @@
 	if(istype(O, /obj/item/borg/apparatus/organ_storage))
 		return //Borg organ bags shouldn't be killing brains
 
-	if(damage > 0 && O.is_drainable() && O.reagents.has_reagent(/datum/reagent/medicine/alkysine)) //attempt to heal the brain
-		. = TRUE //don't do attack animation.
-		if(brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
-			to_chat(user, span_warning("[src] is far too damaged, there's nothing else we can do for it!"))
-			return
-
-		if(organ_flags & ORGAN_DEAD)
-			if(!O.reagents.has_reagent(/datum/reagent/medicine/alkysine, 10))
-				to_chat(user, span_warning("There's not enough alkysine in [O] to restore [src]!"))
-				return
-
-		user.visible_message(span_notice("[user] starts to pour the contents of [O] onto [src]."), span_notice("You start to slowly pour the contents of [O] onto [src]."))
-		if(!do_after(user, src, 6 SECONDS))
-			to_chat(user, span_warning("You failed to pour [O] onto [src]!"))
-			return
-
-		if(organ_flags & ORGAN_DEAD)
-			user.visible_message(span_notice("[user] pours the contents of [O] onto [src], causing it to reform its original shape and turn a slightly brighter shade of pink."), span_notice("You pour the contents of [O] onto [src], causing it to reform its original shape and turn a slightly brighter shade of pink."))
-		else
-			user.visible_message(span_notice("[user] pours the contents of [O] onto [src]."))
-		var/healby = O.reagents.get_reagent_amount(/datum/reagent/medicine/alkysine)
-		setOrganDamage(damage - healby*2) //heals 2 damage per unit of alkysine, and by using "setorgandamage", we clear the failing variable if that was up
-		O.reagents.clear_reagents()
-		return
-
 	// Cutting out skill chips.
 	if(length(skillchips) && (O.sharpness & SHARP_EDGED))
 		to_chat(user,span_notice("You begin to excise skillchips from [src]."))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -385,16 +385,27 @@
 /mob/living/carbon/proc/share_blood_on_touch(mob/living/carbon/human/who_touched_us)
 	return
 
+/// Place blood onto us if the toucher has blood on their hands or clothing. messy_slots deteremines what slots to bloody.
 /mob/living/carbon/human/share_blood_on_touch(mob/living/carbon/human/who_touched_us, messy_slots = ITEM_SLOT_ICLOTHING|ITEM_SLOT_OCLOTHING)
 	if(!istype(who_touched_us) || !messy_slots)
 		return
 
+	// Find out what is touching us so we can put blood onto them
+	var/obj/item/clothing/covering_torso = get_item_covering_zone(BODY_ZONE_CHEST)
+	if(covering_torso)
+		who_touched_us.add_blood_DNA_to_items(covering_torso.return_blood_DNA(), ITEM_SLOT_GLOVES)
+	else
+		who_touched_us.add_blood_DNA_to_items(return_blood_DNA(), ITEM_SLOT_GLOVES)
+
+	// Take blood from their hands/gloves
+	var/given_blood = FALSE
 	for(var/obj/item/thing as anything in who_touched_us.get_equipped_items())
 		if((thing.body_parts_covered & HANDS) && prob(thing.blood_DNA_length() * 25))
 			add_blood_DNA_to_items(thing.return_blood_DNA(), messy_slots)
-			return
+			given_blood = TRUE
+			break
 
-	if(prob(who_touched_us.blood_in_hands * who_touched_us.blood_DNA_length() * 10))
+	if(!given_blood && prob(who_touched_us.blood_in_hands * who_touched_us.blood_DNA_length() * 10))
 		add_blood_DNA_to_items(who_touched_us.return_blood_DNA(), messy_slots)
 		who_touched_us.blood_in_hands -= 1
 		who_touched_us.update_worn_gloves()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -382,6 +382,23 @@
 	if(should_stun)
 		Paralyze(60)
 
+/mob/living/carbon/proc/share_blood_on_touch(mob/living/carbon/human/who_touched_us)
+	return
+
+/mob/living/carbon/human/share_blood_on_touch(mob/living/carbon/human/who_touched_us, messy_slots = ITEM_SLOT_ICLOTHING|ITEM_SLOT_OCLOTHING)
+	if(!istype(who_touched_us) || !messy_slots)
+		return
+
+	for(var/obj/item/thing as anything in who_touched_us.get_equipped_items())
+		if((thing.body_parts_covered & HANDS) && prob(thing.blood_DNA_length() * 25))
+			add_blood_DNA_to_items(thing.return_blood_DNA(), messy_slots)
+			return
+
+	if(prob(who_touched_us.blood_in_hands * who_touched_us.blood_DNA_length() * 10))
+		add_blood_DNA_to_items(who_touched_us.return_blood_DNA(), messy_slots)
+		who_touched_us.blood_in_hands -= 1
+		who_touched_us.update_worn_gloves()
+
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/helper)
 	if(on_fire)
 		to_chat(helper, span_warning("You can't put [p_them()] out with just your bare hands!"))
@@ -402,6 +419,8 @@
 						null, span_hear("You hear the rustling of clothes."), DEFAULT_MESSAGE_RANGE, list(helper, src))
 		to_chat(helper, span_notice("You shake [src] trying to pick [p_them()] up!"))
 		to_chat(src, span_notice("[helper] shakes you to get you up!"))
+		share_blood_on_touch(helper, ITEM_SLOT_OCLOTHING | ITEM_SLOT_ICLOTHING)
+
 	else if(deprecise_zone(helper.zone_selected) == BODY_ZONE_HEAD && get_bodypart(BODY_ZONE_HEAD)) //Headpats!
 		helper.visible_message(span_notice("[helper] gives [src] a pat on the head to make [p_them()] feel better!"), \
 					null, span_hear("You hear a soft patter."), DEFAULT_MESSAGE_RANGE, list(helper, src))
@@ -410,6 +429,7 @@
 
 		if(HAS_TRAIT(src, TRAIT_BADTOUCH))
 			to_chat(helper, span_warning("[src] looks visibly upset as you pat [p_them()] on the head."))
+		share_blood_on_touch(helper, ITEM_SLOT_HEAD|ITEM_SLOT_MASK)
 
 	else if ((helper.zone_selected == BODY_ZONE_PRECISE_GROIN) && !isnull(src.getorgan(/obj/item/organ/tail)))
 		helper.visible_message(span_notice("[helper] pulls on [src]'s tail!"), \

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -185,6 +185,7 @@ There are several things that need to be remembered:
 	cut_overlay(bloody_overlay)
 	if(!gloves && blood_in_hands && (num_hands > 0))
 		bloody_overlay = mutable_appearance('icons/effects/blood.dmi', "bloodyhands", -GLOVES_LAYER)
+		bloody_overlay.color = get_blood_dna_color(return_blood_DNA()) || COLOR_HUMAN_BLOOD
 		if(num_hands < 2)
 			if(has_left_hand(FALSE))
 				bloody_overlay.icon_state = "bloodyhands_left"

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -320,7 +320,11 @@
 
 ///Returns an item that is covering a body_zone (BODY_ZONE_CHEST, etc)
 /mob/living/carbon/proc/get_item_covering_zone(zone)
-	zone = body_zone2cover_flags(zone)
+	var/list/zones = body_zone2cover_flags(zone)
+	var/cover_field = NONE
+	for(var/_zone in zones)
+		cover_field |= _zone
+
 	for(var/obj/item/inv_item in get_all_worn_items())
 		if(zone & inv_item.body_parts_covered)
 			return inv_item

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -326,7 +326,7 @@
 		cover_field |= _zone
 
 	for(var/obj/item/inv_item in get_all_worn_items())
-		if(zone & inv_item.body_parts_covered)
+		if(cover_field & inv_item.body_parts_covered)
 			return inv_item
 
 /// Update any visuals relating to an item when it's equipped, unequipped, or it's flags_inv changes.

--- a/code/modules/mob/living/carbon/pain.dm
+++ b/code/modules/mob/living/carbon/pain.dm
@@ -98,7 +98,7 @@
 
 /mob/living/carbon/proc/pain_message(message, amount, ignore_cd)
 	set waitfor = FALSE
-	if(!amount || (stat != CONSCIOUS))
+	if(!amount || (stat != CONSCIOUS) || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		return FALSE
 
 	. = COOLDOWN_FINISHED(src, pain_cd)

--- a/code/modules/surgery/new_surgery/_surgery_step.dm
+++ b/code/modules/surgery/new_surgery/_surgery_step.dm
@@ -135,33 +135,34 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 	if (can_infect)
 		spread_germs(user, affected)
 
-	if(affected && IS_ORGANIC_LIMB(affected) && !istype(tool, /obj/item/reagent_containers))
-		tool.transfer_mob_blood_dna(target)
+	if(affected)
+		if(IS_ORGANIC_LIMB(affected) && !istype(tool, /obj/item/reagent_containers))
+			tool.transfer_mob_blood_dna(target)
 
-	var/mob/living/carbon/human/human_user
-	// Bloody items
-	if(affected && ishuman(user))
-		human_user = user
+		var/mob/living/carbon/human/human_user
+		// Bloody items
+		if(ishuman(user))
+			human_user = user
 
-		if(prob(60) && (affected.bodypart_flags & BP_HAS_BLOOD))
-			if(surgery_flags & SURGERY_BLOODY_BODY)
-				human_user.add_blood_DNA_to_items(target.get_blood_dna_list(), ITEM_SLOT_GLOVES|ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
+			if(prob(60) && (affected.bodypart_flags & BP_HAS_BLOOD))
+				if(surgery_flags & SURGERY_BLOODY_BODY)
+					human_user.add_blood_DNA_to_items(target.get_blood_dna_list(), ITEM_SLOT_GLOVES|ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
 
-			else if(surgery_flags & SURGERY_BLOODY_GLOVES)
-				human_user.add_blood_DNA_to_items(target.get_blood_dna_list(), ITEM_SLOT_GLOVES)
+				else if(surgery_flags & SURGERY_BLOODY_GLOVES)
+					human_user.add_blood_DNA_to_items(target.get_blood_dna_list(), ITEM_SLOT_GLOVES)
 
-	// Transmit diseases if no gloves.
-	if(IS_ORGANIC_LIMB(affected) && !human_user?.gloves)
-		for(var/datum/disease/D as anything in user.diseases)
-			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
-				target.ContactContractDisease(D)
+		// Transmit diseases if no gloves.
+		if(IS_ORGANIC_LIMB(affected) && !human_user?.gloves)
+			for(var/datum/disease/D as anything in user.diseases)
+				if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
+					target.ContactContractDisease(D)
 
-		for(var/datum/disease/D as anything in target.diseases)
-			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
-				user.ContactContractDisease(D)
+			for(var/datum/disease/D as anything in target.diseases)
+				if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
+					user.ContactContractDisease(D)
 
-	if(affected && pain_given && !(affected.bodypart_flags & BP_NO_PAIN) && target.stat == CONSCIOUS)
-		target.apply_pain(pain_given, affected.body_zone, ignore_cd = TRUE)
+		if(pain_given && !(affected.bodypart_flags & BP_NO_PAIN) && target.stat == CONSCIOUS)
+			target.apply_pain(pain_given, affected.body_zone, ignore_cd = TRUE)
 
 	if (target.stat == UNCONSCIOUS && prob(20))
 		to_chat(target, span_boldnotice("... [pick("bright light", "faraway pain", "something moving in you", "soft beeping")] ..."))

--- a/code/modules/surgery/new_surgery/_surgery_step.dm
+++ b/code/modules/surgery/new_surgery/_surgery_step.dm
@@ -377,8 +377,11 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 			return
 
 		// It's a surprise tool that'll help us later
+		#ifndef UNIT_TESTS
 		var/datum/roll_result/result = user.stat_roll(6, /datum/rpg_skill/handicraft, roll_modifier)
-
+		#else
+		var/datum/roll_result/result = GLOB.success_roll
+		#endif
 		var/duration = rand(step.min_duration, step.max_duration)
 
 		if(do_after(user, target, duration, DO_PUBLIC, extra_checks = sanity_check_callback, display = src))

--- a/code/modules/surgery/new_surgery/_surgery_step.dm
+++ b/code/modules/surgery/new_surgery/_surgery_step.dm
@@ -22,14 +22,12 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 	var/max_duration = 0
 	/// evil infection stuff that will make everyone hate me
 	var/can_infect = 0
-	/// How much blood this step can get on surgeon. 1 - hands, 2 - full body.
-	var/blood_level = 0                  // How much blood this step can get on surgeon. 1 - hands, 2 - full body.
 	/// How much pain to deliver to the patient
 	var/pain_given =0
 	/// if this step NEEDS stable optable or can be done on any valid surface with no penalty
 	var/delicate = 0
 	/// Various bitflags for requirements of the surgery.
-	var/surgery_candidate_flags = 0      // Various bitflags for requirements of the surgery.
+	var/surgery_flags = 0      // Various bitflags for requirements of the surgery.
 	/// Whether or not this surgery will be fuzzy on size requirements.
 	var/strict_access_requirement = TRUE
 	/// Does this step attempt to repeat itself after every success?
@@ -43,6 +41,13 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 	var/failure_sound
 
 
+/datum/surgery_step/New()
+	. = ..()
+	#ifdef UNIT_TESTS
+	min_duration = 0
+	max_duration = 0
+	#endif
+
 /// Returns how well tool is suited for this step
 /datum/surgery_step/proc/tool_potency(obj/item/tool)
 	if(tool.tool_behaviour)
@@ -53,6 +58,7 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 	for (var/T in allowed_tools)
 		if (istype(tool,T))
 			return allowed_tools[T]
+
 	return 0
 
 /// Checks if the target is valid.
@@ -68,6 +74,7 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 
 /// Checks if this surgery step can be performed with the given parameters.
 /datum/surgery_step/proc/can_operate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	SHOULD_CALL_PARENT(TRUE)
 	return is_valid_target(target) && assess_bodypart(user, target, target_zone, tool)
 
 /datum/surgery_step/proc/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -79,27 +86,27 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 		return FALSE
 
 	// Check various conditional flags.
-	if(((surgery_candidate_flags & SURGERY_NO_ROBOTIC) && !IS_ORGANIC_LIMB(affected)) || \
-		((surgery_candidate_flags & SURGERY_NO_STUMP) && affected.is_stump)         || \
-		((surgery_candidate_flags & SURGERY_NO_FLESH) && (IS_ORGANIC_LIMB(affected))))
+	if(((surgery_flags & SURGERY_NO_ROBOTIC) && !IS_ORGANIC_LIMB(affected)) || \
+		((surgery_flags & SURGERY_NO_STUMP) && affected.is_stump)         || \
+		((surgery_flags & SURGERY_NO_FLESH) && (IS_ORGANIC_LIMB(affected))))
 		return FALSE
 
 	// Check if the surgery target is accessible.
 	if(!IS_ORGANIC_LIMB(affected))
-		if(((surgery_candidate_flags & SURGERY_NEEDS_DEENCASEMENT) || \
-			(surgery_candidate_flags & SURGERY_NEEDS_INCISION)      || \
-			(surgery_candidate_flags & SURGERY_NEEDS_RETRACTED))    && \
+		if(((surgery_flags & SURGERY_NEEDS_DEENCASEMENT) || \
+			(surgery_flags & SURGERY_NEEDS_INCISION)      || \
+			(surgery_flags & SURGERY_NEEDS_RETRACTED))    && \
 			affected.hatch_state != HATCH_OPENED)
 			return FALSE
 	else
 		var/open_threshold = 0
-		if(surgery_candidate_flags & SURGERY_NEEDS_INCISION)
+		if(surgery_flags & SURGERY_NEEDS_INCISION)
 			open_threshold = SURGERY_OPEN
 
-		else if(surgery_candidate_flags & SURGERY_NEEDS_RETRACTED)
+		else if(surgery_flags & SURGERY_NEEDS_RETRACTED)
 			open_threshold = SURGERY_RETRACTED
 
-		else if(surgery_candidate_flags & SURGERY_NEEDS_DEENCASEMENT)
+		else if(surgery_flags & SURGERY_NEEDS_DEENCASEMENT)
 			open_threshold = (affected.encased ? SURGERY_DEENCASED : SURGERY_RETRACTED)
 
 		if(open_threshold && ((strict_access_requirement && affected.how_open() != open_threshold) || \
@@ -128,25 +135,32 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 	if (can_infect)
 		spread_germs(user, affected)
 
-	if(user && affected)
-		if(ishuman(user) && prob(60) && (affected.bodypart_flags & BP_HAS_BLOOD))
-			var/mob/living/carbon/human/H = user
-			if (blood_level)
-				H.blood_in_hands = blood_level
+	if(IS_ORGANIC_LIMB(affected) && !istype(tool, /obj/item/reagent_containers))
+		tool.transfer_mob_blood_dna(target)
 
-			if (blood_level > 1)
-				user.add_mob_blood(target)
+	var/mob/living/carbon/human/human_user
+	// Bloody items
+	if(ishuman(user))
+		human_user = user
 
-		if((ishuman(user) && user:gloves) && IS_ORGANIC_LIMB(affected))
-			for(var/datum/disease/D as anything in user.diseases)
-				if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
-					target.ContactContractDisease(D)
+		if(prob(60) && (affected.bodypart_flags & BP_HAS_BLOOD))
+			if(surgery_flags & SURGERY_BLOODY_BODY)
+				human_user.add_blood_DNA_to_items(target.get_blood_dna_list(), ITEM_SLOT_GLOVES|ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
 
-			for(var/datum/disease/D as anything in target.diseases)
-				if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
-					user.ContactContractDisease(D)
+			else if(surgery_flags & SURGERY_BLOODY_GLOVES)
+				human_user.add_blood_DNA_to_items(target.get_blood_dna_list(), ITEM_SLOT_GLOVES)
 
-	if(pain_given && !(HAS_TRAIT(target, TRAIT_NO_PAINSHOCK) || HAS_TRAIT(target, TRAIT_FAKEDEATH)) && !(affected.bodypart_flags & BP_NO_PAIN))
+	// Transmit diseases if no gloves.
+	if(IS_ORGANIC_LIMB(affected) && !human_user?.gloves)
+		for(var/datum/disease/D as anything in user.diseases)
+			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
+				target.ContactContractDisease(D)
+
+		for(var/datum/disease/D as anything in target.diseases)
+			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
+				user.ContactContractDisease(D)
+
+	if(pain_given && !(affected.bodypart_flags & BP_NO_PAIN) && target.stat == CONSCIOUS)
 		target.apply_pain(pain_given, affected.body_zone, ignore_cd = TRUE)
 
 	if (target.stat == UNCONSCIOUS && prob(20))
@@ -156,6 +170,7 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 // Does stuff to end the step, which is normally print a message + do whatever this step changes
 /datum/surgery_step/proc/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	SHOULD_CALL_PARENT(TRUE)
+	tool.handle_post_surgery()
 	if(!success_sound)
 		return
 	playsound(get_turf(target), success_sound, 75, TRUE, falloff_exponent = 12, falloff_distance = 1)
@@ -170,36 +185,36 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 
 
 /// The chance for success vs failure
-/datum/surgery_step/proc/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
-	. = tool_potency(tool)
-	if(user == target)
-		. -= 10
+/datum/surgery_step/proc/success_modifier(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
+	var/potency = tool_potency(tool)
+	if(potency == 0)
+		return 0
 
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		. -= round(H.shock_stage / 2)
-		if(H.eye_blurry)
-			. -= 20
-		if(H.eye_blind)
-			. -= 60
+	var/modifier = 0
+	if(prob(100 - potency))
+		modifier -= 4
+
+	if(user == target)
+		modifier -= 1
+
+	var/turf/T = get_turf(target)
+	var/has_op_table = locate(/obj/structure/table/optable, T)
+	if(has_op_table)
+		modifier += 2
 
 	if(delicate)
-		if(user.has_status_effect(/datum/status_effect/speech/slurring/drunk))
-			. -= 10
 		if(target.body_position == STANDING_UP)
-			. -= 30
-		var/turf/T = get_turf(target)
+			. -= 2
 
-		if(locate(/obj/structure/table/optable, T))
-			. -= 0
-		else if(locate(/obj/structure/bed, T))
-			. -= 5
-		else if(locate(/obj/structure/table, T))
-			. -= 10
-		else if(locate(/obj/effect/rune, T))
-			. -= 10
-
-	. = max(., 0)
+		if(!has_op_table)
+			if(locate(/obj/structure/bed, T))
+				modifier += 1
+			else if(locate(/obj/structure/table, T))
+				modifier += 1
+			else if(locate(/obj/effect/rune, T))
+				modifier -= 1
+			else
+				modifier -= 3
 
 /datum/surgery_step/proc/play_preop_sound(mob/user, mob/living/carbon/target, target_zone, obj/item/tool)
 	if(!preop_sound)
@@ -238,22 +253,47 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 
 	BP.germ_level = germ_level //as funny as scrubbing microbes out with clean gloves is - no.
 
+/// Can a mob perform surgery with this item. Step is optional.
+/obj/item/proc/surgery_sanity_check(mob/living/carbon/target, mob/living/user, datum/surgery_step/step, target_zone)
+	if(!istype(target))
+		return FALSE
+
+	if(QDELETED(target) || QDELETED(user))
+		return FALSE
+
+	if(user.combat_mode)
+		return FALSE
+
+	if(user.get_active_held_item() != src)
+		return FALSE
+
+	if(!user.can_perform_surgery_on(target))
+		return FALSE
+
+	if(step && !step.can_operate(user, target, target_zone, src))
+		return FALSE
+
+	return TRUE
+
 /// Attempt to perform a surgery step.
-/obj/item/proc/attempt_surgery(mob/living/carbon/M, mob/living/user)
+/obj/item/proc/attempt_surgery(mob/living/carbon/target, mob/living/user)
 	// Check for the Hippocratic oath.
-	if(!istype(M) || user.combat_mode || GLOB.surgery_tool_exceptions[type])
+	if(GLOB.surgery_tool_exceptions[type])
+		return FALSE
+
+	if(!surgery_sanity_check(target, user))
 		return FALSE
 
 	// Check for multi-surgery drifting.
 	var/zone = deprecise_zone(user.zone_selected)
-	if(LAZYACCESS(M.surgeries_in_progress, zone))
+	if(LAZYACCESS(target.surgeries_in_progress, zone))
 		to_chat(user, span_warning("You can't operate on this area while surgery is already in progress."))
 		return TRUE
 
 	// What surgeries does our tool/target enable?
 	var/list/possible_surgeries
 	for(var/datum/surgery_step/step in GLOB.surgeries_list)
-		if(step.tool_potency(src) && step.can_operate(user, M, zone, src))
+		if(step.tool_potency(src) && step.can_operate(user, target, zone, src))
 			LAZYSET(possible_surgeries, step, TRUE)
 
 	// Which surgery, if any, do we actually want to do?
@@ -285,75 +325,85 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 	if(!istype(step))
 		return FALSE
 
-	var/obj/item/bodypart/BP = M.get_bodypart(zone)
+	// The step selector contains an input, so we need to check again after.
+	if(!surgery_sanity_check(target, user, step, zone))
+		return TRUE
+
+	var/obj/item/bodypart/BP = target.get_bodypart(zone)
 	if(BP?.bandage)
 		to_chat(user, span_warning("You cannot operate on a bandaged bodypart, remove it!"))
 		return TRUE
 
-	if(M == user)
+	if(target == user)
 		if(user.zone_selected == BODY_ZONE_HEAD)
 			to_chat(user, span_warning("You cannot operate on your own head!"))
 			return TRUE
+
 		var/hand = user.get_active_hand().body_zone
 		if(user.zone_selected == hand)
 			to_chat(src, span_warning("You cannot operate on that arm with that hand!"))
 			return TRUE
 
-	// Otherwise we can make a start on surgery!
-	do_it_all_again:
-	if(istype(M) && !QDELETED(M) && !user.combat_mode && (user.get_active_held_item() == src))
+	perform_surgery(target, user, step, zone)
+	return TRUE
+
+/obj/item/proc/perform_surgery(mob/living/carbon/target, mob/living/user, datum/surgery_step/step, zone)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	PRIVATE_PROC(TRUE) // Should not be called from anywhere besides attempt_surgery()
+
+	var/datum/callback/sanity_check_callback = CALLBACK(src, PROC_REF(surgery_sanity_check), target, user)
+	var/can_loop = FALSE
+
+	do
+		if(!surgery_sanity_check(target, user, step, zone))
+			return
+
 		// Double-check this in case it changed between initial check and now.
-		if(zone in M.surgeries_in_progress)
+		if(zone in target.surgeries_in_progress)
 			to_chat(user, span_warning("You can't operate on this area while surgery is already in progress."))
+			return
 
-		else if(step.can_operate(user, M, zone, src))
+		var/operation_data = step.pre_surgery_step(user, target, zone, src)
+		if(!operation_data) // Surgery step recognized but failed for some reason
+			return
 
-			var/operation_data = step.pre_surgery_step(user, M, zone, src)
+		LAZYSET(target.surgeries_in_progress, zone, operation_data)
 
-			if(!operation_data) // Surgery step recognized but failed for some reason, terminate attack chain.
-				return TRUE
+		step.begin_step(user, target, zone, src)
 
-			LAZYSET(M.surgeries_in_progress, zone, operation_data)
+		var/roll_modifier = step.success_modifier(user, target, src, zone)
+		if(roll_modifier == -INFINITY)
+			return
 
-			step.begin_step(user, M, zone, src)
+		// It's a surprise tool that'll help us later
+		var/datum/roll_result/result = user.stat_roll(6, /datum/rpg_skill/handicraft, roll_modifier)
 
-			var/can_loop = FALSE
-			#ifndef UNIT_TESTS
-			var/duration = rand(step.min_duration, step.max_duration)
-			#else
-			var/duration = 0
-			#endif
-			if(do_after(user, M, duration, DO_PUBLIC, display = src))
-				if (step.can_operate(user, M, zone, src))
-					if(prob(step.success_chance(user, M, src, zone)))
-						step.succeed_step(user, M, zone, src)
-						handle_post_surgery()
-						can_loop = TRUE
-					else
-						step.fail_step(user, M, zone, src)
+		var/duration = rand(step.min_duration, step.max_duration)
+
+		if(do_after(user, target, duration, DO_PUBLIC, extra_checks = sanity_check_callback, display = src))
+			switch(result.outcome)
+				if(SUCCESS, CRIT_SUCCESS)
+					step.succeed_step(user, target, zone, src)
+					can_loop = TRUE
 				else
-					to_chat(user, span_warning("The patient lost the target organ before you could finish operating!"))
+					step.fail_step(user, target, zone, src)
 
-			else
-				step.fail_step(user, M, zone, src)
+		else if(!(QDELING(user) || QDELING(target) || QDELING(src)))
+			step.fail_step(user, target, zone, src)
 
-			if(!QDELETED(M))
-				LAZYREMOVE(M.surgeries_in_progress, zone) // Clear the in-progress flag.
-				/*if(ishuman(M))
-					var/mob/living/carbon/human/H = M
-					H.update_surgery()*/
+		if(!QDELETED(target))
+			LAZYREMOVE(target.surgeries_in_progress, zone) // Clear the in-progress flag.
+			/*if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				H.update_surgery()*/
 
-			if(step.looping && can_loop)
-				goto do_it_all_again
+	while(step.looping && can_loop)
 
-		return TRUE
-	return FALSE
-
-/obj/item/proc/handle_post_surgery()
+/obj/item/proc/handle_post_surgery(mob/living/user, mob/living/carbon/human/target)
 	use(1)
 	return
 
-/mob/proc/can_operate_on(mob/living/target)
+/mob/proc/can_perform_surgery_on(mob/living/target)
 	var/turf/T = get_turf(target)
 
 	if(target.body_position == LYING_DOWN)
@@ -365,7 +415,9 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 	else if(locate(/obj/effect/rune, T))
 		. = TRUE
 
-/mob/living/can_operate_on(mob/living/target, silent)
+	return . || FALSE
+
+/mob/living/can_perform_surgery_on(mob/living/target, silent)
 	if(combat_mode)
 		return FALSE
 	return ..()

--- a/code/modules/surgery/new_surgery/_surgery_step.dm
+++ b/code/modules/surgery/new_surgery/_surgery_step.dm
@@ -135,12 +135,12 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 	if (can_infect)
 		spread_germs(user, affected)
 
-	if(IS_ORGANIC_LIMB(affected) && !istype(tool, /obj/item/reagent_containers))
+	if(affected && IS_ORGANIC_LIMB(affected) && !istype(tool, /obj/item/reagent_containers))
 		tool.transfer_mob_blood_dna(target)
 
 	var/mob/living/carbon/human/human_user
 	// Bloody items
-	if(ishuman(user))
+	if(affected && ishuman(user))
 		human_user = user
 
 		if(prob(60) && (affected.bodypart_flags & BP_HAS_BLOOD))
@@ -160,7 +160,7 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
 				user.ContactContractDisease(D)
 
-	if(pain_given && !(affected.bodypart_flags & BP_NO_PAIN) && target.stat == CONSCIOUS)
+	if(affected && pain_given && !(affected.bodypart_flags & BP_NO_PAIN) && target.stat == CONSCIOUS)
 		target.apply_pain(pain_given, affected.body_zone, ignore_cd = TRUE)
 
 	if (target.stat == UNCONSCIOUS && prob(20))

--- a/code/modules/surgery/new_surgery/_surgery_step.dm
+++ b/code/modules/surgery/new_surgery/_surgery_step.dm
@@ -187,9 +187,13 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, typecacheof(list(
 
 /// The chance for success vs failure
 /datum/surgery_step/proc/success_modifier(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
+	SHOULD_CALL_PARENT(TRUE)
 	var/potency = tool_potency(tool)
 	if(potency == 0)
 		return 0
+
+	if(surgery_flags & SURGERY_CANNOT_FAIL)
+		return 100
 
 	var/modifier = 0
 	if(prob(100 - potency))

--- a/code/modules/surgery/new_surgery/bones.dm
+++ b/code/modules/surgery/new_surgery/bones.dm
@@ -28,9 +28,9 @@
 
 	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in [target]'s [affected.name]"
 	if(affected.encased == "skull")
-		user.visible_message(span_notice("[user] begins to piece [bone] back together with [tool]."))
+		user.visible_message(span_notice("[user] begins to piece [bone] back together with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	else
-		user.visible_message(span_notice("[user] begins to set [bone] in place with [tool]."))
+		user.visible_message(span_notice("[user] begins to set [bone] in place with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/bone/set_bone/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -40,12 +40,12 @@
 
 	if (affected.check_bones() & CHECKBONES_BROKEN)
 		if(affected.encased == "skull")
-			user.visible_message(span_notice("[user] pieces [bone] back together with [tool]."))
+			user.visible_message(span_notice("[user] pieces [bone] back together with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 		else
-			user.visible_message(span_notice("[user] sets [bone] in place with [tool]."))
+			user.visible_message(span_notice("[user] sets [bone] in place with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 		affected.stage = 1
 	else
-		user.visible_message("[span_notice("[user] sets [bone]")] [span_warning("in the WRONG place with [tool].")]")
+		user.visible_message("[span_notice("[user] sets [bone]")] [span_warning("in the WRONG place with [tool].")]", vision_distance = COMBAT_MESSAGE_RANGE)
 		affected.break_bones()
 	..()
 
@@ -85,17 +85,17 @@
 /datum/surgery_step/bone/finish/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
 	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in \the [target]'s [affected.name]"
-	user.visible_message(span_notice("[user] starts to finish mending [bone] with \the [tool]."))
+	user.visible_message(span_notice("[user] starts to finish mending [bone] with \the [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/bone/finish/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
 	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in [target]'s [affected.name]"
-	user.visible_message(span_notice("[user] has mended [bone] with [tool]."))
+	user.visible_message(span_notice("[user] has mended [bone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.heal_bones()
 	..()
 
 /datum/surgery_step/bone/finish/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!"))
+	user.visible_message(span_warning("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()

--- a/code/modules/surgery/new_surgery/bones.dm
+++ b/code/modules/surgery/new_surgery/bones.dm
@@ -4,7 +4,7 @@
 //////////////////////////////////////////////////////////////////
 
 /datum/surgery_step/bone
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NEEDS_RETRACTED
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NEEDS_RETRACTED
 	abstract_type = /datum/surgery_step/bone
 	strict_access_requirement = FALSE
 
@@ -63,13 +63,16 @@
 /datum/surgery_step/bone/finish
 	name = "Repair bone"
 	desc = "Mends a broken bone."
+
+	surgery_flags = parent_type::surgery_flags | SURGERY_BLOODY_GLOVES
+
 	allowed_tools = list(
 		/obj/item/stack/medical/bone_gel = 100,
 		/obj/item/stack/sticky_tape/surgical = 100,
 		/obj/item/stack/sticky_tape = 75
 	)
+
 	can_infect = 1
-	blood_level = 1
 	min_duration = 2 SECONDS
 	max_duration = 3 SECONDS
 	pain_given =20

--- a/code/modules/surgery/new_surgery/brain_trauma.dm
+++ b/code/modules/surgery/new_surgery/brain_trauma.dm
@@ -23,7 +23,7 @@
 
 /datum/surgery_step/brain_trauma/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	. = ..()
-	user.visible_message(span_notice("[user] begins to repair [target]'s brain."))
+	user.visible_message(span_notice("[user] begins to repair [target]'s brain."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 /datum/surgery_step/brain_trauma/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/brain/brain = target.getorganslot(ORGAN_SLOT_BRAIN)
@@ -40,10 +40,10 @@
 /datum/surgery_step/brain_trauma/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	. = ..()
 	if(target.getorganslot(ORGAN_SLOT_BRAIN))
-		user.visible_message(span_warning("[user] screws up, scraping [target]'s brain!"))
+		user.visible_message(span_warning("[user] screws up, scraping [target]'s brain!"), vision_distance = COMBAT_MESSAGE_RANGE)
 		if(target.stat < UNCONSCIOUS)
 			to_chat(target, span_userdanger("Your head throbs with horrible pain; thinking hurts!"))
 		target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 60)
 		target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_SURGERY)
 	else
-		user.visible_message(span_warning("[user] suddenly notices that the brain [user.p_they()] [user.p_were()] working on is not there anymore."))
+		user.visible_message(span_warning("[user] suddenly notices that the brain [user.p_they()] [user.p_were()] working on is not there anymore."), vision_distance = COMBAT_MESSAGE_RANGE)

--- a/code/modules/surgery/new_surgery/brain_trauma.dm
+++ b/code/modules/surgery/new_surgery/brain_trauma.dm
@@ -1,7 +1,7 @@
 /datum/surgery_step/brain_trauma
 	name = "Repair brain trauma"
 	desc = "Repairs physiological and psychological damage to a patient's brain."
-	surgery_candidate_flags = SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NEEDS_DEENCASEMENT
 	allowed_tools = list(
 		TOOL_HEMOSTAT = 85,
 		TOOL_SCREWDRIVER = 35

--- a/code/modules/surgery/new_surgery/cavity.dm
+++ b/code/modules/surgery/new_surgery/cavity.dm
@@ -10,7 +10,7 @@
 /datum/surgery_step/cavity
 	pain_given =40
 	delicate = 1
-	surgery_candidate_flags = SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
 	abstract_type = /datum/surgery_step/cavity
 
 /datum/surgery_step/cavity/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/new_surgery/cavity.dm
+++ b/code/modules/surgery/new_surgery/cavity.dm
@@ -15,8 +15,11 @@
 
 /datum/surgery_step/cavity/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!"), \
-	span_warning("Your hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!"))
+	user.visible_message(
+		span_warning("[user]'s hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!"),
+		span_warning("Your hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!"),
+		vision_distance = COMBAT_MESSAGE_RANGE
+	)
 	affected.receive_damage(20, sharpness = SHARP_EDGED|SHARP_POINTY)
 	..()
 
@@ -41,12 +44,12 @@
 
 /datum/surgery_step/cavity/make_space/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts making some space inside [target]'s [affected.cavity_name] cavity with [tool]."))
+	user.visible_message(span_notice("[user] starts making some space inside [target]'s [affected.cavity_name] cavity with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/cavity/make_space/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] makes some space inside [target]'s [affected.cavity_name] cavity with [tool]."))
+	user.visible_message(span_notice("[user] makes some space inside [target]'s [affected.cavity_name] cavity with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.cavity = TRUE
 	..()
 
@@ -75,13 +78,13 @@
 
 /datum/surgery_step/cavity/close_space/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts mending [target]'s [affected.cavity_name] cavity wall with [tool]."))
+	user.visible_message(span_notice("[user] starts mending [target]'s [affected.cavity_name] cavity wall with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	..()
 
 /datum/surgery_step/cavity/close_space/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] mends [target]'s [affected.cavity_name] cavity walls with [tool]."))
+	user.visible_message(span_notice("[user] mends [target]'s [affected.cavity_name] cavity walls with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.cavity = FALSE
 	..()
 
@@ -130,7 +133,7 @@
 
 /datum/surgery_step/cavity/place_item/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts putting [tool] inside [target]'s [affected.cavity_name] cavity."))
+	user.visible_message(span_notice("[user] starts putting [tool] inside [target]'s [affected.cavity_name] cavity."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	playsound(target.loc, 'sound/effects/squelch1.ogg', 25, 1)
 	..()
@@ -141,7 +144,7 @@
 		return
 	affected.add_cavity_item(tool)
 
-	user.visible_message(span_notice("[user] puts \the [tool] inside [target]'s [affected.cavity_name] cavity."))
+	user.visible_message(span_notice("[user] puts \the [tool] inside [target]'s [affected.cavity_name] cavity."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	if (tool.w_class == affected.cavity_storage_max_weight && prob(50) && IS_ORGANIC_LIMB(affected) && affected.set_sever_artery(TRUE))
 		to_chat(user, span_warning("You tear some blood vessels trying to fit such a big object in this cavity."))
@@ -174,7 +177,7 @@
 
 /datum/surgery_step/cavity/implant_removal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts poking around inside [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] starts poking around inside [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/cavity/implant_removal/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -213,7 +216,7 @@
 			find_prob +=50
 
 		if (prob(find_prob))
-			user.visible_message(span_notice("[user] takes something out of incision on [target]'s [affected.plaintext_zone] with [tool]."))
+			user.visible_message(span_notice("[user] takes something out of incision on [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 			if(istype(obj, /obj/item/implant))
 				var/obj/item/implant/I = obj
 				I.removed(target)
@@ -226,13 +229,15 @@
 		else
 			user.visible_message(
 				span_notice("[user] removes [tool] from [target]'s [affected.plaintext_zone]."),
-				span_notice("There's something inside [target]'s [affected.plaintext_zone], but you just missed it this time.")
+				span_notice("There's something inside [target]'s [affected.plaintext_zone], but you just missed it this time."),
+				vision_distance = COMBAT_MESSAGE_RANGE
 			)
 
 	else
 		user.visible_message(
 			span_notice("[user] could not find anything inside [target]'s [affected.name], and pulls [tool] out."),
-			span_notice("You could not find anything inside [target]'s [affected.name].")
+			span_notice("You could not find anything inside [target]'s [affected.name]."),
+			vision_distance = COMBAT_MESSAGE_RANGE
 		)
 	..()
 
@@ -243,7 +248,7 @@
 		var/fail_prob = 10
 		fail_prob += 100 - tool_potency(tool)
 		if (prob(fail_prob))
-			user.visible_message(span_warning("Something beeps inside [target]'s [affected.name]!"))
+			user.visible_message(span_warning("Something beeps inside [target]'s [affected.name]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 			playsound(imp.loc, 'sound/items/countdown.ogg', 75, 1, -3)
 			spawn(25)
 				imp.activate()

--- a/code/modules/surgery/new_surgery/dental_implant.dm
+++ b/code/modules/surgery/new_surgery/dental_implant.dm
@@ -10,7 +10,7 @@
 
 /datum/surgery_step/insert_pill/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	. = ..()
-	user.visible_message(span_notice("[user] begins inserting [tool] into [target]'s tooth."))
+	user.visible_message(span_notice("[user] begins inserting [tool] into [target]'s tooth."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 /datum/surgery_step/insert_pill/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!istype(tool, /obj/item/reagent_containers/pill)) //what
@@ -24,7 +24,7 @@
 	pill_action.target = tool
 	pill_action.Grant(target) //The pill never actually goes in an inventory slot, so the owner doesn't inherit actions from it
 
-	user.visible_message(span_notice("[user] inserts [tool] into [target]'s tooth."))
+	user.visible_message(span_notice("[user] inserts [tool] into [target]'s tooth."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/insert_pill/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -33,7 +33,7 @@
 
 	var/obj/item/reagent_containers/pill/pill = tool
 	pill.on_consumption(target, user)
-	user.visible_message(span_warning("[pill] slips out of [user]'s hand, right down [target]'s throat!"))
+	user.visible_message(span_warning("[pill] slips out of [user]'s hand, right down [target]'s throat!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/action/item_action/hands_free/activate_pill

--- a/code/modules/surgery/new_surgery/dental_implant.dm
+++ b/code/modules/surgery/new_surgery/dental_implant.dm
@@ -6,7 +6,7 @@
 	)
 	min_duration = 1 SECOND
 	max_duration = 3 SECONDS
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
 
 /datum/surgery_step/insert_pill/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	. = ..()

--- a/code/modules/surgery/new_surgery/generic_organic.dm
+++ b/code/modules/surgery/new_surgery/generic_organic.dm
@@ -28,13 +28,13 @@
 
 /datum/surgery_step/generic_organic/laser_incise/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts the bloodless incision on [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] starts the bloodless incision on [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	return ..()
 
 /datum/surgery_step/generic_organic/laser_incise/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] has made a bloodless incision on [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] has made a bloodless incision on [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.create_wound(WOUND_CUT, affected.minimum_break_damage/2, TRUE)
 	affected.clamp_wounds()
 	//spread_germs_to_organ(affected, user)
@@ -42,7 +42,7 @@
 
 /datum/surgery_step/generic_organic/laser_incise/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips as the blade sputters, searing a long gash in [target]'s [affected.plaintext_zone] with [tool]!"))
+	user.visible_message(span_warning("[user]'s hand slips as the blade sputters, searing a long gash in [target]'s [affected.plaintext_zone] with [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.receive_damage(15, 5, sharpness = SHARP_EDGED|SHARP_POINTY)
 	..()
 
@@ -78,19 +78,19 @@
 
 /datum/surgery_step/generic_organic/incise/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts [access_string] on [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] starts [access_string] on [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/generic_organic/incise/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] has made [access_string] on [target]'s [affected.plaintext_zone] with  [tool]."))
+	user.visible_message(span_notice("[user] has made [access_string] on [target]'s [affected.plaintext_zone] with  [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.create_wound(WOUND_CUT, affected.minimum_break_damage/2, TRUE)
 	playsound(target.loc, 'sound/weapons/bladeslice.ogg', 15, 1)
 	..()
 
 /datum/surgery_step/generic_organic/incise/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, [fail_string] \the [target]'s [affected.plaintext_zone] in the wrong place with [tool]!"))
+	user.visible_message(span_warning("[user]'s hand slips, [fail_string] \the [target]'s [affected.plaintext_zone] in the wrong place with [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.receive_damage(10, sharpness = SHARP_EDGED|SHARP_POINTY)
 	..()
 
@@ -118,12 +118,12 @@
 
 /datum/surgery_step/generic_organic/clamp_bleeders/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts clamping bleeders in [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] starts clamping bleeders in [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/generic_organic/clamp_bleeders/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] clamps bleeders in [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] clamps bleeders in [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.clamp_wounds()
 	//spread_germs_to_organ(affected, user)
 	..()
@@ -160,18 +160,18 @@
 
 /datum/surgery_step/generic_organic/retract_skin/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts to pry open the incision on [target]'s [affected.plaintext_zone] with \the [tool]."))
+	user.visible_message(span_notice("[user] starts to pry open the incision on [target]'s [affected.plaintext_zone] with \the [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/generic_organic/retract_skin/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] keeps the incision open on [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] keeps the incision open on [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.open_incision()
 	..()
 
 /datum/surgery_step/generic_organic/retract_skin/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, tearing the edges of the incision on [target]'s [affected.plaintext_zone] with [tool]!"))
+	user.visible_message(span_warning("[user]'s hand slips, tearing the edges of the incision on [target]'s [affected.plaintext_zone] with [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.receive_damage(12, sharpness = SHARP_EDGED|SHARP_POINTY)
 	..()
 
@@ -222,13 +222,13 @@
 /datum/surgery_step/generic_organic/cauterize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
 	var/datum/wound/W = affected.get_incision()
-	user.visible_message(span_notice("[user] begins to [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] begins to [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/generic_organic/cauterize/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
 	var/datum/wound/W = affected.get_incision()
-	user.visible_message(span_notice("[user] [post_cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] [post_cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	if(istype(W))
 		W.close_wound()
@@ -242,7 +242,7 @@
 
 /datum/surgery_step/generic_organic/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, damaging [target]'s [affected.plaintext_zone] with [tool]!"))
+	user.visible_message(span_warning("[user]'s hand slips, damaging [target]'s [affected.plaintext_zone] with [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.receive_damage(0, 3)
 	..()
 
@@ -281,18 +281,18 @@
 
 /datum/surgery_step/generic_organic/amputate/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone, TRUE)
-	user.visible_message(span_notice("[user] begins to amputate [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] begins to amputate [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/generic_organic/amputate/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone, TRUE)
-	user.visible_message(span_notice("[user] amputates [target]'s [affected.name] at the [affected.amputation_point] with [tool]."))
+	user.visible_message(span_notice("[user] amputates [target]'s [affected.name] at the [affected.amputation_point] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.dismember(DROPLIMB_EDGE, clean = TRUE)
 	..()
 
 /datum/surgery_step/generic_organic/amputate/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone, TRUE)
-	user.visible_message(span_warning("[user]'s hand slips, sawing through the bone in [target]'s [affected.plaintext_zone] with [tool]!"))
+	user.visible_message(span_warning("[user]'s hand slips, sawing through the bone in [target]'s [affected.plaintext_zone] with [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.receive_damage(30, sharpness = SHARP_EDGED|SHARP_POINTY)
 	affected.break_bones()
 	..()

--- a/code/modules/surgery/new_surgery/generic_organic.dm
+++ b/code/modules/surgery/new_surgery/generic_organic.dm
@@ -1,7 +1,7 @@
 /datum/surgery_step/generic_organic
 	can_infect = 1
 	pain_given =10
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP
 	abstract_type = /datum/surgery_step/generic_organic
 
 /datum/surgery_step/generic_organic/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -107,7 +107,7 @@
 	)
 	min_duration = 3 SECONDS
 	max_duration = 5 SECONDS
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_INCISION
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_INCISION
 	strict_access_requirement = FALSE
 	preop_sound = 'sound/surgery/hemostat1.ogg'
 
@@ -143,7 +143,7 @@
 	)
 	min_duration = 3 SECONDS
 	max_duration = 5 SECONDS
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_INCISION
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_INCISION | SURGERY_BLOODY_GLOVES
 	strict_access_requirement = TRUE
 	preop_sound = 'sound/surgery/retractor1.ogg'
 	success_sound = 'sound/surgery/retractor2.ogg'
@@ -189,7 +189,7 @@
 	)
 	min_duration = 4 SECONDS
 	max_duration = 6 SECONDS
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC
+	surgery_flags = SURGERY_NO_ROBOTIC
 	preop_sound = 'sound/surgery/cautery1.ogg'
 	success_sound = 'sound/surgery/cautery2.ogg'
 
@@ -263,7 +263,7 @@
 	)
 	min_duration = 11 SECONDS
 	max_duration = 16 SECONDS
-	surgery_candidate_flags = NONE
+	surgery_flags = NONE
 	pain_given = PAIN_AMT_AGONIZING + 30
 
 	preop_sound = list(

--- a/code/modules/surgery/new_surgery/internal_organs.dm
+++ b/code/modules/surgery/new_surgery/internal_organs.dm
@@ -66,7 +66,7 @@
 	if (istype(tool, /obj/item/stack/medical/bruise_pack))
 		tool_name = "the bandaid"
 
-	user.visible_message(span_notice("[user] starts treating damage to [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool_name]."))
+	user.visible_message(span_notice("[user] starts treating damage to [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool_name]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/internal/fix_organ/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -82,12 +82,12 @@
 		return ..()
 
 	O.surgically_fix(user)
-	user.visible_message(span_notice("[user] finishes treating damage to [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool_name]."))
+	user.visible_message(span_notice("[user] finishes treating damage to [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool_name]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/internal/fix_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, getting mess and tearing the inside of [target]'s [affected.name] with \the [tool]!"))
+	user.visible_message(span_warning("[user]'s hand slips, getting mess and tearing the inside of [target]'s [affected.name] with \the [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	var/dam_amt = 2
 
 	dam_amt = 5
@@ -131,11 +131,11 @@
 		return list(organ_to_remove,attached_organs[organ_to_remove])
 
 /datum/surgery_step/internal/detach_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(span_notice("[user] starts to separate [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool]."))
+	user.visible_message(span_notice("[user] starts to separate [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/internal/detach_organ/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(span_notice("[user] has separated [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool]."))
+	user.visible_message(span_notice("[user] has separated [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	var/obj/item/organ/I = target.getorganslot((LAZYACCESS(target.surgeries_in_progress, target_zone))[2])
 	if(istype(I))
@@ -145,11 +145,11 @@
 /datum/surgery_step/internal/detach_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
 	if(affected.check_artery() & CHECKARTERY_OK)
-		user.visible_message(span_warning("[user]'s hand slips, slicing an artery inside [target]'s [affected.plaintext_zone] with \the [tool]!"))
+		user.visible_message(span_warning("[user]'s hand slips, slicing an artery inside [target]'s [affected.plaintext_zone] with \the [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 		affected.set_sever_artery(TRUE)
 		affected.receive_damage(rand(10,15), sharpness = SHARP_EDGED|SHARP_POINTY)
 	else
-		user.visible_message(span_warning("[user]'s hand slips, slicing up inside [target]'s [affected.plaintext_zone] with \the [tool]!"))
+		user.visible_message(span_warning("[user]'s hand slips, slicing up inside [target]'s [affected.plaintext_zone] with \the [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 		affected.receive_damage(rand(15, 25), sharpness = SHARP_EDGED|SHARP_POINTY)
 	..()
 
@@ -184,7 +184,7 @@
 		return list(organ_to_remove, removable_organs[organ_to_remove])
 
 /datum/surgery_step/internal/remove_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(span_notice("\The [user] starts removing [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with \the [tool]."))
+	user.visible_message(span_notice("\The [user] starts removing [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with \the [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/internal/remove_organ/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -193,7 +193,7 @@
 	if(!O)
 		return
 
-	user.visible_message(span_notice("[user] has removed [target]'s [O.name] with [tool]."))
+	user.visible_message(span_notice("[user] has removed [target]'s [O.name] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	if(istype(O) && istype(affected))
 		affected.remove_cavity_item(O)
@@ -204,7 +204,7 @@
 
 /datum/surgery_step/internal/remove_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, damaging [target]'s [affected.plaintext_zone] with [tool]!"))
+	user.visible_message(span_warning("[user]'s hand slips, damaging [target]'s [affected.plaintext_zone] with [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.receive_damage(20, sharpness = tool.sharpness)
 	..()
 
@@ -240,12 +240,12 @@
 
 /datum/surgery_step/internal/replace_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts [robotic_surgery ? "reinstalling" : "transplanting"] [tool] into [target]'s [affected.plaintext_zone]."))
+	user.visible_message(span_notice("[user] starts [robotic_surgery ? "reinstalling" : "transplanting"] [tool] into [target]'s [affected.plaintext_zone]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/internal/replace_organ/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("\The [user] has [robotic_surgery ? "reinstalled" : "transplanted"] [tool] into [target]'s [affected.plaintext_zone]."))
+	user.visible_message(span_notice("\The [user] has [robotic_surgery ? "reinstalled" : "transplanted"] [tool] into [target]'s [affected.plaintext_zone]."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	var/obj/item/organ/O = tool
 	if(istype(O) && user.transferItemToLoc(O, target))
@@ -257,7 +257,7 @@
 	..()
 
 /datum/surgery_step/internal/replace_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(span_warning("[user]'s hand slips, damaging \the [tool]!"))
+	user.visible_message(span_warning("[user]'s hand slips, damaging \the [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	var/obj/item/organ/I = tool
 	if(istype(I))
 		I.applyOrganDamage(rand(3,5))
@@ -308,7 +308,7 @@
 	return list(organ_to_replace, attachable_organs[organ_to_replace.name])
 
 /datum/surgery_step/internal/attach_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(span_warning("[user] begins reattaching [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with \the [tool]."))
+	user.visible_message(span_warning("[user] begins reattaching [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with \the [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/internal/attach_organ/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -317,7 +317,7 @@
 	if(!I)
 		return
 
-	user.visible_message(span_notice("[user] has reattached [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with [tool]."))
+	user.visible_message(span_notice("[user] has reattached [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	if(istype(I) && affected && deprecise_zone(I.zone) == affected.body_zone && (I in affected.cavity_items))
 		affected.remove_cavity_item(I)
@@ -326,18 +326,26 @@
 
 /datum/surgery_step/internal/attach_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, damaging the flesh in [target]'s [affected.plaintext_zone] with [tool]!"))
+	user.visible_message(span_warning("[user]'s hand slips, damaging the flesh in [target]'s [affected.plaintext_zone] with [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/internal/brain_revival
 	name = "Brain revival"
 	desc = "Utilizes the incredible power of Alkysine to restore the spark of life."
-	allowed_tools = list(
-		/obj/item/reagent_containers/glass = 100,
-	)
+
 	min_duration = 100
 	max_duration = 150
-	surgery_flags = SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
+
+	surgery_flags = SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT | SURGERY_CANNOT_FAIL
+
+/datum/surgery_step/internal/brain_revival/tool_potency(obj/item/tool)
+	if(!tool.reagents)
+		return 0
+
+	if(!(tool.reagents.flags & (OPENCONTAINER)))
+		return 0
+
+	return 100
 
 /datum/surgery_step/internal/brain_revival/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/BP = ..()
@@ -355,7 +363,7 @@
 	. = FALSE
 
 	var/obj/item/reagent_containers/glass/S = tool
-	if(!S.reagents.has_reagent(/datum/reagent/medicine/alkysine, 10))
+	if(!S.reagents.has_reagent(/datum/reagent/medicine/alkysine, 5))
 		to_chat(user, span_warning("\The [S] doesn't contain enough alkysine!"))
 		return
 
@@ -368,12 +376,11 @@
 
 /datum/surgery_step/internal/brain_revival/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user] begins pouring [tool] into [target]'s [affected]..."))
+	user.visible_message(span_warning("[user] begins pouring [tool] into [target]'s [affected]..."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/internal/brain_revival/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/reagent_containers/glass/beaker/S = tool
-	if(!S.reagents.has_reagent(/datum/reagent/medicine/alkysine, 5))
+	if(!tool.reagents.has_reagent(/datum/reagent/medicine/alkysine, 5))
 		return
 
 	var/obj/item/bodypart/head/head = target.get_bodypart(BODY_ZONE_HEAD)
@@ -381,7 +388,7 @@
 	if(!head || !brain)
 		return
 
-	S.reagents.remove_reagent(/datum/reagent/medicine/alkysine, 5)
+	tool.reagents.remove_reagent(/datum/reagent/medicine/alkysine, 5)
 	brain.setOrganDamage(0)
 	..()
 
@@ -394,18 +401,19 @@
 
 	surgery_flags = parent_type::surgery_flags & ~SURGERY_BLOODY_GLOVES
 
-	allowed_tools = list(
-		/obj/item/reagent_containers/dropper = 100,
-		/obj/item/reagent_containers/glass/bottle = 75,
-		/obj/item/reagent_containers/glass/beaker = 75,
-		/obj/item/reagent_containers/spray = 50,
-		/obj/item/reagent_containers/glass/bucket = 50,
-	)
-
 	can_infect = FALSE
 
 	min_duration = 5 SECONDS
 	max_duration = 6 SECONDS
+
+/datum/surgery_step/internal/treat_necrosis/tool_potency(obj/item/tool)
+	if(!tool.reagents)
+		return 0
+
+	if(!(tool.reagents.flags & OPENCONTAINER))
+		return 0
+
+	return 100
 
 /datum/surgery_step/internal/treat_necrosis/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = ..()
@@ -416,10 +424,12 @@
 		if((O.organ_flags & ORGAN_DEAD) && !(O.organ_flags & ORGAN_SYNTHETIC))
 			return affected
 
-
 /datum/surgery_step/internal/treat_necrosis/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/reagent_containers/container = tool
-	if(!istype(container) || !container.reagents.has_reagent(/datum/reagent/medicine/peridaxon) || !..())
+	if(!..())
+		return FALSE
+
+	if(!tool.reagents.has_reagent(/datum/reagent/medicine/peridaxon))
+		to_chat(user, span_warning("[tool] does not contain any peridaxon."))
 		return FALSE
 
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
@@ -430,6 +440,7 @@
 			dead_organs[I.name] = I
 
 	if(!length(dead_organs))
+		to_chat(user, span_warning("[target.name] does not have any dead organs."))
 		return FALSE
 
 	var/obj/item/organ/O
@@ -456,39 +467,50 @@
 /datum/surgery_step/internal/treat_necrosis/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(
 		span_notice("[user] starts applying medication to the affected tissue in [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with \the [tool]."),
-		span_notice("You start applying medication to the affected tissue in [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with \the [tool].")
+		span_notice("You start applying medication to the affected tissue in [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with \the [tool]."),
+		vision_distance = COMBAT_MESSAGE_RANGE
 	)
 	target.apply_pain(50, target_zone)
 	..()
 
 /datum/surgery_step/internal/treat_necrosis/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/affected = LAZYACCESS(target.surgeries_in_progress, target_zone)[2]
-	var/obj/item/reagent_containers/container = tool
 
-	var/rejuvenate = container.reagents.has_reagent(/datum/reagent/medicine/peridaxon)
-	var/transered_amount = container.reagents.trans_to(target, container.amount_per_transfer_from_this, methods = INJECT)
+	var/transfer_amount
+	if(is_reagent_container(tool))
+		var/obj/item/reagent_containers/container = tool
+		transfer_amount = container.amount_per_transfer_from_this
+	else
+		transfer_amount = tool.reagents.total_volume
+
+	var/rejuvenate = tool.reagents.has_reagent(/datum/reagent/medicine/peridaxon)
+	var/transered_amount = tool.reagents.trans_to(target, transfer_amount, methods = INJECT)
 	if(transered_amount > 0)
 		if(rejuvenate)
 			affected.set_organ_dead(FALSE)
 
 		user.visible_message(
 			span_notice("[user] applies [transered_amount] unit\s of the solution to affected tissue in [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]]."),
-			span_notice("You apply [transered_amount] unit\s of the solution to affected tissue in [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with \the [tool].")
+			span_notice("You apply [transered_amount] unit\s of the solution to affected tissue in [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)[1]] with \the [tool]."),
+			vision_distance = COMBAT_MESSAGE_RANGE
 		)
 	..()
 
 /datum/surgery_step/internal/treat_necrosis/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
 
-	if (!istype(tool, /obj/item/reagent_containers))
-		return
+	var/transfer_amount
+	if(is_reagent_container(tool))
+		var/obj/item/reagent_containers/container = tool
+		transfer_amount = container.amount_per_transfer_from_this
+	else
+		transfer_amount = tool.reagents.total_volume
 
-	var/obj/item/reagent_containers/container = tool
-
-	var/trans = container.reagents.trans_to(target, container.amount_per_transfer_from_this, methods = INJECT)
+	var/trans = tool.reagents.trans_to(target, transfer_amount, methods = INJECT)
 
 	user.visible_message(
 		span_warning("[user]'s hand slips, applying [trans] units of the solution to the wrong place in [target]'s [affected.name] with the [tool]!"),
-		span_warning("Your hand slips, applying [trans] units of the solution to the wrong place in [target]'s [affected.name] with the [tool]!")
+		span_warning("Your hand slips, applying [trans] units of the solution to the wrong place in [target]'s [affected.name] with the [tool]!"),
+		vision_distance = COMBAT_MESSAGE_RANGE
 	)
 	..()

--- a/code/modules/surgery/new_surgery/internal_organs.dm
+++ b/code/modules/surgery/new_surgery/internal_organs.dm
@@ -4,10 +4,9 @@
 //////////////////////////////////////////////////////////////////
 /datum/surgery_step/internal
 	can_infect = 1
-	blood_level = 1
-	pain_given =40
+	pain_given = 40
 	delicate = 1
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT | SURGERY_BLOODY_GLOVES
 	abstract_type = /datum/surgery_step/internal
 
 //////////////////////////////////////////////////////////////////
@@ -112,7 +111,7 @@
 	)
 	min_duration = 90
 	max_duration = 110
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
 
 /datum/surgery_step/internal/detach_organ/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
@@ -277,7 +276,7 @@
 	)
 	min_duration = 100
 	max_duration = 120
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
 
 /datum/surgery_step/internal/attach_organ/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 
@@ -338,7 +337,7 @@
 	)
 	min_duration = 100
 	max_duration = 150
-	surgery_candidate_flags = SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
 
 /datum/surgery_step/internal/brain_revival/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/BP = ..()
@@ -392,6 +391,9 @@
 /datum/surgery_step/internal/treat_necrosis
 	name = "Treat necrosis"
 	desc = "Utilizes the restorative power of even the slightest amount of Peridaxon to restore functionality to an organ."
+
+	surgery_flags = parent_type::surgery_flags & ~SURGERY_BLOODY_GLOVES
+
 	allowed_tools = list(
 		/obj/item/reagent_containers/dropper = 100,
 		/obj/item/reagent_containers/glass/bottle = 75,
@@ -401,7 +403,6 @@
 	)
 
 	can_infect = FALSE
-	blood_level = 0
 
 	min_duration = 5 SECONDS
 	max_duration = 6 SECONDS

--- a/code/modules/surgery/new_surgery/other.dm
+++ b/code/modules/surgery/new_surgery/other.dm
@@ -15,12 +15,11 @@
 		/obj/item/stack/sticky_tape = 50
 	)
 	can_infect = 1
-	blood_level = 1
 	min_duration = 5 SECONDS
 	max_duration = 8 SECONDS
 	pain_given =40
 	delicate = 1
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED | SURGERY_BLOODY_GLOVES
 
 /datum/surgery_step/fix_tendon/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = ..()
@@ -56,13 +55,12 @@
 		/obj/item/stack/sticky_tape = 50
 	)
 	can_infect = 1
-	blood_level = 1
 	min_duration = 5 SECONDS
 	max_duration = 8 SECONDS
 	pain_given =40
 	delicate = 1
 	strict_access_requirement = FALSE
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED | SURGERY_BLOODY_BODY
 
 /datum/surgery_step/fix_vein/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = ..()

--- a/code/modules/surgery/new_surgery/other.dm
+++ b/code/modules/surgery/new_surgery/other.dm
@@ -28,18 +28,18 @@
 
 /datum/surgery_step/fix_tendon/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts reattaching the damaged [affected.tendon_name] in [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] starts reattaching the damaged [affected.tendon_name] in [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/fix_tendon/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] has reattached the [affected.tendon_name] in [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] has reattached the [affected.tendon_name] in [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.set_sever_tendon(FALSE)
 	..()
 
 /datum/surgery_step/fix_tendon/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.plaintext_zone]!"))
+	user.visible_message(span_warning("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.plaintext_zone]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.receive_damage(5, sharpness = tool.sharpness)
 	..()
 
@@ -69,17 +69,17 @@
 
 /datum/surgery_step/fix_vein/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts patching the damaged [affected.artery_name] in [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] starts patching the damaged [affected.artery_name] in [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/fix_vein/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] has patched the [affected.artery_name] in [target]'s [affected.plaintext_zone] with \the [tool]."))
+	user.visible_message(span_notice("[user] has patched the [affected.artery_name] in [target]'s [affected.plaintext_zone] with \the [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.set_sever_artery(FALSE)
 	..()
 
 /datum/surgery_step/fix_vein/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.plaintext_zone]!"))
+	user.visible_message(span_warning("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.plaintext_zone]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.receive_damage(5, sharpness = tool.sharpness)
 	..()

--- a/code/modules/surgery/new_surgery/reattach_limb.dm
+++ b/code/modules/surgery/new_surgery/reattach_limb.dm
@@ -42,20 +42,20 @@
 
 /datum/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/BP = tool
-	user.visible_message(span_notice("[user] starts attaching the [BP.plaintext_zone] to [target]'s [BP.amputation_point]."))
+	user.visible_message(span_notice("[user] starts attaching the [BP.plaintext_zone] to [target]'s [BP.amputation_point]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/limb/attach/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!user.temporarilyRemoveItemFromInventory(tool))
 		return
 	var/obj/item/bodypart/BP = tool
-	user.visible_message(span_notice("[user] has attached the [BP.plaintext_zone] to [target]'s [BP.amputation_point]."))
+	user.visible_message(span_notice("[user] has attached the [BP.plaintext_zone] to [target]'s [BP.amputation_point]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	BP.attach_limb(target)
 	..()
 
 /datum/surgery_step/limb/attach/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/BP = target.get_bodypart(target_zone, TRUE)
-	user.visible_message(span_warning("[user]'s hand slips, damaging [target]'s [BP.amputation_point]!"))
+	user.visible_message(span_warning("[user]'s hand slips, damaging [target]'s [BP.amputation_point]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	target.apply_damage(10, BRUTE, BODY_ZONE_CHEST, sharpness = SHARP_EDGED)
 	..()
 
@@ -81,18 +81,18 @@
 
 /datum/surgery_step/limb/connect/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/BP = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts connecting tendons and muscles in [target]'s [BP.amputation_point] with [tool]."))
+	user.visible_message(span_notice("[user] starts connecting tendons and muscles in [target]'s [BP.amputation_point] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/limb/connect/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/BP = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] has connected tendons and muscles in [target]'s [BP.amputation_point] with [tool]."))
+	user.visible_message(span_notice("[user] has connected tendons and muscles in [target]'s [BP.amputation_point] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	BP.bodypart_flags &= ~BP_CUT_AWAY
 	BP.update_disabled()
 	..()
 
 /datum/surgery_step/limb/connect/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/BP = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, damaging [target]'s [BP.amputation_point]!"))
+	user.visible_message(span_warning("[user]'s hand slips, damaging [target]'s [BP.amputation_point]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	target.apply_damage(10, BRUTE, BODY_ZONE_CHEST, sharpness = tool.sharpness)
 	..()

--- a/code/modules/surgery/new_surgery/remove_embedded.dm
+++ b/code/modules/surgery/new_surgery/remove_embedded.dm
@@ -28,6 +28,7 @@
 		embedded.forceMove(user.drop_location())
 
 	user.visible_message(
-		span_notice("[user] pulls [embedded] from [target]'s [affected.plaintext_zone].")
+		span_notice("[user] pulls [embedded] from [target]'s [affected.plaintext_zone]."),
+		vision_distance = COMBAT_MESSAGE_RANGE
 	)
 	..()

--- a/code/modules/surgery/new_surgery/ribcage.dm
+++ b/code/modules/surgery/new_surgery/ribcage.dm
@@ -36,18 +36,18 @@
 
 /datum/surgery_step/open_encased/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] begins to cut through [target]'s [affected.encased] with [tool]."))
+	user.visible_message(span_notice("[user] begins to cut through [target]'s [affected.encased] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/open_encased/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] has cut [target]'s [affected.encased] open with [tool]."))
+	user.visible_message(span_notice("[user] has cut [target]'s [affected.encased] open with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.break_bones(FALSE)
 	..()
 
 /datum/surgery_step/open_encased/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, cracking [target]'s [affected.encased] with \the [tool]!"))
+	user.visible_message(span_warning("[user]'s hand slips, cracking [target]'s [affected.encased] with \the [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.receive_damage(15, sharpness = SHARP_EDGED|SHARP_POINTY)
 	affected.break_bones()
 	..()

--- a/code/modules/surgery/new_surgery/ribcage.dm
+++ b/code/modules/surgery/new_surgery/ribcage.dm
@@ -19,7 +19,7 @@
 	max_duration = 7 SECONDS
 	pain_given = PAIN_AMT_AGONIZING
 	delicate = 1
-	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED | SURGERY_BLOODY_GLOVES
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED | SURGERY_BLOODY_BODY
 	strict_access_requirement = TRUE
 
 	preop_sound = list(

--- a/code/modules/surgery/new_surgery/ribcage.dm
+++ b/code/modules/surgery/new_surgery/ribcage.dm
@@ -15,12 +15,11 @@
 		/obj/item/hatchet = 75
 	)
 	can_infect = 1
-	blood_level = 1
 	min_duration = 5 SECONDS
 	max_duration = 7 SECONDS
 	pain_given = PAIN_AMT_AGONIZING
 	delicate = 1
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED
+	surgery_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED | SURGERY_BLOODY_GLOVES
 	strict_access_requirement = TRUE
 
 	preop_sound = list(

--- a/code/modules/surgery/new_surgery/robotics.dm
+++ b/code/modules/surgery/new_surgery/robotics.dm
@@ -41,12 +41,12 @@
 
 /datum/surgery_step/robotics/unscrew_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts to [affected.hatch_state == HATCH_CLOSED ? "unscrew" : "screw"] the maintenance hatch on [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] starts to [affected.hatch_state == HATCH_CLOSED ? "unscrew" : "screw"] the maintenance hatch on [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/robotics/unscrew_hatch/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] has [affected.hatch_state == HATCH_CLOSED ? "unscrewed" : "screwed"] the maintenance hatch on [target]'s [affected.plaintext_zone] with \the [tool]."))
+	user.visible_message(span_notice("[user] has [affected.hatch_state == HATCH_CLOSED ? "unscrewed" : "screwed"] the maintenance hatch on [target]'s [affected.plaintext_zone] with \the [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	if(affected.hatch_state == HATCH_CLOSED)
 		affected.hatch_state = HATCH_UNSCREWED
 	else
@@ -55,7 +55,7 @@
 
 /datum/surgery_step/robotics/unscrew_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s [tool.name] slips, failing to [affected.hatch_state == HATCH_CLOSED ? "unscrew" : "screw"] [target]'s [affected.plaintext_zone]."))
+	user.visible_message(span_warning("[user]'s [tool.name] slips, failing to [affected.hatch_state == HATCH_CLOSED ? "unscrew" : "screw"] [target]'s [affected.plaintext_zone]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 //////////////////////////////////////////////////////////////////
@@ -81,7 +81,7 @@
 
 /datum/surgery_step/robotics/open_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts to [affected.hatch_state == HATCH_UNSCREWED ? "pry open" : "close"] the maintenance hatch on [target]'s [affected.name] with [tool]."))
+	user.visible_message(span_notice("[user] starts to [affected.hatch_state == HATCH_UNSCREWED ? "pry open" : "close"] the maintenance hatch on [target]'s [affected.name] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/robotics/open_hatch/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -95,7 +95,7 @@
 
 /datum/surgery_step/robotics/open_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s [tool.name] slips, failing to [affected.hatch_state == HATCH_UNSCREWED ? "open" : "close"] the hatch on [target]'s [affected.name]."))
+	user.visible_message(span_warning("[user]'s [tool.name] slips, failing to [affected.hatch_state == HATCH_UNSCREWED ? "open" : "close"] the hatch on [target]'s [affected.name]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 //////////////////////////////////////////////////////////////////
@@ -131,17 +131,17 @@
 
 /datum/surgery_step/robotics/repair_brute/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] begins to patch damage to [target]'s [affected.plaintext_zone]'s support structure with [tool]."))
+	user.visible_message(span_notice("[user] begins to patch damage to [target]'s [affected.plaintext_zone]'s support structure with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/robotics/repair_brute/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] finishes patching damage to [target]'s [affected.plaintext_zone] with [tool]."))
+	user.visible_message(span_notice("[user] finishes patching damage to [target]'s [affected.plaintext_zone] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/robotics/repair_brute/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s [tool.name] slips, damaging the internal structure of [target]'s [affected.plaintext_zone]."))
+	user.visible_message(span_warning("[user]'s [tool.name] slips, damaging the internal structure of [target]'s [affected.plaintext_zone]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.receive_damage(0, rand(5, 10))
 	..()
 
@@ -178,19 +178,19 @@
 
 /datum/surgery_step/robotics/repair_burn/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] begins to splice new cabling into [target]'s [affected.plaintext_zone]."))
+	user.visible_message(span_notice("[user] begins to splice new cabling into [target]'s [affected.plaintext_zone]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/robotics/repair_burn/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] finishes splicing cable into [target]'s [affected.plaintext_zone]."))
+	user.visible_message(span_notice("[user] finishes splicing cable into [target]'s [affected.plaintext_zone]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.heal_damage(0, rand(30,50), BODYTYPE_ROBOTIC)
 	tool.use(2) // We need 3 cable coil, and `handle_post_surgery()` removes 1.
 	..()
 
 /datum/surgery_step/robotics/repair_burn/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user] causes a short circuit in [target]'s [affected.plaintext_zone]!"))
+	user.visible_message(span_warning("[user] causes a short circuit in [target]'s [affected.plaintext_zone]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.receive_damage(0, rand(5,10))
 	..()
 
@@ -235,7 +235,7 @@
 		return list(organ, organs[organ])
 
 /datum/surgery_step/robotics/fix_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(span_notice("[user] starts mending the damage to [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] mechanisms."))
+	user.visible_message(span_notice("[user] starts mending the damage to [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] mechanisms."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/robotics/fix_organ_robotic/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -243,13 +243,13 @@
 	if(!I || !I.owner == target)
 		return
 
-	user.visible_message(span_notice("[user] repairs [target]'s [I.name] with [tool]."))
+	user.visible_message(span_notice("[user] repairs [target]'s [I.name] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	I.damage = 0
 	..()
 
 /datum/surgery_step/robotics/fix_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_warning("[user]'s hand slips, gumming up the mechanisms inside of [target]'s [affected.plaintext_zone] with [tool]!"))
+	user.visible_message(span_warning("[user]'s hand slips, gumming up the mechanisms inside of [target]'s [affected.plaintext_zone] with [tool]!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	affected.create_wound(WOUND_CUT, 5)
 	for(var/obj/item/organ/I in affected.contained_organs)
 		I.applyOrganDamage(rand(3,5))
@@ -283,11 +283,11 @@
 		return list(organ_to_remove,attached_organs[organ_to_remove])
 
 /datum/surgery_step/robotics/detach_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(span_notice("[user] starts to decouple [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool]."))
+	user.visible_message(span_notice("[user] starts to decouple [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/robotics/detach_organ_robotic/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(span_notice("[user] has decoupled [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool]."))
+	user.visible_message(span_notice("[user] has decoupled [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	var/obj/item/organ/I = target.getorganslot((LAZYACCESS(target.surgeries_in_progress, target_zone))[2])
 	if(istype(I))
 		I.cut_away()
@@ -326,7 +326,7 @@
 		return list(organ_to_replace, removable_organs[organ_to_replace])
 
 /datum/surgery_step/robotics/attach_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(span_notice("[user] begins reattaching [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool]."))
+	user.visible_message(span_notice("[user] begins reattaching [target]'s [(LAZYACCESS(target.surgeries_in_progress, target_zone))[1]] with [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/robotics/attach_organ_robotic/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -335,7 +335,7 @@
 	if(!O)
 		return
 
-	user.visible_message(span_notice("[user] has reattached [target]'s [O.name] with \the [tool]."))
+	user.visible_message(span_notice("[user] has reattached [target]'s [O.name] with \the [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	O.organ_flags &= ~ORGAN_CUT_AWAY
 	affected.remove_cavity_item(O)
@@ -343,5 +343,5 @@
 	..()
 
 /datum/surgery_step/robotics/attach_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(span_warning("[user]'s hand slips, disconnecting [tool]."))
+	user.visible_message(span_warning("[user]'s hand slips, disconnecting [tool]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()

--- a/code/modules/surgery/new_surgery/robotics.dm
+++ b/code/modules/surgery/new_surgery/robotics.dm
@@ -1,6 +1,6 @@
 /datum/surgery_step/robotics
 	can_infect = 0
-	surgery_candidate_flags = SURGERY_NO_FLESH | SURGERY_NO_STUMP
+	surgery_flags = SURGERY_NO_FLESH | SURGERY_NO_STUMP
 	abstract_type = /datum/surgery_step/robotics
 
 /datum/surgery_step/robotics/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -11,13 +11,13 @@
 /datum/surgery_step/internal/remove_organ/robotic
 	name = "Remove robotic component"
 	can_infect = 0
-	surgery_candidate_flags = SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
 
 /datum/surgery_step/internal/replace_organ/robotic
 	name = "Replace robotic component"
 	can_infect = 0
 	robotic_surgery = TRUE
-	surgery_candidate_flags = SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
 
 //////////////////////////////////////////////////////////////////
 //	 unscrew robotic limb hatch surgery step
@@ -205,7 +205,7 @@
 	)
 	min_duration = 4 SECONDS
 	max_duration = 6 SECONDS
-	surgery_candidate_flags = SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NO_STUMP | SURGERY_NEEDS_DEENCASEMENT
 
 /datum/surgery_step/robotics/fix_organ_robotic/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = ..()
@@ -265,7 +265,7 @@
 	)
 	min_duration = 9 SECONDS
 	max_duration = 11 SECONDS
-	surgery_candidate_flags = SURGERY_NO_STUMP | SURGERY_NO_FLESH | SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NO_STUMP | SURGERY_NO_FLESH | SURGERY_NEEDS_DEENCASEMENT
 
 /datum/surgery_step/robotics/detach_organ_robotic/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
@@ -308,7 +308,7 @@
 	)
 	min_duration = 10 SECONDS
 	max_duration = 12 SECONDS
-	surgery_candidate_flags = SURGERY_NO_STUMP | SURGERY_NO_FLESH | SURGERY_NEEDS_DEENCASEMENT
+	surgery_flags = SURGERY_NO_STUMP | SURGERY_NO_FLESH | SURGERY_NEEDS_DEENCASEMENT
 
 /datum/surgery_step/robotics/attach_organ_robotic/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/list/removable_organs = list()

--- a/code/modules/surgery/new_surgery/tend_wounds.dm
+++ b/code/modules/surgery/new_surgery/tend_wounds.dm
@@ -1,7 +1,7 @@
 /datum/surgery_step/tend_wounds
 	name = "Repair greivous physical trauma (organic)"
 	desc = "Repairs extreme damage from cuts, bruises, and punctures."
-	surgery_candidate_flags = SURGERY_NO_ROBOTIC
+	surgery_flags = SURGERY_NO_ROBOTIC
 	allowed_tools = list(
 		TOOL_HEMOSTAT = 100
 	)
@@ -57,7 +57,7 @@
 /datum/surgery_step/tend_wounds/robotic
 	name = "Repair greivous physical trauma (robotic)"
 	desc = "Repairs extreme damage from dents or punctures"
-	surgery_candidate_flags = SURGERY_NO_FLESH
+	surgery_flags = SURGERY_NO_FLESH
 	allowed_tools = list(
 		TOOL_WELDER = 95
 	)
@@ -75,4 +75,4 @@
 /datum/surgery_step/tend_wounds/robotic/burn
 	name = "Repair third degree burns (robotic)"
 	desc = "Repairs extreme damage from burns."
-	surgery_candidate_flags = SURGERY_NO_FLESH
+	surgery_flags = SURGERY_NO_FLESH

--- a/code/modules/surgery/new_surgery/tend_wounds.dm
+++ b/code/modules/surgery/new_surgery/tend_wounds.dm
@@ -37,13 +37,13 @@
 
 /datum/surgery_step/tend_wounds/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] starts to mend [target]'s [affected.plaintext_zone]."))
+	user.visible_message(span_notice("[user] starts to mend [target]'s [affected.plaintext_zone]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 
 /datum/surgery_step/tend_wounds/succeed_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	..()
 	var/obj/item/bodypart/affected = target.get_bodypart(target_zone)
-	user.visible_message(span_notice("[user] successfully mends [target]'s [affected.plaintext_zone]."))
+	user.visible_message(span_notice("[user] successfully mends [target]'s [affected.plaintext_zone]."), vision_distance = COMBAT_MESSAGE_RANGE)
 	if(damage_type == BRUTE)
 		affected.heal_damage(15)
 	else

--- a/code/modules/three_dsix/roll.dm
+++ b/code/modules/three_dsix/roll.dm
@@ -1,3 +1,4 @@
+GLOBAL_DATUM_INIT(success_roll, /datum/roll_result/success, new)
 /**
  * Perform a stat roll, returning a roll result datum.
  *
@@ -150,6 +151,13 @@
 	var/seperator = "<span style='color: #bbbbad;font-style: italic'>: </span>"
 
 	return "[prefix] <span data-component=\"Tooltip\" data-innerhtml=\"[tooltip_html]\" class=\"tooltip\">[finished_prob_string]</span>[seperator][body]"
+
+/datum/roll_result/success
+	outcome = SUCCESS
+	success_prob = 100
+	crit_success_prob = 0
+	roll = 18
+	requirement = 3
 
 /mob/living/verb/testroll()
 	name = "testroll"

--- a/code/modules/three_dsix/skills/coordination.dm
+++ b/code/modules/three_dsix/skills/coordination.dm
@@ -3,3 +3,24 @@
 	desc = "Forge new creations from rubble and ruin."
 
 	parent_stat_type = /datum/rpg_stat/motorics
+
+/datum/rpg_skill/handicraft/get(mob/living/user)
+	. = ..()
+
+	if(CHEM_EFFECT_MAGNITUDE(user, CE_STIMULANT))
+		. -= 1
+
+	if(user.is_blind())
+		. -= 4
+	else if(user.eye_blurry)
+		. -= 1
+
+	if(!iscarbon(user))
+		return
+
+	var/mob/living/carbon/carbon_user = user
+
+	if(carbon_user.shock_stage > 30)
+		. -= 2
+	else if(carbon_user.shock_stage > 10)
+		. -= 1

--- a/code/modules/three_dsix/skills/skirmish.dm
+++ b/code/modules/three_dsix/skills/skirmish.dm
@@ -10,8 +10,11 @@
 		. += 1
 	if(user.incapacitated())
 		. -= 10 //lol fucked
-	if(user.eye_blurry)
-		. -= -1
+
+	if(user.is_blind())
+		. -= -4
+	else if(user.eye_blurry)
+		. -= 1
 
 	if(!iscarbon(user))
 		return

--- a/code/modules/three_dsix/stats/motorics.dm
+++ b/code/modules/three_dsix/stats/motorics.dm
@@ -14,3 +14,6 @@
 	var/obj/item/organ/brain/brain = carbon_user.getorganslot(ORGAN_SLOT_BRAIN)
 	if(brain && (brain.damage >= (brain.maxHealth * brain.low_threshold)))
 		. -= 4
+
+	if(carbon_user.has_status_effect(/datum/status_effect/speech/slurring/drunk))
+		. -= 2


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Kapu1178, MrMelbert
fix: You can no longer infinitely spread blood to turfs.
fix: Bloody hands are blood colored and not white.
fix: Surgery bloodies only the gloves of the surgeon.
fix: Wearing gloves correctly prevents disease spread during surgery.
fix: Grabs should now properly release... more often.
qol: Surgery attempts will now fail the moment they become impossible, not after the do_after().
qol: More surgeries provide more detailed feedback when a surgery is not a valid option.
add: Improved the logic for getting clothes bloody.
add: Grabs now spread blood.
remove: You can no longer revive brains outside of Brain Revival surgery.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
