### PR TITLE
Adds a screen alert for being prone

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -839,6 +839,19 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "You are in very bad shape. Max stamina reduced by 100 and stamina regen reduced by 5."
 	icon_state = ALERT_SOFTCRIT
 
+/atom/movable/screen/alert/lying_down
+	name = "Prone"
+	desc = "You are prone. Click to attempt to stand up."
+	icon_state = "paralysis"
+
+/atom/movable/screen/alert/lying_down/Click(location, control, params)
+	. = ..()
+	if(!.)
+		return
+
+	var/mob/living/living_owner = owner
+	living_owner.set_resting(FALSE)
+
 // PRIVATE = only edit, use, or override these if you're editing the system as a whole
 
 // Re-render all alerts - also called in /datum/hud/show_hud() because it's needed there

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -528,25 +528,33 @@
 /mob/living/proc/on_lying_down(new_lying_angle)
 	if(layer == initial(layer)) //to avoid things like hiding larvas.
 		layer = LYING_MOB_LAYER //so mob lying always appear behind standing mobs
+
 	ADD_TRAIT(src, TRAIT_UI_BLOCKED, LYING_DOWN_TRAIT)
 	ADD_TRAIT(src, TRAIT_PULL_BLOCKED, LYING_DOWN_TRAIT)
+
 	set_density(FALSE) // We lose density and stop bumping passable dense things.
+
 	if(HAS_TRAIT(src, TRAIT_FLOORED) && !(dir & (NORTH|SOUTH)))
 		setDir(pick(NORTH, SOUTH)) // We are and look helpless.
-	body_position_pixel_y_offset = PIXEL_Y_OFFSET_LYING
-	playsound(loc, 'goon/sounds/body_thud.ogg', ishuman(src) ? 40 : 15, 1, 0.3)
 
+	body_position_pixel_y_offset = PIXEL_Y_OFFSET_LYING
+
+	playsound(loc, 'goon/sounds/body_thud.ogg', ishuman(src) ? 40 : 15, 1, 0.3)
+	throw_alert("lying_down", /atom/movable/screen/alert/lying_down)
 
 /// Proc to append behavior related to lying down.
 /mob/living/proc/on_standing_up()
 	if(layer == LYING_MOB_LAYER)
 		layer = initial(layer)
+
 	set_density(initial(density)) // We were prone before, so we become dense and things can bump into us again.
+
 	REMOVE_TRAIT(src, TRAIT_UI_BLOCKED, LYING_DOWN_TRAIT)
 	REMOVE_TRAIT(src, TRAIT_PULL_BLOCKED, LYING_DOWN_TRAIT)
+
 	body_position_pixel_y_offset = 0
 
-
+	clear_alert("lying_down")
 
 //Recursive function to find everything a mob is holding. Really shitty proc tbh.
 /mob/living/get_contents()


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Added a screen alert for being prone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
