### PR TITLE
Removes the random wall in Recreation

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -54573,7 +54573,7 @@
 "uml" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
-/turf/closed/wall/prepainted/daedalus,
+/turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "umr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{


### PR DESCRIPTION

:cl:
fix: Removed the random wall in Dorms/Recreation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
