### PR TITLE
fixes stamina damage

### DIFF
--- a/code/modules/mob/mob_attacked_by.dm
+++ b/code/modules/mob/mob_attacked_by.dm
@@ -2,8 +2,9 @@
 	var/hit_zone = BODY_ZONE_CHEST
 	var/hit_zone_text = "body"
 
+	var/ishuman = ishuman(src)
 	// Humans have miss chance. We dont apply this to living mobs for my sanity, i guess.
-	if(ishuman(src))
+	if(ishuman)
 		var/target_zone = deprecise_zone(attacker.zone_selected) //our REAL intended target
 
 		// Can't hit a bodypart that doesn't exist!
@@ -60,7 +61,7 @@
 	if(damage <= 0)
 		return MOB_ATTACKEDBY_NO_DAMAGE
 
-	if(ishuman(src) || client) // istype(src) is kinda bad, but it's to avoid spamming the blackbox
+	if(ishuman || client) // istype(src) is kinda bad, but it's to avoid spamming the blackbox
 		SSblackbox.record_feedback("nested tally", "item_used_for_combat", 1, list("[attacking_item.force]", "[attacking_item.type]"))
 		SSblackbox.record_feedback("tally", "zone_targeted", 1, parse_zone(deprecise_zone(attacker.zone_selected)))
 
@@ -77,6 +78,16 @@
 	on_take_combat_damage(damage_done, hit_zone, armor_block, attacking_item, attacker)
 	return MOB_ATTACKEDBY_SUCCESS
 
+/mob/living/carbon/human/attacked_by(obj/item/attacking_item, mob/living/attacker)
+	. = ..()
+	if(. != MOB_ATTACKEDBY_SUCCESS)
+		return .
+
+	if(attacking_item.stamina_damage)
+		var/damage = attacking_item.stamina_damage
+		if(prob(attacking_item.stamina_critical_chance))
+			damage *= attacking_item.stamina_critical_modifier
+		stamina.adjust(-damage)
 /**
  * Called when we take damage, used to cause effects such as a blood splatter.
  *

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -99,6 +99,7 @@
 #include "combat_emp_flashlight.dm"
 #include "combat_flash.dm"
 #include "combat_pistol_whip.dm"
+#include "combat_stamina.dm"
 #include "component_tests.dm"
 #include "confusion.dm"
 #include "connect_loc.dm"

--- a/code/modules/unit_tests/combat_stamina.dm
+++ b/code/modules/unit_tests/combat_stamina.dm
@@ -4,7 +4,7 @@
 	var/obj/item/chair/chair = ALLOCATE_BOTTOM_LEFT()
 
 	chair.stamina_cost = 50
-	victim.put_in_active_hand(chair)
+	attacker.put_in_active_hand(chair)
 	attacker.set_combat_mode(TRUE)
 	ADD_TRAIT(attacker, TRAIT_PERFECT_ATTACKER, TRAIT_SOURCE_UNIT_TESTS)
 

--- a/code/modules/unit_tests/combat_stamina.dm
+++ b/code/modules/unit_tests/combat_stamina.dm
@@ -10,7 +10,7 @@
 
 	click_wrapper(attacker, victim)
 
-	var/expected_loss = attacker.stamina.maximum - 50
+	var/expected_loss = 50
 	var/actual_loss = attacker.stamina.loss
 	TEST_ASSERT_EQUAL(actual_loss, expected_loss, "Attacker didn't lose 50 stamina, lost [actual_loss] instead.")
 
@@ -27,6 +27,6 @@
 
 	click_wrapper(attacker, victim)
 
-	var/expected_loss = victim.stamina.maximum - 50
+	var/expected_loss = 50
 	var/actual_loss = victim.stamina.loss
 	TEST_ASSERT_EQUAL(actual_loss, expected_loss, "Victim didn't lose 50 stamina, lost [actual_loss] instead.")

--- a/code/modules/unit_tests/combat_stamina.dm
+++ b/code/modules/unit_tests/combat_stamina.dm
@@ -1,0 +1,32 @@
+/datum/unit_test/stamina_swing/Run()
+	var/mob/living/carbon/human/consistent/attacker = ALLOCATE_BOTTOM_LEFT()
+	var/mob/living/carbon/human/consistent/victim = ALLOCATE_BOTTOM_LEFT()
+	var/obj/item/chair/chair = ALLOCATE_BOTTOM_LEFT()
+
+	chair.stamina_cost = 50
+	victim.put_in_active_hand(chair)
+	attacker.set_combat_mode(TRUE)
+	ADD_TRAIT(attacker, TRAIT_PERFECT_ATTACKER, TRAIT_SOURCE_UNIT_TESTS)
+
+	click_wrapper(attacker, victim)
+
+	var/expected_loss = attacker.stamina.maximum - 50
+	var/actual_loss = attacker.stamina.loss
+	TEST_ASSERT_EQUAL(actual_loss, expected_loss, "Attacker didn't lose 50 stamina, lost [actual_loss] instead.")
+
+/datum/unit_test/stamina_damage/Run()
+	var/mob/living/carbon/human/consistent/attacker = ALLOCATE_BOTTOM_LEFT()
+	var/mob/living/carbon/human/consistent/victim = ALLOCATE_BOTTOM_LEFT()
+	var/obj/item/chair/chair = ALLOCATE_BOTTOM_LEFT()
+
+	chair.stamina_critical_chance = 0
+	chair.stamina_damage = 50
+	victim.put_in_active_hand(chair)
+	attacker.set_combat_mode(TRUE)
+	ADD_TRAIT(attacker, TRAIT_PERFECT_ATTACKER, TRAIT_SOURCE_UNIT_TESTS)
+
+	click_wrapper(attacker, victim)
+
+	var/expected_loss = victim.stamina.maximum - 50
+	var/actual_loss = victim.stamina.loss
+	TEST_ASSERT_EQUAL(actual_loss, expected_loss, "Victim didn't lose 50 stamina, lost [actual_loss] instead.")

--- a/code/modules/unit_tests/combat_stamina.dm
+++ b/code/modules/unit_tests/combat_stamina.dm
@@ -21,7 +21,7 @@
 
 	chair.stamina_critical_chance = 0
 	chair.stamina_damage = 50
-	victim.put_in_active_hand(chair)
+	attacker.put_in_active_hand(chair)
 	attacker.set_combat_mode(TRUE)
 	ADD_TRAIT(attacker, TRAIT_PERFECT_ATTACKER, TRAIT_SOURCE_UNIT_TESTS)
 


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Stamina damage is dealt when attacking with items again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
