### PR TITLE
Antagonist preferences start on

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -117,6 +117,7 @@ GLOBAL_LIST_INIT(special_roles, list(
 	ROLE_THIEF = 0,
 	ROLE_TRAITOR = 0,
 	ROLE_WIZARD = 14,
+	ROLE_VAMPIRE = 0,
 
 	// Midround
 	ROLE_ABDUCTOR = 0,

--- a/code/modules/client/preferences/antagonists.dm
+++ b/code/modules/client/preferences/antagonists.dm
@@ -5,7 +5,7 @@
 /datum/preference/blob/antagonists/create_default_value()
 	. = list()
 	for(var/antagonist in GLOB.special_roles)
-		.[antagonist] = FALSE
+		.[antagonist] = TRUE
 
 /datum/preference/blob/antagonists/deserialize(input, datum/preferences/preferences)
 	var/list/reference = create_default_value()


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: Antagonist preferences start ON.
fix: Sanguine Plague Outbreak didn't work due to an oversight.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
