### PR TITLE
Fixes split out stacks not having any materials

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -594,7 +594,7 @@
 	if(!use(amount, TRUE, FALSE))
 		return null
 
-	var/obj/item/stack/F = new type(spawn_loc, amount, FALSE, mats_per_unit, absorption_capacity)
+	var/obj/item/stack/F = new type(spawn_loc, amount, FALSE, mats_per_unit, null, absorption_capacity)
 	. = F
 	transfer_evidence_to(F)
 	loc.atom_storage?.refresh_views()


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Splitting a stack no longer causes the new stack to have no materials.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
