### PR TITLE
adds 2 new reagents

### DIFF
--- a/code/modules/reagents/chemistry/goon_reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/goon_reagents/medicine_reagents.dm
@@ -62,3 +62,62 @@
 
 /datum/reagent/medicine/strange_reagent/affect_touch(mob/living/carbon/C, removed)
 	holder.del_reagent(type)
+
+/datum/reagent/medicine/silver_sulfadiazine
+	name = "Silver Sulfadiazine"
+	description = "This antibacterial compound is used to treat burn victims."
+	reagent_state = LIQUID
+	color = "#F0DC00"
+	touch_met = 1
+	harmful = TRUE
+	taste_description = "burn cream"
+
+	var/heal_per_unit = 1.2
+
+/datum/reagent/medicine/silver_sulfadiazine/expose_mob(mob/living/exposed_mob, reac_volume, exposed_temperature, datum/reagents/source, methods, show_message, touch_protection)
+	. = ..()
+
+	if(!(methods & TOUCH))
+		return
+
+	exposed_mob.heal_overall_damage(burn = heal_per_unit * reac_volume, required_status = BODYTYPE_ORGANIC)
+
+/datum/reagent/medicine/silver_sulfadiazine/affect_blood(mob/living/carbon/C, removed)
+	C.adjustToxLoss(0.5 * removed, FALSE)
+	return TRUE
+
+/datum/reagent/medicine/silver_sulfadiazine/affect_touch(mob/living/carbon/C, removed)
+	C.heal_overall_damage(burn = heal_per_unit * removed, required_status = BODYTYPE_ORGANIC)
+	return TRUE
+
+/datum/reagent/medicine/styptic_powder
+	name = "Styptic Powder"
+	description = "Styptic (aluminum sulfate) powder helps control bleeding and heal physical wounds."
+	reagent_state = LIQUID
+	color = "#FF9696"
+	touch_met = 1
+	harmful = TRUE
+	taste_description = "wound cream"
+
+	var/heal_per_unit = 1.2
+
+/datum/reagent/medicine/styptic_powder/expose_mob(mob/living/exposed_mob, reac_volume, exposed_temperature, datum/reagents/source, methods, show_message, touch_protection)
+	. = ..()
+
+	if(!(methods & TOUCH))
+		return
+
+	exposed_mob.heal_overall_damage(heal_per_unit * reac_volume, required_status = BODYTYPE_ORGANIC)
+
+	if(ishuman(exposed_mob))
+		var/mob/living/carbon/human/H = exposed_mob
+		H.notify_pain(1, "Your flesh burns.", TRUE)
+
+/datum/reagent/medicine/styptic_powder/affect_blood(mob/living/carbon/C, removed)
+	C.adjustToxLoss(0.5 * removed, FALSE)
+	return TRUE
+
+/datum/reagent/medicine/styptic_powder/affect_touch(mob/living/carbon/C, removed)
+	C.heal_overall_damage(heal_per_unit * removed, required_status = BODYTYPE_ORGANIC)
+	APPLY_CHEM_EFFECT(C, CE_ANTICOAGULANT, -1)
+	return TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -151,7 +151,7 @@
 	description = "Meralyne is a concentrated form of bicaridine and can be used to treat extensive physical trauma."
 	color = "#FD5964"
 	taste_mult = 12
-	metabolization_rate = 0.2
+	metabolization_rate = 0.4
 	overdose_threshold = 20
 
 /datum/reagent/medicine/meralyne/affect_blood(mob/living/carbon/C, removed)
@@ -187,6 +187,7 @@
 	taste_mult = 1.5
 	reagent_state = LIQUID
 	color = "#ff8000"
+	metabolization_rate = 0.4
 	overdose_threshold = 20
 	value = 3.9
 

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -197,3 +197,26 @@
 	// Chlorine is a good enough substitute for bromine right?
 	required_reagents = list(/datum/reagent/fuel/oil = 1, /datum/reagent/carbon = 1, /datum/reagent/chlorine = 1, /datum/reagent/diethylamine = 1, /datum/reagent/consumable/ethanol = 1)
 	mix_message = "The mixture fizzes gently."
+
+/datum/chemical_reaction/styptic_powder
+	results = list(/datum/reagent/medicine/styptic_powder = 2)
+	required_reagents = list(
+		/datum/reagent/aluminium = 1,
+		/datum/reagent/hydrogen = 1,
+		/datum/reagent/oxygen = 1,
+		/datum/reagent/medicine/bicaridine = 1,
+	)
+	mix_message = "The solution yields an astringent powder."
+
+/datum/chemical_reaction/silver_sulfadiazine
+	results = list(/datum/reagent/medicine/silver_sulfadiazine = 4)
+	// 	C10H9AgN4O2S is the chemical compound for silver sulf in real life. we conveniently have all of these chemicals, so let's replicate it here
+	required_reagents = list(
+		/datum/reagent/medicine/kelotane = 1, // Kelotane brings the carbon
+		/datum/reagent/hydrogen = 1,
+		/datum/reagent/silver = 1,
+		/datum/reagent/nitrogen = 1,
+		/datum/reagent/oxygen = 1,
+		/datum/reagent/sulfur = 1
+	)
+	mix_message = "A strong and cloying odor begins to bubble from the mixture."

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -213,9 +213,8 @@
 	// 	C10H9AgN4O2S is the chemical compound for silver sulf in real life. we conveniently have all of these chemicals, so let's replicate it here
 	required_reagents = list(
 		/datum/reagent/medicine/kelotane = 1, // Kelotane brings the carbon
-		/datum/reagent/hydrogen = 1,
+		/datum/reagent/ammonia = 1, // Ammonia brings the hydrogen and nitrogen
 		/datum/reagent/silver = 1,
-		/datum/reagent/nitrogen = 1,
 		/datum/reagent/oxygen = 1,
 		/datum/reagent/sulfur = 1
 	)

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -5,10 +5,11 @@
 	icon_state = "bandaid"
 	inhand_icon_state = "bandaid"
 	possible_transfer_amounts = list()
-	volume = 40
+	volume = 15
 	apply_type = TOUCH
 	apply_method = "apply"
-	self_delay = 30 // three seconds
+	self_delay = 2 SECONDS
+	other_delay = 1 SECOND
 	dissolvable = FALSE
 
 /obj/item/reagent_containers/pill/patch/attack(mob/living/L, mob/user)
@@ -27,8 +28,27 @@
 		return FALSE
 	return TRUE // Masks were stopping people from "eating" patches. Thanks, inheritance.
 
+/obj/item/reagent_containers/pill/patch/on_consumption(mob/M, mob/user)
+	if(!reagents.total_volume)
+		return
+
+	reagents.trans_to(M, reagents.total_volume, transfered_by = user, methods = TOUCH)
+	reagents.clear_reagents()
+
 /obj/item/reagent_containers/pill/patch/synthflesh
 	name = "synthflesh patch"
 	desc = "Helps with brute and burn injuries. Slightly toxic."
-	list_reagents = list(/datum/reagent/medicine/synthflesh = 20)
+	list_reagents = list(/datum/reagent/medicine/synthflesh = 15)
 	icon_state = "bandaid_both"
+
+/obj/item/reagent_containers/pill/patch/styptic_powder
+	name = "styptic patch"
+	desc = "A patch for aiding the healing of cuts and abrasions."
+	list_reagents = list(/datum/reagent/medicine/styptic_powder = 15)
+	icon_state = "bandaid_brute"
+
+/obj/item/reagent_containers/pill/patch/silver_sulfadiazine
+	name = "silver sulfadiazine patch"
+	desc = "A path which soothes burns on flesh."
+	list_reagents = list(/datum/reagent/medicine/silver_sulfadiazine = 15)
+	icon_state = "bandaid_burn"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -14,6 +14,7 @@
 	var/apply_method = "swallow"
 	var/rename_with_volume = FALSE
 	var/self_delay = 0 //pills are instant, this is because patches inheret their aplication from pills
+	var/other_delay = 3 SECONDS
 	var/dissolvable = TRUE
 
 /obj/item/reagent_containers/pill/Initialize(mapload)
@@ -35,14 +36,25 @@
 		to_chat(M, span_notice("You [apply_method] [src]."))
 
 	else
-		M.visible_message(span_danger("[user] attempts to force [M] to [apply_method] [src]."), \
-							span_userdanger("[user] attempts to force you to [apply_method] [src]."))
-		if(!do_after(user, M, CHEM_INTERACT_DELAY(3 SECONDS, user), DO_PUBLIC, display = src))
-			return FALSE
-		M.visible_message(span_danger("[user] forces [M] to [apply_method] [src]."), \
-							span_userdanger("[user] forces you to [apply_method] [src]."))
+		M.visible_message(
+			span_danger("[user] attempts to force [M] to [apply_method] [src]."),
+			span_userdanger("[user] attempts to force you to [apply_method] [src].")
+		)
 
-	return on_consumption(M, user)
+		if(!do_after(user, M, CHEM_INTERACT_DELAY(other_delay, user), DO_PUBLIC, display = src))
+			return FALSE
+
+		M.visible_message(
+			span_danger("[user] forces [M] to [apply_method] [src]."),
+			span_userdanger("[user] forces you to [apply_method] [src].")
+		)
+
+	return consume(M, user)
+
+/// Consume the pill.
+/obj/item/reagent_containers/pill/proc/consume(mob/M, mob/user)
+	. = on_consumption(M, user)
+	qdel(src)
 
 ///Runs the consumption code, can be overriden for special effects
 /obj/item/reagent_containers/pill/proc/on_consumption(mob/M, mob/user)
@@ -52,7 +64,6 @@
 
 	if(reagents.total_volume)
 		reagents.trans_to(M, reagents.total_volume, transfered_by = user, methods = apply_type)
-	qdel(src)
 	return TRUE
 
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1111,7 +1111,7 @@
 		if(coag_level > 0)
 			bleed_rate *= 1 + coag_level
 		else
-			bleed_rate *= 0.5 / coag_level
+			bleed_rate *= 0.5 / -coag_level
 
 	return bleed_rate
 

--- a/code/modules/surgery/new_surgery/dental_implant.dm
+++ b/code/modules/surgery/new_surgery/dental_implant.dm
@@ -32,7 +32,7 @@
 		return
 
 	var/obj/item/reagent_containers/pill/pill = tool
-	pill.on_consumption(target, user)
+	pill.consume(target, user)
 	user.visible_message(span_warning("[pill] slips out of [user]'s hand, right down [target]'s throat!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	..()
 


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Silver Sulfadiazine, a fast-acting but inefficient topical burn healing reagent.
add: Styptic Powder, a fast-acting but inefficient topical brute healing reagent.
fix: Fixed coagulant effects causing errors.
balance: Doubled the metabolization rates of Dermaline and Meralyne. I felt they weren't impactful enough for how annoying they are to make.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
