### PR TITLE
Fix Sanguine Plague Outbreak

### DIFF
--- a/code/game/gamemodes/blood_plague_outbreak.dm
+++ b/code/game/gamemodes/blood_plague_outbreak.dm
@@ -50,6 +50,7 @@
 	if(.)
 		return
 
+	var/list/transit_levels = SSmapping.levels_by_trait(ZTRAIT_TRANSIT)
 	// If there's no non-vampires left alive, end the round.
 	// If this becomes too common, something is wrong, this is NOT a conversion antagonist.
 	for(var/mob/living/carbon/human in GLOB.human_list)
@@ -57,7 +58,7 @@
 			continue
 
 		var/turf/pos = get_turf(human)
-		if(!is_station_level(pos.z))
+		if(isnull(pos) || !(is_station_level(pos.z) || (pos.z in transit_levels)))
 			continue
 
 		if(IS_VAMPIRE(human))

--- a/code/game/gamemodes/blood_plague_outbreak.dm
+++ b/code/game/gamemodes/blood_plague_outbreak.dm
@@ -63,4 +63,6 @@
 		if(IS_VAMPIRE(human))
 			continue
 
-		return TRUE
+		return FALSE
+
+	return TRUE


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Sanguine Plague Outbreak gamemode no longer instantly ends.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
