### PR TITLE
improvements to equipment slowdown

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -240,6 +240,8 @@ GLOBAL_LIST_INIT(security_wintercoat_allowed, typecacheof(list(
 #define EQUIP_DELAY_OVERSUIT (7 SECONDS)
 /// Delay base for things like coats that are trivially removed or put on.
 #define EQUIP_DELAY_COAT (2 SECONDS)
+/// Delay base for masks
+#define EQUIP_DELAY_MASK (1 SECONDS)
 /// Delay base for back-worn objects.
 #define EQUIP_DELAY_BACK (2 SECONDS)
 /// Delay base for belts.
@@ -248,3 +250,9 @@ GLOBAL_LIST_INIT(security_wintercoat_allowed, typecacheof(list(
 #define EQUIP_DELAY_GLOVES (1 SECONDS)
 /// Delay base for shoes.
 #define EQUIP_DELAY_SHOES (1 SECONDS)
+
+// Flags for self equipping items
+/// Allow movement during equip/unequip
+#define EQUIP_ALLOW_MOVEMENT (1<<0)
+/// Apply a slowdown when equipping or unequipping.
+#define EQUIP_SLOWDOWN (1<<1)

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -447,6 +447,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 */
 #define TRAIT_DONUT_LOVER "donut_lover"
 
+/// Equipping or unequipping an item
+#define TRAIT_EQUIPPING_OR_UNEQUIPPING "equipping_or_unequipping"
+
 /// `do_teleport` will not allow this atom to teleport
 #define TRAIT_NO_TELEPORT "no-teleport"
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -158,6 +158,8 @@ DEFINE_INTERACTABLE(/obj/item)
 	var/weak_against_armor = null
 	///What objects the suit storage can store
 	var/list/allowed = null
+	/// Flags for equipping/unequipping items, only applies to self manipulation.
+	var/equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	///In deciseconds, how long an item takes to equip; counts only for normal clothing slots, not pockets etc.
 	var/equip_delay_self = 0
 	///In deciseconds, how long an item takes to put on another person

--- a/code/game/objects/items/food/deepfried.dm
+++ b/code/game/objects/items/food/deepfried.dm
@@ -33,6 +33,7 @@
 	desc = fried.desc
 	w_class = fried.w_class
 	slowdown = fried.slowdown
+	equip_self_flags = fried.equip_self_flags
 	equip_delay_self = fried.equip_delay_self
 	equip_delay_other = fried.equip_delay_other
 	strip_delay = fried.strip_delay

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -12,6 +12,7 @@
 	attack_verb_continuous = list("challenges")
 	attack_verb_simple = list("challenge")
 
+	equip_delay_self = EQUIP_ALLOW_MOVEMENT
 	equip_delay_self = EQUIP_DELAY_GLOVES
 	equip_delay_other = EQUIP_DELAY_GLOVES + (3 SECONDS)
 	strip_delay = EQUIP_DELAY_GLOVES + (3 SECONDS)

--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -7,6 +7,10 @@
 	equip_delay_other = 40
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION | CLOTHING_VOX_VARIATION
 
+	equip_delay_self = EQUIP_DELAY_MASK
+	equip_delay_other = EQUIP_DELAY_MASK * 1.5
+	strip_delay = EQUIP_DELAY_MASK * 1.5
+
 	var/modifies_speech = FALSE
 	var/mask_adjusted = FALSE
 	var/adjusted_flags = null

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -14,6 +14,7 @@
 	permeability_coefficient = 0.5
 	slowdown = 0
 
+	equip_self_flags = NONE
 	equip_delay_self = EQUIP_DELAY_SHOES
 	equip_delay_other = EQUIP_DELAY_SHOES * 1.5
 	strip_delay = EQUIP_DELAY_SHOES // In stripping code, if the mob is standing, it adds additional time.

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -11,6 +11,7 @@
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound = 'sound/items/handling/cloth_pickup.ogg'
 
+	equip_self_flags = NONE
 	equip_delay_self = EQUIP_DELAY_OVERSUIT
 	equip_delay_other = EQUIP_DELAY_OVERSUIT * 1.5
 	strip_delay = EQUIP_DELAY_OVERSUIT * 1.5

--- a/code/modules/clothing/suits/chaplainsuits.dm
+++ b/code/modules/clothing/suits/chaplainsuits.dm
@@ -3,6 +3,7 @@
 /obj/item/clothing/suit/chaplainsuit
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/food/drinks/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5
@@ -10,6 +11,7 @@
 /obj/item/clothing/suit/hooded/chaplainsuit
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/food/drinks/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -12,6 +12,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDESUITSTORAGE
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5

--- a/code/modules/clothing/suits/jacket.dm
+++ b/code/modules/clothing/suits/jacket.dm
@@ -10,6 +10,7 @@
 
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION | CLOTHING_TESHARI_VARIATION | CLOTHING_VOX_VARIATION
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -54,6 +54,7 @@
 
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION | CLOTHING_TESHARI_VARIATION | CLOTHING_VOX_VARIATION
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5
@@ -80,6 +81,7 @@
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION | CLOTHING_TESHARI_VARIATION | CLOTHING_VOX_VARIATION
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5
@@ -115,6 +117,7 @@
 
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON | CLOTHING_TESHARI_VARIATION | CLOTHING_VOX_VARIATION
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5
@@ -133,6 +136,7 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5
@@ -239,6 +243,7 @@
 	cold_protection = CHEST|ARMS
 	heat_protection = CHEST|ARMS
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5
@@ -284,6 +289,7 @@
 	armor = list(BLUNT = 0, PUNCTURE = 0, SLASH = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 50, ACID = 50)
 	supports_variations_flags = CLOTHING_TESHARI_VARIATION
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -28,6 +28,7 @@
 
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON | CLOTHING_TESHARI_VARIATION | CLOTHING_VOX_VARIATION
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -3,6 +3,7 @@
 /obj/item/clothing/suit/hooded
 	actions_types = list(/datum/action/item_action/toggle_hood)
 
+	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
 	equip_delay_self = EQUIP_DELAY_COAT
 	equip_delay_other = EQUIP_DELAY_COAT * 1.5
 	strip_delay = EQUIP_DELAY_COAT * 1.5

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -15,6 +15,7 @@
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound = 'sound/items/handling/cloth_pickup.ogg'
 
+	equip_self_flags = NONE
 	equip_delay_self = EQUIP_DELAY_UNDERSUIT
 	equip_delay_other = EQUIP_DELAY_UNDERSUIT * 1.5
 	strip_delay = EQUIP_DELAY_UNDERSUIT * 1.5

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -660,7 +660,14 @@
 		span_notice("[src] starts to put on [I]..."),
 		span_notice("You start to put on [I]...")
 	)
-	return do_after(src, src, I.equip_delay_self, DO_PUBLIC, display = I)
+
+	. = I.do_equip_wait(src)
+
+	if(.)
+		visible_message(
+			span_notice("[src] puts on [I]."),
+			span_notice("You put on [I].")
+		)
 
 /mob/living/carbon/human/unequip_delay_self_check(obj/item/I)
 	if(!I.equip_delay_self || is_holding(I))
@@ -668,6 +675,31 @@
 
 	visible_message(
 		span_notice("[src] starts to take off [I]..."),
-		span_notice("You start to take off [I]...")
+		span_notice("You start to take off [I]..."),
 	)
-	return do_after(src, src, I.equip_delay_self, DO_PUBLIC, display = I)
+
+	. = I.do_equip_wait(src)
+
+	if(.)
+		visible_message(
+			span_notice("[src] takes off [I]."),
+			span_notice("You takes off [I].")
+		)
+
+/// Called by equip_delay_self and unequip_delay_self.
+/obj/item/proc/do_equip_wait(mob/living/L)
+	var/flags = DO_PUBLIC
+	if(equip_self_flags & EQUIP_ALLOW_MOVEMENT)
+		flags |= IGNORE_USER_LOC_CHANGE | IGNORE_TARGET_LOC_CHANGE
+
+	if(equip_self_flags & EQUIP_SLOWDOWN)
+		L.add_movespeed_modifier(/datum/movespeed_modifier/equipping)
+
+	ADD_TRAIT(L, TRAIT_EQUIPPING_OR_UNEQUIPPING, ref(src))
+
+	. = do_after(L, L, equip_delay_self, flags, display = src)
+
+	REMOVE_TRAIT(L, TRAIT_EQUIPPING_OR_UNEQUIPPING, ref(src))
+
+	if(!HAS_TRAIT(L, TRAIT_EQUIPPING_OR_UNEQUIPPING))
+		L.remove_movespeed_modifier(/datum/movespeed_modifier/equipping)

--- a/code/modules/movespeed/modifiers/items.dm
+++ b/code/modules/movespeed/modifiers/items.dm
@@ -16,3 +16,6 @@
 
 /datum/movespeed_modifier/sphere
 	slowdown = -0.5
+
+/datum/movespeed_modifier/equipping
+	slowdown = 1.5


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: (Un)Equipping items such as gloves, backpacks, jackets, labcoats, and belts can now be done while moving.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
