### PR TITLE
REOPEN: Allow viewing account link code without panic bunker

### DIFF
--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -45,6 +45,7 @@
 			full_version = "[M.client.byond_version].[M.client.byond_build ? M.client.byond_build : "xxx"]"
 		body += "<br>\[<b>Byond version:</b> [full_version]\]<br>"
 		body += "<br><b>Input Mode:</b> [M.client.hotkeys ? "Using Hotkeys" : "Using Classic Input"]<br>"
+		body += "<br><b>Linked Discord ID:</b> [M.client.linked_discord_account ? M.client.linked_discord_account : "NONE"]<br>"
 
 
 	body += "<br><br>\[ "

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -45,7 +45,10 @@
 			full_version = "[M.client.byond_version].[M.client.byond_build ? M.client.byond_build : "xxx"]"
 		body += "<br>\[<b>Byond version:</b> [full_version]\]<br>"
 		body += "<br><b>Input Mode:</b> [M.client.hotkeys ? "Using Hotkeys" : "Using Classic Input"]<br>"
-		body += "<br><b>Linked Discord ID:</b> [M.client.linked_discord_account ? M.client.linked_discord_account : "NONE"]<br>"
+		if(isnull(M.client.linked_discord_account))
+			body += "<br><b>Linked Discord ID:</b> <code>MISSING RESPONSE DATUM, HAVE THEY JUST JOINED OR IS SQL DISABLED?</code><br>"
+		else
+			body += "<br><b>Linked Discord ID:</b> <code>[M.client.linked_discord_account.valid ? M.client.linked_discord_account.discord_id : "NONE"]</code><br>"
 
 
 	body += "<br><br>\[ "

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -111,6 +111,9 @@
 	var/account_join_date = null
 	///Age of byond account in days
 	var/account_age = -1
+	///Linked Discord account ID. Null is valid if the bunker is disabled.
+	var/linked_discord_account = null
+
 
 	preload_rsc = PRELOAD_RSC
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -112,7 +112,7 @@
 	///Age of byond account in days
 	var/account_age = -1
 	///Linked Discord account ID. Null is valid if the bunker is disabled.
-	var/linked_discord_account = null
+	var/datum/discord_link_record/linked_discord_account = NULL
 
 
 	preload_rsc = PRELOAD_RSC

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -112,7 +112,7 @@
 	///Age of byond account in days
 	var/account_age = -1
 	///Linked Discord account ID. Null is valid if the bunker is disabled.
-	var/datum/discord_link_record/linked_discord_account = NULL
+	var/datum/discord_link_record/linked_discord_account = null
 
 
 	preload_rsc = PRELOAD_RSC

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -533,6 +533,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	//Clear the credits browser if it's left over the from the previous round
 	clear_credits()
 
+	//Open to moving this: Pull the player's discord link if one exists:
+	linked_discord_account = discord_lookup_id(ckey)
+
 	view_size = new(src, getScreenSize(prefs.read_preference(/datum/preference/toggle/widescreen)))
 	view_size.resetFormat()
 	view_size.setZoomMode()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -534,7 +534,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	clear_credits()
 
 	//Open to moving this: Pull the player's discord link if one exists:
-	linked_discord_account = discord_lookup_id(ckey)
+	discord_read_linked_id()
 
 	view_size = new(src, getScreenSize(prefs.read_preference(/datum/preference/toggle/widescreen)))
 	view_size.resetFormat()

--- a/code/modules/discord/discord_helpers.dm
+++ b/code/modules/discord/discord_helpers.dm
@@ -52,3 +52,27 @@
 	if(link)
 		return link.valid
 	return FALSE
+
+/**
+ * Checks if the the given ckey has a valid discord link. This also updates the client's linked account var.
+ * Returns: TRUE if valid, FALSE if invalid or missing.
+ */
+/client/proc/discord_read_linked_id()
+	var/datum/discord_link_record/link = find_discord_link_by_ckey(ckey, timebound = FALSE) //We need their persistent link.
+	if(!link)
+
+		//No link history *at all?*, let's quietly create a blank one for them and check again.
+		discord_generate_one_time_token(ckey)
+		link = find_discord_link_by_ckey(ckey, timebound = FALSE)
+
+		if(!link)
+			//Fuck it, I give up. Set return value and stack.
+			. = FALSE
+			CRASH("Could not coerce a valid discord link record for [ckey].")
+
+	linked_discord_account = link
+
+	if(link.valid && link.discord_id)
+		return TRUE
+
+	return FALSE

--- a/code/modules/mob/dead/new_player/new_player_panel.dm
+++ b/code/modules/mob/dead/new_player/new_player_panel.dm
@@ -23,17 +23,19 @@
 	if(!parent.client)
 		return
 
+
+	if(href_list["verify"])
+		show_otp_menu()
+		return TRUE
+
+	if(href_list["link_to_discord"])
+		var/_link = CONFIG_GET(string/panic_bunker_discord_link)
+		if(_link)
+			parent << link(_link)
+		return TRUE
+
+	//Restricted clients can't do anything else.
 	if(parent.client.restricted_mode)
-		if(href_list["verify"])
-			show_otp_menu()
-			return TRUE
-
-		if(href_list["link_to_discord"])
-			var/_link = CONFIG_GET(string/panic_bunker_discord_link)
-			if(_link)
-				parent << link(_link)
-			return TRUE
-
 		return TRUE
 
 	if(href_list["npp_options"])
@@ -218,6 +220,9 @@
 				<div>
 					>[LINKIFY_CONSOLE_OPTION("lore_primer.txt", "view_primer=1")]
 				</div>
+				<div>
+					>[LINKIFY_CONSOLE_OPTION("discord_link.lnk", "verify=1")]
+				</div>
 				[poll]
 				<br>
 				<div>
@@ -330,6 +335,10 @@
 	if(!parent.client)
 		return
 
+	if(parent.client.linked_discord_account)
+		alert(parent.client, "Your discord account is already linked.\nIf you believe this is in error, please contact staff.\nLinked ID: [parent.client.linked_discord_account]", "Already Linked")
+		return
+
 	var/discord_otp = parent.client.discord_get_or_generate_one_time_token_for_ckey(parent.ckey)
 	var/discord_prefix = CONFIG_GET(string/discordbotcommandprefix)
 	var/browse_body = {"
@@ -348,7 +357,8 @@
 	"}
 
 	var/datum/browser/popup = new(parent, "discordauth", "<center><div>Verification</div></center>", 660, 270)
-	popup.set_window_options("can_close=0;focus=true;can_resize=0")
+	//If we aren't in restricted mode, let them close the window.
+	popup.set_window_options("can_close=[!parent.client.restricted_mode];focus=true;can_resize=0")
 	popup.set_content(browse_body)
 	popup.open()
 

--- a/code/modules/mob/dead/new_player/new_player_panel.dm
+++ b/code/modules/mob/dead/new_player/new_player_panel.dm
@@ -335,8 +335,16 @@
 	if(!parent.client)
 		return
 
-	if(parent.client.linked_discord_account)
-		alert(parent.client, "Your discord account is already linked.\nIf you believe this is in error, please contact staff.\nLinked ID: [parent.client.linked_discord_account]", "Already Linked")
+	if(!CONFIG_GET(flag/sql_enabled))
+		alert(parent.client, "No database to link to, bud. Scream at the host.", "Writing to Nowhere.")
+		return
+
+	if(isnull(parent.client.linked_discord_account))
+		alert(parent.client, "You haven't fully loaded, please wait...", "Please Wait")
+		return
+
+	if(parent.client.linked_discord_account?.valid)
+		alert(parent.client, "Your discord account is already linked.\nIf you believe this is in error, please contact staff.\nLinked ID: [parent.client.linked_discord_account.discord_id]", "Already Linked")
 		return
 
 	var/discord_otp = parent.client.discord_get_or_generate_one_time_token_for_ckey(parent.ckey)


### PR DESCRIPTION
:cl:
server: Discord account linking no longer hard-requires the panic bunker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
