### PR TITLE
Fix niche interaction with nested inventory deleting items

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -191,8 +191,9 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	view_audit_buttons()
 
 /mob/proc/create_mob_hud()
-	if(!client || hud_used)
+	if(!GET_CLIENT(src) || hud_used)
 		return
+
 	set_hud_used(new hud_type(src))
 	update_sight()
 	SEND_SIGNAL(src, COMSIG_MOB_HUD_CREATED)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -191,7 +191,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	view_audit_buttons()
 
 /mob/proc/create_mob_hud()
-	if(!GET_CLIENT(src) || hud_used)
+	if(!client || hud_used)
 		return
 
 	set_hud_used(new hud_type(src))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -305,17 +305,7 @@
 		. |= dropItemToGround(I)
 
 /mob/proc/putItemFromInventoryInHandIfPossible(obj/item/I, hand_index, force_removal = FALSE, use_unequip_delay = FALSE)
-	if(!can_put_in_hand(I, hand_index))
-		return FALSE
-	if(!temporarilyRemoveItemFromInventory(I, force_removal, use_unequip_delay = use_unequip_delay))
-		return FALSE
-
-	I.remove_item_from_storage(src)
-
-	if(!pickup_item(I, hand_index, ignore_anim = TRUE))
-		qdel(I)
-		CRASH("Assertion failure: putItemFromInventoryInHandIfPossible") //should never be possible
-	return TRUE
+	return pickup_item(I, hand_index, ignore_anim = TRUE)
 
 /// Switches the items inside of two hand indexes.
 /mob/proc/swapHeldIndexes(index_A, index_B)
@@ -412,6 +402,9 @@
 /mob/proc/tryUnequipItem(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE, use_unequip_delay = FALSE, slot = get_slot_by_item(I))
 	PROTECTED_PROC(TRUE)
 	if(!I) //If there's nothing to drop, the drop is automatically succesfull. If(unEquip) should generally be used to check for TRAIT_NODROP.
+		return TRUE
+
+	if(I.equipped_to != src) // It isn't even equipped to us.
 		return TRUE
 
 	if(!force && !canUnequipItem(I, newloc, no_move, invdrop, silent))

--- a/code/modules/unit_tests/combat/__include.dm
+++ b/code/modules/unit_tests/combat/__include.dm
@@ -6,5 +6,6 @@
 #include "combat_door_click.dm"
 #include "combat_emp_flashlight.dm"
 #include "combat_flash.dm"
+#include "combat_nested_inventory.dm"
 #include "combat_pistol_whip.dm"
 #include "combat_stamina.dm"

--- a/code/modules/unit_tests/combat/combat_nested_inventory.dm
+++ b/code/modules/unit_tests/combat/combat_nested_inventory.dm
@@ -7,9 +7,9 @@
 	var/obj/item/storage/box/survival/box = ALLOCATE_BOTTOM_LEFT()
 
 	box.forceMove(backpack)
-	user.equip_to_slot_if_possible(backpack, ITEM_SLOT_BACKPACK)
+	user.equip_to_slot_if_possible(backpack, ITEM_SLOT_BACK)
 
-	TEST_ASSERT(user.get_item_by_slot(ITEM_SLOT_BACKPACK) == backpack, "Mob did not equip the backpack.")
+	TEST_ASSERT(user.get_item_by_slot(ITEM_SLOT_BACK) == backpack, "Mob did not equip the backpack.")
 
 	var/obj/item/nested_item = box.contents[1]
 	var/atom/movable/screen/inventory/hand/hand_inventory = user.hud_used.hand_slots["[user.active_hand_index]"]

--- a/code/modules/unit_tests/combat/combat_nested_inventory.dm
+++ b/code/modules/unit_tests/combat/combat_nested_inventory.dm
@@ -7,7 +7,7 @@
 	var/obj/item/storage/box/survival/box = ALLOCATE_BOTTOM_LEFT()
 
 	box.forceMove(backpack)
-	user.equip_to_slot_if_possible(backpack)
+	user.equip_to_slot_if_possible(backpack, ITEM_SLOT_BACKPACK)
 
 	TEST_ASSERT(user.get_item_by_slot(ITEM_SLOT_BACKPACK) == backpack, "Mob did not equip the backpack.")
 

--- a/code/modules/unit_tests/combat/combat_nested_inventory.dm
+++ b/code/modules/unit_tests/combat/combat_nested_inventory.dm
@@ -3,7 +3,7 @@
 
 /datum/unit_test/nested_inventory/Run()
 	var/mob/living/carbon/human/consistent/user = ALLOCATE_BOTTOM_LEFT()
-	var/obj/item/backpack/backpack = ALLOCATE_BOTTOM_LEFT()
+	var/obj/item/storage/backpack/backpack = ALLOCATE_BOTTOM_LEFT()
 	var/obj/item/storage/box/survival/box = ALLOCATE_BOTTOM_LEFT()
 
 	box.forceMove(backpack)
@@ -18,4 +18,4 @@
 
 	TEST_ASSERT(!user.is_holding(nested_item), "Mob equipped the item.")
 	TEST_ASSERT(!QDELETED(nested_item), "Item was qdeleted.")
-	TEST_ASSERT(nested_item.loc == box, "Item ended up outside the box, inside [I.loc || "NULLSPACE"].")
+	TEST_ASSERT(nested_item.loc == box, "Item ended up outside the box, inside [nested_item.loc || "NULLSPACE"].")

--- a/code/modules/unit_tests/combat/combat_nested_inventory.dm
+++ b/code/modules/unit_tests/combat/combat_nested_inventory.dm
@@ -6,19 +6,13 @@
 	var/obj/item/storage/backpack/backpack = ALLOCATE_BOTTOM_LEFT()
 	var/obj/item/storage/box/survival/box = ALLOCATE_BOTTOM_LEFT()
 
-	var/datum/client_interface/mock_client = new
-	user.mock_client = mock_client
-	user.create_mob_hud()
-
 	box.forceMove(backpack)
 	user.equip_to_slot_if_possible(backpack, ITEM_SLOT_BACK)
 
 	TEST_ASSERT(user.get_item_by_slot(ITEM_SLOT_BACK) == backpack, "Mob did not equip the backpack.")
 
 	var/obj/item/nested_item = box.contents[1]
-	var/atom/movable/screen/inventory/hand/hand_inventory = user.hud_used.hand_slots["[user.active_hand_index]"]
-
-	hand_inventory.MouseDroppedOn(nested_item)
+	user.putItemFromInventoryInHandIfPossible(nested_item, user.active_hand_index)
 
 	TEST_ASSERT(!user.is_holding(nested_item), "Mob equipped the item.")
 	TEST_ASSERT(!QDELETED(nested_item), "Item was qdeleted.")

--- a/code/modules/unit_tests/combat/combat_nested_inventory.dm
+++ b/code/modules/unit_tests/combat/combat_nested_inventory.dm
@@ -6,6 +6,10 @@
 	var/obj/item/storage/backpack/backpack = ALLOCATE_BOTTOM_LEFT()
 	var/obj/item/storage/box/survival/box = ALLOCATE_BOTTOM_LEFT()
 
+	var/datum/client_interface/mock_client = new
+	user.mock_client = mock_client
+	user.create_mob_hud()
+
 	box.forceMove(backpack)
 	user.equip_to_slot_if_possible(backpack, ITEM_SLOT_BACK)
 

--- a/code/modules/unit_tests/combat/combat_nested_inventory.dm
+++ b/code/modules/unit_tests/combat/combat_nested_inventory.dm
@@ -1,0 +1,21 @@
+/datum/unit_test/nested_inventory
+	name = "COMBAT/INTERACTION: Clikc-Dragging Nested Inventory Shall Not Delete Items"
+
+/datum/unit_test/nested_inventory/Run()
+	var/mob/living/carbon/human/consistent/user = ALLOCATE_BOTTOM_LEFT()
+	var/obj/item/backpack/backpack = ALLOCATE_BOTTOM_LEFT()
+	var/obj/item/storage/box/survival/box = ALLOCATE_BOTTOM_LEFT()
+
+	box.forceMove(backpack)
+	user.equip_to_slot_if_possible(backpack)
+
+	TEST_ASSERT(user.get_item_by_slot(ITEM_SLOT_BACKPACK) == backpack, "Mob did not equip the backpack.")
+
+	var/obj/item/nested_item = box.contents[1]
+	var/atom/movable/screen/inventory/hand/hand_inventory = user.hud_used.hand_slots["[user.active_hand_index]"]
+
+	hand_inventory.MouseDroppedOn(nested_item)
+
+	TEST_ASSERT(!user.is_holding(nested_item), "Mob equipped the item.")
+	TEST_ASSERT(!QDELETED(nested_item), "Item was qdeleted.")
+	TEST_ASSERT(nested_item.loc == box, "Item ended up outside the box, inside [I.loc || "NULLSPACE"].")


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a bug where click-dragging an item inside of a nested storage container to your hand would delete the item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
