### PR TITLE
fix clown title

### DIFF
--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -10,12 +10,13 @@
 		/datum/employer/none
 	)
 
-	alt_titles = list("Mime")
+	alt_titles = list(JOB_CLOWN, "Mime")
 	outfits = list(
 		"Default" = list(
 			SPECIES_HUMAN = /datum/outfit/job/clown,
 			SPECIES_PLASMAMAN = /datum/outfit/job/clown/plasmaman,
 		),
+
 		"Mime" = list(
 			SPECIES_HUMAN = /datum/outfit/job/mime,
 			SPECIES_PLASMAMAN = /datum/outfit/job/mime/plasmaman,


### PR DESCRIPTION
comedy restored

:cl:
fix: You can now properly set your job title back to Clown.
/:cl:

