### PR TITLE
Ports tg#84247: Fixes magazine overflow and russian roulette starting with 6(7) bullets

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -65,7 +65,7 @@
 		stack_trace("Tried loading unsupported ammocasing type [load_type] into ammo box [type].")
 		return
 
-	for(var/i in max(1, stored_ammo.len) to max_ammo)
+	for(var/i in max(1, stored_ammo.len + 1) to max_ammo)
 		stored_ammo += new round_check(src)
 	update_ammo_count()
 

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -15,7 +15,8 @@
 	ammo_type = /obj/item/ammo_casing/a357
 	caliber = CALIBER_357
 	max_ammo = 6
+	start_empty = TRUE
 
-/obj/item/ammo_box/magazine/internal/rus357/Initialize(mapload)
+/obj/item/ammo_box/magazine/internal/cylinder/rus357/Initialize(mapload)
 	stored_ammo += new ammo_type(src)
 	. = ..()


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/84247
> ## About The Pull Request
> 
> Box magazine code started from `.len` instead of `.len + 1` when refilling mags which would be fine if BYOND's `to` didn't include the last number. Unfortunately, it does, and if the mag has bullets when its refilled it will have one over the limit.
> 
> Russian revolver code had a type typo where ammo was added in nonexistent `/obj/item/ammo_box/magazine/internal/rus357`'s `Initialize` instead of `/obj/item/ammo_box/magazine/internal/cylinder/rus357`. It was pretty clearly was meant to start with a single bullet instead of 6, but neither removing existing ammo nor adding new was implemented properly. I stuff it with 5 blanks instead of making it empty because this will at least allow it to click with current guncode instead of bashing yourself over the head without any feedback, until I rework it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

🆑 SmArtKar
fix: Guns no longer can be overfilled by 1 bullet
fix: Russian revolvers now spawn with only 1 live round as originally intended, and click when firing a blank.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
