### PR TITLE
Removes Haloperidol rounds from the Medical Director's Rifle

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -82,17 +82,13 @@
 	new /obj/item/defibrillator/compact/loaded(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/reagent_containers/hypospray/cmo(src)
-	new /obj/item/autosurgeon/organ/cmo(src)
-	new /obj/item/clothing/neck/petcollar(src)
-	new /obj/item/pet_carrier(src)
 	new /obj/item/wallframe/defib_mount(src)
 	new /obj/item/circuitboard/machine/fabricator/department/medical(src)
 	new /obj/item/storage/photo_album/cmo(src)
 	new /obj/item/storage/lockbox/medal/med(src)
 	new /obj/item/gun/ballistic/rifle/tranqrifle(src)
-	new /obj/item/ammo_box/magazine/tranq_rifle(src)
 	new /obj/item/ammo_box/magazine/tranq_rifle/ryetalyn(src)
-
+	new /obj/item/ammo_box/magazine/tranq_rifle/ryetalyn(src)
 
 /obj/structure/closet/secure_closet/animal
 	name = "animal control"

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -17,7 +17,6 @@
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/syringe,
-		/obj/item/gun/syringe,
 		/obj/item/sensor_device,
 		/obj/item/soap,
 		/obj/item/stack/medical,

--- a/code/modules/projectiles/guns/special/tranq_rifle.dm
+++ b/code/modules/projectiles/guns/special/tranq_rifle.dm
@@ -13,7 +13,7 @@
 	custom_materials = list(/datum/material/iron=2000)
 	clumsy_check = FALSE
 	fire_sound = 'sound/items/syringeproj.ogg'
-	mag_type = /obj/item/ammo_box/magazine/tranq_rifle
+	mag_type = /obj/item/ammo_box/magazine/tranq_rifle/ryetalyn
 	internal_magazine = FALSE
 	empty_alarm = FALSE
 	hidden_chambered = TRUE


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Haloperidol rounds in the safari rifle have been swapped for Ryetalyn rounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
