### PR TITLE
Ports tg#84299: Fixed lights stopping emitting light in some situations

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_turf.dm
+++ b/code/__DEFINES/dcs/signals/signals_turf.dm
@@ -24,3 +24,6 @@
 #define COMSIG_TURF_PREPARE_STEP_SOUND "turf_prepare_step_sound"
 	//stops element/footstep/proc/prepare_step() from returning null if the turf itself has no sound
 	#define FOOTSTEP_OVERRIDEN (1<<0)
+
+///Called when turf no longer blocks light from passing through
+#define COMSIG_TURF_NO_LONGER_BLOCK_LIGHT "turf_no_longer_block_light"

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -90,6 +90,7 @@
 	//yes, we register the signal to the top atom too, this is intentional and ensures contained lighting updates properly
 	if(ismovable(new_atom_host))
 		RegisterSignal(new_atom_host, COMSIG_MOVABLE_MOVED, PROC_REF(update_host_lights))
+	RegisterSignal(new_atom_host, COMSIG_TURF_NO_LONGER_BLOCK_LIGHT, PROC_REF(force_update))
 	return TRUE
 
 ///remove this light source from old_atom_host's light_sources list, unsetting movement registrations
@@ -100,6 +101,7 @@
 	LAZYREMOVE(old_atom_host.light_sources, src)
 	if(ismovable(old_atom_host))
 		UnregisterSignal(old_atom_host, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(old_atom_host, COMSIG_TURF_NO_LONGER_BLOCK_LIGHT)
 	return TRUE
 
 // Yes this doesn't align correctly on anything other than 4 width tabs.

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -80,12 +80,16 @@
 			reconsider_lights()
 		return
 	directional_opacity = NONE
-	for(var/atom/movable/opacity_source as anything in opacity_sources)
-		if(opacity_source.flags_1 & ON_BORDER_1)
-			directional_opacity |= opacity_source.dir
-		else //If fulltile and opaque, then the whole tile blocks view, no need to continue checking.
-			directional_opacity = ALL_CARDINALS
-			break
+	if(opacity_sources)
+		for(var/atom/movable/opacity_source as anything in opacity_sources)
+			if(opacity_source.flags_1 & ON_BORDER_1)
+				directional_opacity |= opacity_source.dir
+			else //If fulltile and opaque, then the whole tile blocks view, no need to continue checking.
+				directional_opacity = ALL_CARDINALS
+				break
+	else
+		for(var/atom/movable/content as anything in contents)
+			SEND_SIGNAL(content, COMSIG_TURF_NO_LONGER_BLOCK_LIGHT)
 	if(. != directional_opacity && (. == ALL_CARDINALS || directional_opacity == ALL_CARDINALS))
 		reconsider_lights() //The lighting system only cares whether the tile is fully concealed from all directions or not.
 


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/84299
> ## About The Pull Request
> 
> Light sources stop emitting light if the tile in which the light source itself is located and all 4 adjacent tile block the light. This usually happens when a smoke grenade is thrown, or something went wrong in the chemistry again
>
> ## Why It's Good For The Game
> 
> You wont need to switch the lights twice to make them work after someone threw smoke grenades into the hallways anymore

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

🆑 Kocma-san
fix: Fixed lights stopping emitting light in some situations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
