### PR TITLE
Minor bug with equip delays

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -655,9 +655,14 @@
 /mob/proc/unequip_delay_self_check(obj/item/I, bypass_delay)
 	return TRUE
 
+#define EQUIPPING_INTERACTION_KEY(item) "equipping_item_[ref(item)]"
+
 /mob/living/carbon/human/equip_delay_self_check(obj/item/I, bypass_delay)
 	if(!I.equip_delay_self || bypass_delay)
 		return TRUE
+
+	if(DOING_INTERACTION(src, EQUIPPING_INTERACTION_KEY(I)))
+		return FALSE
 
 	visible_message(
 		span_notice("[src] starts to put on [I]..."),
@@ -675,6 +680,9 @@
 /mob/living/carbon/human/unequip_delay_self_check(obj/item/I)
 	if(!I.equip_delay_self || is_holding(I))
 		return TRUE
+
+	if(DOING_INTERACTION(src, EQUIPPING_INTERACTION_KEY(I)))
+		return FALSE
 
 	visible_message(
 		span_notice("[src] starts to take off [I]..."),
@@ -700,9 +708,11 @@
 
 	ADD_TRAIT(L, TRAIT_EQUIPPING_OR_UNEQUIPPING, ref(src))
 
-	. = do_after(L, L, equip_delay_self, flags, display = src)
+	. = do_after(L, L, equip_delay_self, flags, interaction_key = EQUIPPING_INTERACTION_KEY(src), display = src)
 
 	REMOVE_TRAIT(L, TRAIT_EQUIPPING_OR_UNEQUIPPING, ref(src))
 
 	if(!HAS_TRAIT(L, TRAIT_EQUIPPING_OR_UNEQUIPPING))
 		L.remove_movespeed_modifier(/datum/movespeed_modifier/equipping)
+
+#undef EQUIPPING_INTERACTION_KEY


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can no longer bypass movement speed from equip delays.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
