### PR TITLE
extra skill stuff

### DIFF
--- a/code/__DEFINES/three_dsix.dm
+++ b/code/__DEFINES/three_dsix.dm
@@ -17,5 +17,13 @@
 #define SKILL_SOURCE_DEATH_RESOLVE "Overcome witnessing a death"
 /// Witness a death
 #define SKILL_SOURCE_WITNESS_DEATH "Witnessed a death"
+/// Have nicotine in your blood
+#define SKILL_SOURCE_NICOTINE "Nicotine"
+/// Have a nicotine withdrawl
+#define SKILL_SOURCE_NICOTINE_WITHDRAWL "Nicottine withdrawl"
+/// Opiod Withdrawl
+#define SKILL_SOURCE_OPIOD_WITHDRAWL "Opiod withdrawl"
+/// Alchohol withdrawl
+#define SKILL_SOURCE_ALCHOHOL_WITHDRAWL "Alchohol withdrawl"
 /// The baseline value for a stat.
 #define STATS_BASELINE_VALUE 11

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -846,7 +846,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(FAILURE, CRIT_FAILURE)
 			user.apply_damage(5, BURN, user.get_active_hand())
 			to_chat(user, result.create_tooltip("You burn yourself while lighting the lighter!"))
-		if(SUCCESS)
+		if(SUCCESS, CRIT_SUCCESS)
 			to_chat(user, result.create_tooltip("After a few attempts, you manage to light [src]."))
 	user.visible_message(span_notice("After a few attempts, [user] manages to light [src]."))
 

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -843,9 +843,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	var/datum/roll_result/result = user.stat_roll(9, /datum/rpg_skill/handicraft)
 	switch(result.outcome)
-		if(FAILURE)
-			var/hitzone = user.held_index_to_dir(user.active_hand_index) == "r" ? BODY_ZONE_PRECISE_R_HAND : BODY_ZONE_PRECISE_L_HAND
-			user.apply_damage(5, BURN, hitzone)
+		if(FAILURE, CRIT_FAILURE)
+			user.apply_damage(5, BURN, user.get_active_hand())
 			to_chat(user, result.create_tooltip("You burn yourself while lighting the lighter!"))
 		if(SUCCESS)
 			to_chat(user, result.create_tooltip("After a few attempts, you manage to light [src]."))

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -834,19 +834,22 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(gloves.max_heat_protection_temperature)
 			hand_protected = (gloves.max_heat_protection_temperature > 360)
 
-	if(hand_protected || prob(75))
+	if(hand_protected)
 		user.visible_message(
 			span_notice("After a few attempts, [user] manages to light [src]."),
 			span_notice("After a few attempts, you manage to light [src].")
 		)
 		return
 
-	var/hitzone = user.held_index_to_dir(user.active_hand_index) == "r" ? BODY_ZONE_PRECISE_R_HAND : BODY_ZONE_PRECISE_L_HAND
-	user.apply_damage(5, BURN, hitzone)
-	user.visible_message(
-		span_warning("After a few attempts, [user] manages to light [src] - however, [user.p_they()] burn [user.p_their()] finger in the process."),
-		span_warning("You burn yourself while lighting the lighter!")
-	)
+	var/datum/roll_result/result = user.stat_roll(9, /datum/rpg_skill/handicraft)
+	switch(result.outcome)
+		if(FAILURE)
+			var/hitzone = user.held_index_to_dir(user.active_hand_index) == "r" ? BODY_ZONE_PRECISE_R_HAND : BODY_ZONE_PRECISE_L_HAND
+			user.apply_damage(5, BURN, hitzone)
+			to_chat(user, result.create_tooltip("You burn yourself while lighting the lighter!"))
+		if(SUCCESS)
+			to_chat(user, result.create_tooltip("After a few attempts, you manage to light [src]."))
+	user.visible_message(span_notice("After a few attempts, [user] manages to light [src]."))
 
 /obj/item/lighter/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(lit && M.ignite_mob())

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -88,6 +88,10 @@
 	C.AdjustParalyzed(-10 * removed)
 	C.AdjustImmobilized(-10 * removed)
 	. = TRUE
+	C.stats?.set_skill_modifier(1, /datum/rpg_skill/handicraft, SKILL_SOURCE_NICOTINE)
+
+/datum/reagent/drug/nicotine/on_mob_end_metabolize(mob/living/carbon/C, class)
+	C.stats?.remove_skill_modifier(/datum/rpg_skill/handicraft, SKILL_SOURCE_NICOTINE)
 
 /datum/reagent/drug/nicotine/overdose_process(mob/living/carbon/C)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -90,10 +90,13 @@
 	. = TRUE
 
 /datum/reagent/drug/nicotine/on_mob_metabolize(mob/living/carbon/C, class)
-	. = ..()
+	if(class != CHEM_BLOOD)
+		return
 	C.stats?.set_skill_modifier(1, /datum/rpg_skill/handicraft, SKILL_SOURCE_NICOTINE)
 
 /datum/reagent/drug/nicotine/on_mob_end_metabolize(mob/living/carbon/C, class)
+	if(class != CHEM_BLOOD)
+		return
 	C.stats?.remove_skill_modifier(/datum/rpg_skill/handicraft, SKILL_SOURCE_NICOTINE)
 
 /datum/reagent/drug/nicotine/overdose_process(mob/living/carbon/C)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -88,6 +88,9 @@
 	C.AdjustParalyzed(-10 * removed)
 	C.AdjustImmobilized(-10 * removed)
 	. = TRUE
+
+/datum/reagent/drug/nicotine/on_mob_metabolize(mob/living/carbon/C, class)
+	. = ..()
 	C.stats?.set_skill_modifier(1, /datum/rpg_skill/handicraft, SKILL_SOURCE_NICOTINE)
 
 /datum/reagent/drug/nicotine/on_mob_end_metabolize(mob/living/carbon/C, class)

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -11,6 +11,7 @@
 /datum/addiction/opiods/withdrawal_enters_stage_2(mob/living/carbon/affected_carbon)
 	. = ..()
 	affected_carbon.apply_status_effect(/datum/status_effect/high_blood_pressure)
+	affected_carbon.stats?.set_skill_modifier(-1, /datum/rpg_skill/willpower, SKILL_SOURCE_OPIOD_WITHDRAWL)
 
 /datum/addiction/opiods/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
@@ -22,6 +23,7 @@
 	. = ..()
 	affected_carbon.remove_status_effect(/datum/status_effect/high_blood_pressure)
 	affected_carbon.set_disgust(affected_carbon.disgust * 0.5) //half their disgust to help
+	affected_carbon.stats?.remove_skill_modifier(-1, /datum/rpg_skill/willpower, SKILL_SOURCE_OPIOD_WITHDRAWL)
 
 ///Stimulants
 
@@ -55,6 +57,7 @@
 /datum/addiction/alcohol/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
 	affected_carbon.set_timed_status_effect(10 SECONDS * delta_time, /datum/status_effect/jitter, only_if_higher = TRUE)
+	affected_carbon.stats?.set_skill_modifier(-2, /datum/rpg_skill/handicraft, SKILL_SOURCE_ALCHOHOL_WITHDRAWL)
 
 /datum/addiction/alcohol/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
@@ -68,6 +71,10 @@
 	if(DT_PROB(4, delta_time))
 		if(!HAS_TRAIT(affected_carbon, TRAIT_ANTICONVULSANT))
 			affected_carbon.apply_status_effect(/datum/status_effect/seizure)
+
+/datum/addiction/alcohol/end_withdrawal(mob/living/carbon/affected_carbon)
+	. = ..()
+	affected_carbon.stats?.remove_skill_modifier(-2, /datum/rpg_skill/handicraft, SKILL_SOURCE_ALCHOHOL_WITHDRAWL)
 
 /datum/addiction/hallucinogens
 	name = "hallucinogen"
@@ -235,6 +242,7 @@
 /datum/addiction/nicotine/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
 	affected_carbon.set_timed_status_effect(10 SECONDS * delta_time, /datum/status_effect/jitter, only_if_higher = TRUE)
+	affected_carbon.stats?.set_skill_modifier(-2, /datum/rpg_skill/handicraft, SKILL_SOURCE_NICOTINE_WITHDRAWL) //can't focus without my cigs
 
 /datum/addiction/nicotine/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
@@ -247,3 +255,7 @@
 	affected_carbon.set_timed_status_effect(30 SECONDS * delta_time, /datum/status_effect/jitter, only_if_higher = TRUE)
 	if(DT_PROB(15, delta_time))
 		affected_carbon.emote("cough")
+
+/datum/addiction/nicotine/end_withdrawal(mob/living/carbon/affected_carbon)
+	. = ..()
+	affected_carbon.stats?.remove_skill_modifier(-2, /datum/rpg_skill/handicraft, SKILL_SOURCE_NICOTINE_WITHDRAWL)

--- a/code/modules/three_dsix/skills/coordination.dm
+++ b/code/modules/three_dsix/skills/coordination.dm
@@ -1,6 +1,6 @@
 /datum/rpg_skill/handicraft
 	name = "Handicraft"
-	desc = "Control and manipulate, with style"
+	desc = "Control and manipulate, with style."
 
 	parent_stat_type = /datum/rpg_stat/motorics
 

--- a/code/modules/three_dsix/skills/coordination.dm
+++ b/code/modules/three_dsix/skills/coordination.dm
@@ -1,6 +1,6 @@
 /datum/rpg_skill/handicraft
 	name = "Handicraft"
-	desc = "Forge new creations from rubble and ruin."
+	desc = "Control and manipulate, with style"
 
 	parent_stat_type = /datum/rpg_stat/motorics
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds skill debuffs to withdrawals
adds skill buff to nicotine 
makes the cheap lighter burn chance be a skill roll
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
adds like, realism or something
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Skill debuffs to drug withdrawals
add: Handicraft skill boost due to nicotine (Daedalus Dock does not promote nicotine usage but it does not deny how cool and radical it is)
tweak: using a cheap lighter is now a handicraft check rather than pure RNG
tweak: the description of the handicraft skill has been changed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
