### PR TITLE
Disposals tweaks

### DIFF
--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -301,9 +301,6 @@
 
 // handle machine interaction
 
-/obj/machinery/disposal/bin/ui_state(mob/user)
-	return GLOB.notcontained_state
-
 /obj/machinery/disposal/bin/ui_interact(mob/user, datum/tgui/ui)
 	if(machine_stat & BROKEN)
 		return

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -142,9 +142,13 @@
 /obj/structure/disposalholder/relaymove(mob/living/user, direction)
 	if(user.incapacitated())
 		return
-	for(var/mob/M in range(5, get_turf(src)))
-		M.show_message("<FONT size=[max(0, 5 - get_dist(src, M))]>CLONG, clong!</FONT>", MSG_AUDIBLE)
+
+	var/message = pick("CLUNK!", "CLONK!", "CLANK!", "BANG!")
+	audible_message(span_hear("[icon2html(src, hearers(src) | user)] [message]"))
 	playsound(src.loc, 'sound/effects/clang.ogg', 50, FALSE, FALSE)
+
+	var/armor = user.run_armor_check(attack_flag = BLUNT, silent = TRUE)
+	user.apply_damage(2, BRUTE, blocked = armor, spread_damage = TRUE)
 
 // called to vent all gas in holder to a location
 /obj/structure/disposalholder/proc/vent_gas(turf/T)

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -83,9 +83,19 @@
 	if(H2 && !H2.active)
 		H.merge(H2)
 
-	for(var/mob/living/L in H)
-		var/armor = L.run_armor_check(attack_flag = BLUNT, silent = TRUE)
-		L.apply_damage(3, BRUTE, blocked = armor, spread_damage = TRUE)
+	if(prob(5) && (locate(/mob/living) in H))
+		var/list/mobs = list()
+
+		for(var/mob/living/L in H)
+			mobs += L
+
+		var/message = pick("CLUNK!", "CLONK!", "CLANK!", "BANG!")
+		audible_message(span_hear("[icon2html(src, hearers(src) | mobs)] [message]"))
+		playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
+
+		for(var/mob/living/L as anything in mobs)
+			var/armor = L.run_armor_check(attack_flag = BLUNT, silent = TRUE)
+			L.apply_damage(5, BRUTE, blocked = armor, spread_damage = TRUE)
 
 	H.forceMove(P)
 	return P

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -91,7 +91,7 @@
 
 		var/message = pick("CLUNK!", "CLONK!", "CLANK!", "BANG!")
 		audible_message(span_hear("[icon2html(src, hearers(src) | mobs)] [message]"))
-		playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
+		playsound(src, 'sound/effects/clang.ogg', 50, FALSE, FALSE)
 
 		for(var/mob/living/L as anything in mobs)
 			var/armor = L.run_armor_check(attack_flag = BLUNT, silent = TRUE)

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -502,7 +502,7 @@ em {
 }
 
 .hear {
-  color: #7996ff;
+  color: #b6b4a9;
   font-style: italic;
 }
 
@@ -516,7 +516,7 @@ em {
 }
 
 .unconscious {
-  color: #cac5a5;
+  color: #b6b4a9;
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Disposals damage has been HEAVVVVVVVVVVVVVIIILLLLLLLLYYYYYY reduced.
qol: Mobs in disposals will now cause loud banging to occur as they travel down and get hurt.
qol: You can now use the disposals UI from within the bin.
tweak: Adjusted the text styling of Hearing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
