### PR TITLE
Defib Cleanup

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -102,26 +102,13 @@
 	cell = locate(/obj/item/stock_parts/cell) in contents
 	update_power()
 
-/obj/item/defibrillator/ui_action_click()
-	INVOKE_ASYNC(src, PROC_REF(toggle_paddles))
+/obj/item/defibrillator/ui_action_click(mob/user, actiontype)
+	INVOKE_ASYNC(src, PROC_REF(toggle_paddles), user)
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/defibrillator/attack_hand(mob/user, list/modifiers)
-	if(loc == user)
-		if(slot_flags == ITEM_SLOT_BACK)
-			if(user.get_item_by_slot(ITEM_SLOT_BACK) == src)
-				ui_action_click()
-			else
-				to_chat(user, span_warning("Put the defibrillator on your back first!"))
-
-		else if(slot_flags == ITEM_SLOT_BELT)
-			if(user.get_item_by_slot(ITEM_SLOT_BELT) == src)
-				ui_action_click()
-			else
-				to_chat(user, span_warning("Strap the defibrillator's belt on first!"))
-		return
-	else if(istype(loc, /obj/machinery/defibrillator_mount))
-		ui_action_click() //checks for this are handled in defibrillator.mount.dm
+	if(equipped_to == user || istype(loc, /obj/machinery/defibrillator_mount))
+		toggle_paddles(user)
 	return ..()
 
 /obj/item/defibrillator/screwdriver_act(mob/living/user, obj/item/tool)
@@ -135,7 +122,8 @@
 
 /obj/item/defibrillator/attackby(obj/item/W, mob/user, params)
 	if(W == paddles)
-		toggle_paddles()
+		toggle_paddles(user)
+
 	else if(istype(W, /obj/item/stock_parts/cell))
 		var/obj/item/stock_parts/cell/C = W
 		if(cell)
@@ -151,6 +139,13 @@
 			update_power()
 	else
 		return ..()
+
+/obj/item/defibrillator/AltClick(mob/user)
+	. = ..()
+	if(!user.canUseTopic(src, USE_CLOSE|USE_NEED_HANDS))
+		return
+
+	toggle_paddles(user)
 
 /obj/item/defibrillator/emag_act(mob/user)
 	if(safety)
@@ -180,47 +175,52 @@
 		playsound(src, 'sound/machines/defib_saftyOn.ogg', 50, FALSE)
 	update_power()
 
-/obj/item/defibrillator/proc/toggle_paddles()
+/obj/item/defibrillator/verb/toggle_paddles_verb()
 	set name = "Toggle Paddles"
 	set category = "Object"
+	set src in view(1)
+
+	var/mob/living/user = usr
+	if(!istype(user) || !user.canUseTopic(src, USE_CLOSE|USE_NEED_HANDS))
+		return
+
+	toggle_paddles(user)
+
+/// Equips or unequips paddles. Overloaded AF.
+/obj/item/defibrillator/proc/toggle_paddles(mob/living/user)
 	on = !on
 
-	var/mob/living/carbon/user = usr
 	if(on)
 		//Detach the paddles into the user's hands
-		if(!usr.put_in_hands(paddles))
+		if(!user.put_in_hands(paddles))
 			on = FALSE
 			to_chat(user, span_warning("You need a free hand to hold the paddles!"))
 			update_power()
-			return
+			return FALSE
 	else
 		//Remove from their hands and back onto the defib unit
-		remove_paddles(user)
+		remove_paddles()
 
 	update_power()
 	update_action_buttons()
-
+	return TRUE
 
 /obj/item/defibrillator/equipped(mob/user, slot)
 	..()
 	if((slot_flags == ITEM_SLOT_BACK && slot != ITEM_SLOT_BACK) || (slot_flags == ITEM_SLOT_BELT && slot != ITEM_SLOT_BELT))
-		remove_paddles(user)
+		remove_paddles()
 		update_power()
 
 /obj/item/defibrillator/item_action_slot_check(slot, mob/user)
 	if(slot == user.getBackSlot())
 		return 1
 
-/obj/item/defibrillator/proc/remove_paddles(mob/user) //this fox the bug with the paddles when other player stole you the defib when you have the paddles equiped
-	if(ismob(paddles.loc))
-		var/mob/M = paddles.loc
-		M.dropItemToGround(paddles, TRUE)
-	return
+/obj/item/defibrillator/proc/remove_paddles() //this fox the bug with the paddles when other player stole you the defib when you have the paddles equiped
+	paddles.equipped_to?.dropItemToGround(paddles, TRUE)
 
 /obj/item/defibrillator/Destroy()
 	if(on)
-		var/M = get(paddles, /mob)
-		remove_paddles(M)
+		remove_paddles()
 	QDEL_NULL(paddles)
 	QDEL_NULL(cell)
 	return ..()
@@ -336,7 +336,17 @@
 
 /obj/item/shockpaddles/Initialize(mapload)
 	. = ..()
+	ADD_TRAIT(src, TRAIT_NO_STORAGE_INSERT, TRAIT_GENERIC) //stops shockpaddles from being inserted in BoH
 	AddElement(/datum/element/update_icon_updates_onmob, ITEM_SLOT_HANDS|ITEM_SLOT_BACK)
+	if(!req_defib)
+		return
+
+	if (!loc || !istype(loc, /obj/item/defibrillator)) //To avoid weird issues from admin spawns
+		return INITIALIZE_HINT_QDEL
+
+	defib = loc
+	busy = FALSE
+	update_appearance()
 
 /obj/item/shockpaddles/Destroy()
 	defib = null
@@ -347,6 +357,17 @@
 	if(!req_defib)
 		return
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(check_range))
+
+/obj/item/shockpaddles/attack_self(mob/user, modifiers)
+	. = ..()
+	if(.)
+		return
+
+	if(wielded)
+		unwield(user)
+	else
+		wield(user)
+	return TRUE
 
 /obj/item/shockpaddles/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	. = ..()
@@ -380,17 +401,6 @@
 	T.audible_message(span_notice("[src] beeps: Unit is recharged."))
 	playsound(src, 'sound/machines/defib_ready.ogg', 50, FALSE)
 	cooldown = FALSE
-	update_appearance()
-
-/obj/item/shockpaddles/Initialize(mapload)
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NO_STORAGE_INSERT, TRAIT_GENERIC) //stops shockpaddles from being inserted in BoH
-	if(!req_defib)
-		return //If it doesn't need a defib, just say it exists
-	if (!loc || !istype(loc, /obj/item/defibrillator)) //To avoid weird issues from admin spawns
-		return INITIALIZE_HINT_QDEL
-	defib = loc
-	busy = FALSE
 	update_appearance()
 
 /obj/item/shockpaddles/suicide_act(mob/user)

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -142,7 +142,7 @@
 
 /obj/item/defibrillator/AltClick(mob/user)
 	. = ..()
-	if(!user.canUseTopic(src, USE_CLOSE|USE_NEED_HANDS))
+	if(on || !user.canUseTopic(src, USE_CLOSE|USE_NEED_HANDS))
 		return
 
 	toggle_paddles(user)

--- a/code/modules/unit_tests/snapback_sanity.dm
+++ b/code/modules/unit_tests/snapback_sanity.dm
@@ -5,7 +5,7 @@
 	var/mob/living/carbon/human/user = ALLOCATE_BOTTOM_LEFT()
 	var/obj/item/defibrillator/defib = ALLOCATE_BOTTOM_LEFT()
 
-	TEST_ASSERT(user.put_in_hands(defib.paddles), "Mob failed to equip defib paddles.")
+	TEST_ASSERT(defib.toggle_paddles(user), "Mob failed to equip defib paddles.")
 	user.forceMove(locate(user.x + 2, user.y, user.z))
 
 	TEST_ASSERT(!user.is_holding(defib.paddles), "Mob is still holding defib paddles after moving out of range.")


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can now take paddles from a defibrillator at any time.
qol: You can use AltClick to take paddles from a defibrillator.
qol: You can use the Toggle Paddles verb to take paddles from a defibrillator.
qol: You can now use the Use In Hand keybind to wield/unwield paddles (Restoring old behavior).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
