### PR TITLE
wound cleanup

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -12,10 +12,15 @@
 	var/t_s = p_s()
 	var/obscure_name
 
+	var/viewer_hallucinating = FALSE
 	if(isliving(user))
 		var/mob/living/L = user
 		if(HAS_TRAIT(L, TRAIT_PROSOPAGNOSIA) || HAS_TRAIT(L, TRAIT_INVISIBLE_MAN))
 			obscure_name = TRUE
+
+	if(ishuman(user))
+		var/mob/living/carbon/H = user
+		viewer_hallucinating = H.hal_screwyhud
 
 	var/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
@@ -173,7 +178,7 @@
 					break
 			if(!is_bloody)
 				msg += span_notice("[t_His] [body_part.plaintext_zone] is covered.\n")
-			for(var/string in body_part.mob_examine(hal_screwyhud, TRUE))
+			for(var/string in body_part.mob_examine(viewer_hallucinating, TRUE))
 				msg += "[string]</br>"
 
 			continue
@@ -182,7 +187,7 @@
 			if((body_part.brute_dam + body_part.burn_dam) >= body_part.max_damage * 0.8)
 				fucked_reasons["[t_His] [body_part.plaintext_zone] is greviously injured."] = 3
 
-			for(var/string in body_part.mob_examine(hal_screwyhud, FALSE))
+			for(var/string in body_part.mob_examine(viewer_hallucinating, FALSE))
 				msg += "[string]</br>"
 
 	for(var/X in disabled)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -821,7 +821,11 @@
 		if(HM.quality != POSITIVE)
 			dna.remove_mutation(HM.name)
 	set_coretemperature(get_body_temp_normal(apply_change=FALSE))
-	return ..()
+
+	. = ..()
+	for(var/obj/item/bodypart/BP as anything in bodyparts)
+		for(var/datum/wound/W as anything in BP.wounds)
+			qdel(W)
 
 /mob/living/carbon/human/vomit(lost_nutrition = 10, blood = FALSE, stun = TRUE, distance = 1, message = TRUE, vomit_type = VOMIT_TOXIC, harm = TRUE, force = FALSE, purge_ratio = 0.1)
 	if(blood && (NOBLOOD in dna.species.species_traits) && !HAS_TRAIT(src, TRAIT_TOXINLOVER))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1055,11 +1055,15 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		log_combat(user, target, "attempted to punch (missed)")
 		return FALSE
 
+	var/attack_sharpness = NONE
 	switch(atk_effect)
 		if(ATTACK_EFFECT_BITE)
 			target.add_trace_DNA_on_clothing_or_self(user, attacking_zone)
+			attack_sharpness |= SHARP_POINTY
+
 		if(ATTACK_EFFECT_PUNCH, ATTACK_EFFECT_CLAW, ATTACK_EFFECT_SLASH)
 			target.add_fingerprint_on_clothing_or_self(user, attacking_zone)
+			attack_sharpness |= SHARP_EDGED
 
 	var/armor_block = target.run_armor_check(affecting, BLUNT)
 
@@ -1088,7 +1092,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	else//other attacks deal full raw damage + 1.5x in stamina damage
 
-		target.apply_damage(damage, attack_type, affecting, armor_block, attack_direction = attack_direction)
+		target.apply_damage(damage, attack_type, affecting, armor_block, sharpness = attack_sharpness, attack_direction = attack_direction)
 		target.stamina.adjust(-STAMINA_DAMAGE_UNARMED)
 		log_combat(user, target, "punched")
 		. |= ATTACK_CONSUME_STAMINA

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -356,7 +356,7 @@
 		return english_list(flavor_text)
 
 	if(owner)
-		if(current_damage)
+		if(length(flavor_text))
 			. += "[owner.p_they(TRUE)] [owner.p_have()] [english_list(flavor_text)] on [owner.p_their()] [plaintext_zone]."
 
 		for(var/obj/item/I in embedded_objects)
@@ -491,17 +491,15 @@
 
 	if(!IS_ORGANIC_LIMB(src)) //Robotic limbs don't heal or get worse.
 		for(var/datum/wound/W as anything in wounds) //Repaired wounds disappear though
-			if(W.damage <= 0)  //and they disappear right away
+			if(W.damage <= 0)
 				qdel(W)
 		return
 
 	for(var/datum/wound/W as anything in wounds)
 		// wounds can disappear after 10 minutes at the earliest
-		if(W.damage <= 0 && W.created + (10 MINUTES) <= world.time)
+		if(W.damage <= 0 && (W.scar_expiration <= world.time))
 			qdel(W)
-			stack_trace("Wound with zero health collected")
 			continue
-			// let the GC handle the deletion of the wound
 
 		// slow healing
 		var/heal_amt = 0
@@ -608,8 +606,9 @@
 	/*
 	// START WOUND HANDLING
 	*/
+
 	// If the limbs can break, make sure we don't exceed the maximum damage a limb can take before breaking
-	var/block_cut = (pure_brute < 10) || !IS_ORGANIC_LIMB(src)
+	var/block_cut = (pure_brute < 6) || !IS_ORGANIC_LIMB(src)
 	var/can_cut = !block_cut && ((sharpness) || prob(brute))
 	if(brute)
 		var/to_create = WOUND_BRUISE
@@ -779,7 +778,7 @@
 
 	//update damage counts
 	for(var/datum/wound/W as anything in wounds)
-		if(W.damage <= 0)
+		if(W.damage <= 0 && (W.scar_expiration <= world.time))
 			qdel(W)
 			continue
 

--- a/code/modules/surgery/bodyparts/bodypart_examine.dm
+++ b/code/modules/surgery/bodyparts/bodypart_examine.dm
@@ -1,0 +1,155 @@
+/obj/item/bodypart/examine(mob/user)
+	SHOULD_CALL_PARENT(TRUE)
+	. = ..()
+	var/hallucinating = FALSE
+	if(ishuman(user))
+		var/mob/living/carbon/human/human_user
+		hallucinating = human_user.hal_screwyhud
+	. += mob_examine(hallucinating)
+
+/obj/item/bodypart/proc/mob_examine(hallucinating, covered)
+	. = list()
+
+	if(covered)
+		for(var/obj/item/I in embedded_objects)
+			if(I.isEmbedHarmless())
+				. += "<a href='?src=[REF(src)];embedded_object=[REF(I)]' class='danger'>There is \a [I] stuck to [owner.p_their()] [plaintext_zone]!</a>"
+			else
+				. += "<a href='?src=[REF(src)];embedded_object=[REF(I)]' class='danger'>There is \a [I] embedded in [owner.p_their()] [plaintext_zone]!</a>"
+
+		if(splint && istype(splint, /obj/item/stack))
+			. += span_notice("\t <a href='?src=[REF(src)];splint_remove=1' class='notice'>[owner.p_their(TRUE)] [plaintext_zone] is splinted with [splint].</a>")
+
+		if(bandage)
+			. += span_notice("\t <a href='?src=[REF(src)];bandage_remove=1' class='[bandage.absorption_capacity ? "notice" : "warning"]'>[owner.p_their(TRUE)] [plaintext_zone] is bandaged with [bandage][bandage.absorption_capacity ? "." : ", blood is trickling out."]</a>")
+		return
+
+	. += get_wound_descriptions(hallucinating)
+
+	if(owner)
+		for(var/obj/item/I in embedded_objects)
+			if(I.isEmbedHarmless())
+				. += "\t <a href='?src=[REF(src)];embedded_object=[REF(I)]' class='warning'>There is \a [I] stuck to [owner.p_their()] [plaintext_zone]!</a>"
+			else
+				. += "\t <a href='?src=[REF(src)];embedded_object=[REF(I)]' class='warning'>There is \a [I] embedded in [owner.p_their()] [plaintext_zone]!</a>"
+
+		if(splint && istype(splint, /obj/item/stack))
+			. += span_notice("\t <a href='?src=[REF(src)];splint_remove=1' class='warning'>[owner.p_their(TRUE)] [plaintext_zone] is splinted with [splint].</a>")
+		if(bandage)
+			. += span_notice("\n\t <a href='?src=[REF(src)];bandage_remove=1' class='notice'>[owner.p_their(TRUE)] [plaintext_zone] is bandaged with [bandage][bandage.absorption_capacity ? "." : ", <span class='warning'>it is no longer absorbing blood</span>."]</a>")
+		return
+
+	else
+		if(bodypart_flags & BP_BROKEN_BONES)
+			. += span_warning("It is dented and swollen.")
+		return
+
+/// Returns a list of wound descriptions in text form.
+/obj/item/bodypart/proc/get_wound_descriptions(hallucinating) as /list
+	RETURN_TYPE(/list)
+
+	if(hallucinating == SCREWYHUD_HEALTHY)
+		return list()
+
+	switch(hallucinating)
+		if(SCREWYHUD_HEALTHY)
+			return list()
+
+		if(SCREWYHUD_CRIT, SCREWYHUD_DEAD)
+			var/list/hal_wounds = list("a")
+			hal_wounds += pick("pair of", "ton of")
+			hal_wounds += pick("large cuts", "severe burns")
+			return list("[owner.p_they(TRUE)] [owner.p_have()] [english_list(jointext(hal_wounds, " "))] on [owner.p_their()] [plaintext_zone].")
+
+	if(!IS_ORGANIC_LIMB(src))
+		var/cyber_wounds = list()
+		if(brute_dam)
+			switch(brute_dam)
+				if(0 to 20)
+					cyber_wounds += "some dents"
+				if(21 to INFINITY)
+					cyber_wounds += pick("a lot of dents","severe denting")
+		if(burn_dam)
+			switch(burn_dam)
+				if(0 to 20)
+					cyber_wounds += "some burns"
+				if(21 to INFINITY)
+					cyber_wounds += pick("a lot of burns","severe melting")
+
+		return list("[owner.p_they(TRUE)] [owner.p_have()] [english_list(cyber_wounds)] on [owner.p_their()] [plaintext_zone].")
+
+	var/list/flavor_text = list()
+	var/list/wound_locations = list(
+		"[plaintext_zone]" = list(),
+	)
+
+	if((bodypart_flags & BP_CUT_AWAY) && !is_stump)
+		wound_locations[plaintext_zone]["tear at the [amputation_point] so severe that it hangs by a scrap of flesh"] = 1
+
+	for(var/datum/wound/W as anything in wounds)
+		var/descriptor = W.get_examine_desc()
+		if(descriptor)
+			var/wound_location = W.wound_location()
+			LAZYINITLIST(wound_locations[wound_location])
+			wound_locations[wound_location][descriptor] += W.amount
+
+	if(how_open() >= SURGERY_RETRACTED)
+		var/bone = encased ? encased : "bone"
+		if(bodypart_flags & BP_BROKEN_BONES)
+			bone = "broken [bone]"
+		wound_locations[plaintext_zone]["[bone] exposed"] = 1
+
+		if(!encased || how_open() >= SURGERY_DEENCASED)
+			var/list/bits = list()
+			for(var/obj/item/organ/organ in contained_organs)
+				if(organ.cosmetic_only)
+					continue
+				bits += organ.get_visible_state()
+
+			for(var/obj/item/implant in cavity_items)
+				bits += implant.name
+
+			if(length(bits))
+				wound_locations[plaintext_zone]["[english_list(bits)] visible in the wounds"] = 1
+
+	if(owner)
+		for(var/wound_loc in wound_locations)
+			var/list/wound_text = list()
+			if(!length(wound_locations[wound_loc]))
+				continue
+
+			for(var/wound in wound_locations[wound_loc])
+				switch(wound_locations[wound_loc][wound])
+					if(1)
+						wound_text += "a [wound]"
+					if(2)
+						wound_text += "a pair of [wound]s"
+					if(3 to 5)
+						wound_text += "several [wound]s"
+					if(6 to INFINITY)
+						wound_text += "a ton of [wound]\s"
+
+			if(length(wound_text))
+				flavor_text += span_warning("[owner.p_they(TRUE)] [owner.p_have()] [english_list(wound_text)] on [owner.p_their()] [wound_loc].")
+	else
+		var/list/wound_text = list()
+		for(var/wound_loc in wound_locations)
+			if(!length(wound_locations[wound_loc]))
+				continue
+
+			for(var/wound in wound_locations[wound_loc])
+				switch(wound_locations[wound_loc][wound])
+					if(1)
+						wound_text += "a [wound]"
+					if(2)
+						wound_text += "a pair of [wound]s"
+					if(3 to 5)
+						wound_text += "several [wound]s"
+					if(6 to INFINITY)
+						wound_text += "a ton of [wound]\s"
+
+		if(length(wound_text))
+			flavor_text += span_warning("It has [english_list(wound_text)].")
+
+
+	return flavor_text

--- a/code/modules/surgery/bodyparts/injuries.dm
+++ b/code/modules/surgery/bodyparts/injuries.dm
@@ -280,7 +280,8 @@
 	var/datum/wound/W = get_incision()
 	if(!W)
 		return
-	W.open_wound(min(W.damage * 2, W.damage_list[1] - W.damage))
+
+	W.open_wound(min(W.damage * 2, W.damage_list[length(W.damage_list)] - W.damage))
 
 /obj/item/bodypart/proc/jointlock(mob/living/user)
 	if(!IS_ORGANIC_LIMB(src))

--- a/code/modules/surgery/bodyparts/injuries.dm
+++ b/code/modules/surgery/bodyparts/injuries.dm
@@ -237,12 +237,13 @@
 
 	var/smol_threshold = minimum_break_damage * 0.4
 	var/beeg_threshold = minimum_break_damage * 0.6
+	var/incision_max_size = incision.damage_list[length(incision.damage_list)]
 	// Clamp it to the largest that the wound can be
-	beeg_threshold = min(beeg_threshold, incision.damage_list[1])
+	beeg_threshold = min(beeg_threshold, incision_max_size)
 
 	if(!(incision.autoheal_cutoff == 0)) //not clean incision
 		smol_threshold *= 1.5
-		beeg_threshold = max(beeg_threshold, min(beeg_threshold * 1.5, incision.damage_list[1])) //wounds can't achieve bigger
+		beeg_threshold = max(beeg_threshold, min(beeg_threshold * 1.5, incision_max_size)) //wounds can't achieve bigger
 
 	if(incision.damage >= smol_threshold) //smol incision
 		. = SURGERY_OPEN
@@ -259,7 +260,7 @@
 	var/datum/wound/incision
 
 	for(var/datum/wound/cut/W in wounds)
-		if(W.current_stage > W.max_bleeding_stage) // Shit's unusable
+		if(W.current_stage < W.min_bleeding_stage) // Shit's unusable
 			continue
 		if(strict && !W.is_surgical()) //We don't need dirty ones
 			continue

--- a/code/modules/surgery/bodyparts/wounds/_wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds/_wounds.dm
@@ -16,7 +16,7 @@
 	///Ticks of bleeding left
 	var/bleed_timer = 0
 	///Above this amount wounds you will need to treat the wound to stop bleeding, regardless of bleed_timer
-	var/bleed_threshold = 30
+	var/always_bleed_threshold = 30
 	///Amount of damage the current wound type requires(less means we need to apply the next healing stage)
 	var/min_damage = 0
 
@@ -27,7 +27,9 @@
 	///Is disinfected?
 	var/disinfected = 0
 
-	var/created = 0
+	/// World.time the wound can be deleted. This is so that wounds with zero damage can scar and take some time to disappear. For flavor.
+	var/scar_expiration
+
 	///Number of wounds of this type
 	var/amount = 1
 	///Amount of germs in the wound
@@ -37,8 +39,8 @@
 	/// stages such as "cut", "deep cut", etc.
 	var/list/stages
 
-	///Maximum stage at which bleeding should still happen. Beyond this stage bleeding is prevented.
-	var/max_bleeding_stage = 0
+	///Minimum stage at which bleeding can happen. Below this stage bleeding is prevented.
+	var/min_bleeding_stage = 0
 
 	/// String (One of `wound_type_*`). The wound's injury type.
 	var/wound_type = WOUND_CUT
@@ -47,13 +49,17 @@
 	var/autoheal_cutoff = 15
 
 	// helper lists
+	/// Flat version of the description portion of stages.
 	var/tmp/list/desc_list = list()
+	/// Flat version of the damage value portion of stages.
 	var/tmp/list/damage_list = list()
-	var/tmp/list/embedded_objects //lazy
+
+	/// Lazylist of
+	var/tmp/list/embedded_objects
 
 /datum/wound/New(damage, obj/item/bodypart/BP = null)
 
-	created = world.time
+	scar_expiration = world.time + 10 MINUTES
 
 	// reading from a list("stage" = damage) is pretty difficult, so build two separate
 	// lists from them instead
@@ -62,9 +68,7 @@
 		damage_list += stages[V]
 
 	src.damage = damage
-
-	// initialize with the appropriate stage
-	src.init_stage(damage)
+	update_wound_stage()
 
 	bleed_timer += damage
 
@@ -74,37 +78,45 @@
 /datum/wound/Destroy()
 	if(parent)
 		LAZYREMOVE(parent.wounds, src)
+		parent.update_damage()
 		parent = null
 
 	LAZYCLEARLIST(embedded_objects)
 	return ..()
 
-///Returns 1 if there's a next stage, 0 otherwise
-/datum/wound/proc/init_stage(initial_damage)
-	current_stage = stages.len
+/// Set the wound stage based on the current damage.
+/datum/wound/proc/update_wound_stage()
+	current_stage = 1
 
-	while(src.current_stage > 1 && src.damage_list[current_stage-1] <= initial_damage / src.amount)
-		src.current_stage--
+	var/wound_damage = wound_damage()
 
-	src.min_damage = damage_list[current_stage]
-	src.desc = desc_list[current_stage]
+	for(var/i in 1 to length(stages))
+		if(damage_list[i] > wound_damage)
+			break
+
+		current_stage = i
+
+	min_damage = damage_list[current_stage]
+	desc = desc_list[current_stage]
 
 ///The amount of damage per wound
 /datum/wound/proc/wound_damage()
-	return src.damage / src.amount
+	return max(0, round(damage / amount, DAMAGE_PRECISION))
 
 /datum/wound/proc/can_autoheal()
 	if(LAZYLEN(embedded_objects))
 		return FALSE
 
+	var/wound_damage = wound_damage()
 	switch(wound_type) //OOP is a lie. Should bruises, cuts, and punctures all share a common parent? Probably. Fuck you!
 		if (WOUND_BRUISE, WOUND_CUT, WOUND_PIERCE)
 			if(parent.bandage)
-				return wound_damage() <= initial(autoheal_cutoff)
+				return wound_damage <= initial(autoheal_cutoff)
+
 		if(WOUND_BURN)
 			. = salved
 
-	. ||= (wound_damage() <= autoheal_cutoff)
+	. ||= (wound_damage <= autoheal_cutoff)
 
 ///Checks whether the wound has been appropriately treated
 /datum/wound/proc/is_treated()
@@ -139,7 +151,7 @@
 	src.amount += other.amount
 	src.bleed_timer += other.bleed_timer
 	src.germ_level = max(src.germ_level, other.germ_level)
-	src.created = max(src.created, other.created)	//take the newer created time
+	src.scar_expiration = max(src.scar_expiration, other.scar_expiration) //take the newer time
 	qdel(other)
 
 // checks if wound is considered open for external infections
@@ -199,27 +211,20 @@
 	*/
 
 	var/healed_damage = min(src.damage, amount)
-	amount -= healed_damage
-	src.damage -= healed_damage
+	amount = round(amount - healed_damage, DAMAGE_PRECISION)
+	damage = round(damage - healed_damage, DAMAGE_PRECISION)
 
-	while(src.wound_damage() < damage_list[current_stage] && current_stage < src.desc_list.len)
-		current_stage++
-	desc = desc_list[current_stage]
-	src.min_damage = damage_list[current_stage]
+	update_wound_stage()
 
 	// return amount of healing still leftover, can be used for other wounds
 	return amount
 
 // opens the wound again
 /datum/wound/proc/open_wound(damage, update_damage = TRUE)
-	src.damage += damage
+	src.damage = round(src.damage + damage, DAMAGE_PRECISION)
 	bleed_timer += damage
 
-	while(src.current_stage > 1 && src.damage_list[current_stage-1] <= src.damage / src.amount)
-		src.current_stage--
-
-	src.desc = desc_list[current_stage]
-	src.min_damage = damage_list[current_stage]
+	update_wound_stage()
 
 	if(update_damage)
 		parent.update_damage()
@@ -239,7 +244,8 @@
 	//with 1.5*, a shallow cut will be able to carry at most 30 damage,
 	//37.5 for a deep cut
 	//52.5 for a flesh wound, etc.
-	var/max_wound_damage = 1.5*src.damage_list[1]
+
+	var/max_wound_damage = 1.5 * damage_list[length(damage_list)]
 	if (src.damage + damage > max_wound_damage)
 		return 0
 	return 1
@@ -248,12 +254,17 @@
 /datum/wound/proc/bleeding()
 	if(clamped)
 		return FALSE
+
+	if(current_stage < min_bleeding_stage)
+		return FALSE
+
 	if(length(embedded_objects))
 		for(var/obj/item/thing in embedded_objects)
 			if(thing.w_class > WEIGHT_CLASS_SMALL)
 				return FALSE
+
 	// If the bleed_timer is greater than zero, OR the wound_damage() is greater than the damage required to bleed constantly.
-	return ((bleed_timer > 0 || wound_damage() > bleed_threshold) && current_stage <= max_bleeding_stage)
+	return (bleed_timer > 0) || (wound_damage() > always_bleed_threshold)
 
 /datum/wound/proc/is_surgical()
 	return 0
@@ -264,7 +275,7 @@
 		this_wound_desc = "salved [this_wound_desc]"
 
 	if(bleeding())
-		if(wound_damage() > bleed_threshold)
+		if(wound_damage() > always_bleed_threshold)
 			this_wound_desc = "<b>bleeding</b> [this_wound_desc]"
 		else
 			this_wound_desc = "bleeding [this_wound_desc]"

--- a/code/modules/surgery/bodyparts/wounds/bruises.dm
+++ b/code/modules/surgery/bodyparts/wounds/bruises.dm
@@ -2,15 +2,15 @@
 /datum/wound/bruise
 	pain_factor = 1.25
 	stages = list(
-		"monumental bruise" = 80,
-		"huge bruise" = 50,
-		"large bruise" = 30,
-		"moderate bruise" = 20,
+		"tiny bruise" = 5,
 		"small bruise" = 10,
-		"tiny bruise" = 5
+		"moderate bruise" = 20,
+		"large bruise" = 30,
+		"huge bruise" = 50,
+		"monumental bruise" = 80,
 		)
 
-	bleed_threshold = 20
-	max_bleeding_stage = 3 //only large bruise and above can bleed.
+	always_bleed_threshold = 20
+	min_bleeding_stage = 3 //only large bruise and above can bleed.
 	autoheal_cutoff = 30
 	wound_type = WOUND_BRUISE

--- a/code/modules/surgery/bodyparts/wounds/burns.dm
+++ b/code/modules/surgery/bodyparts/wounds/burns.dm
@@ -2,46 +2,46 @@
 /datum/wound/burn
 	pain_factor = 1.875
 	wound_type = WOUND_BURN
-	max_bleeding_stage = 0
+	min_bleeding_stage = INFINITY
 
 /datum/wound/burn/bleeding()
 	return FALSE
 
 /datum/wound/burn/moderate
 	stages = list(
-		"ripped burn" = 10,
-		"moderate burn" = 5,
+		"fresh skin" = 0,
 		"healing moderate burn" = 2,
-		"fresh skin" = 0
-		)
+		"moderate burn" = 5,
+		"ripped burn" = 10,
+	)
 
 /datum/wound/burn/large
 	stages = list(
-		"ripped large burn" = 20,
-		"large burn" = 15,
+		"fresh skin" = 0,
 		"healing large burn" = 5,
-		"fresh skin" = 0
-		)
+		"large burn" = 15,
+		"ripped large burn" = 20,
+	)
 
 /datum/wound/burn/severe
 	stages = list(
-		"ripped severe burn" = 35,
-		"severe burn" = 30,
+		"burn scar" = 0,
 		"healing severe burn" = 10,
-		"burn scar" = 0
-		)
+		"severe burn" = 30,
+		"ripped severe burn" = 35,
+	)
 
 /datum/wound/burn/deep
 	stages = list(
-		"ripped deep burn" = 45,
-		"deep burn" = 40,
+		"large burn scar" = 0,
 		"healing deep burn" = 15,
-		"large burn scar" = 0
-		)
+		"deep burn" = 40,
+		"ripped deep burn" = 45,
+	)
 
 /datum/wound/burn/carbonised
 	stages = list(
-		"carbonised area" = 50,
+		"massive burn scar" = 0,
 		"healing carbonised area" = 20,
-		"massive burn scar" = 0
-		)
+		"carbonised area" = 50,
+	)

--- a/code/modules/surgery/bodyparts/wounds/create_wound.dm
+++ b/code/modules/surgery/bodyparts/wounds/create_wound.dm
@@ -1,4 +1,5 @@
 /obj/item/bodypart/proc/create_wound(wound_type = WOUND_CUT, damage, surgical, update_damage = TRUE)
+	damage = round(damage, DAMAGE_PRECISION)
 	if(damage <= 0)
 		return
 
@@ -32,7 +33,7 @@
 		owner.adjustBloodVolume(-fluid_loss)
 
 	//Check whether we can widen an existing wound
-	if(!surgical && LAZYLEN(wounds) && prob(max(50+(real_wound_count-1)*10,90)))
+	if(!surgical && LAZYLEN(wounds) && prob(min(50+(real_wound_count-1) * 10, 90)))
 		if ((wound_type == WOUND_CUT || wound_type == WOUND_BRUISE) && damage >= 5)
 			//we need to make sure that the wound we are going to worsen is compatible with the type of damage...
 			var/list/compatible_wounds = list()
@@ -84,6 +85,10 @@
 		return W
 
 /obj/item/bodypart/proc/create_wound_easy(type2make, damage, update_damage = TRUE)
+	damage = round(damage, DAMAGE_PRECISION)
+	if(damage <= 0)
+		return
+
 	var/datum/wound/W = new type2make(damage, src)
 	var/merged = FALSE
 	for(var/datum/wound/other as anything in wounds)

--- a/code/modules/surgery/bodyparts/wounds/cuts.dm
+++ b/code/modules/surgery/bodyparts/wounds/cuts.dm
@@ -1,14 +1,14 @@
 /** CUTS **/
 /datum/wound/cut
 	pain_factor = 1.25
-	bleed_threshold = 5
+	always_bleed_threshold = 5
 	wound_type = WOUND_CUT
 
 /datum/wound/cut/is_surgical()
 	return autoheal_cutoff == 0
 
 /datum/wound/cut/close_wound()
-	current_stage = max_bleeding_stage + 1
+	current_stage = min_bleeding_stage - 1
 	desc = desc_list[current_stage]
 	min_damage = damage_list[current_stage]
 	if(damage > min_damage)
@@ -18,65 +18,65 @@
 
 /datum/wound/cut/small
 	// link wound descriptions to amounts of damage
-	// Minor cuts have max_bleeding_stage set to the stage that bears the wound type's name.
-	// The major cut types have the max_bleeding_stage set to the clot stage (which is accordingly given the "blood soaked" descriptor).
-	max_bleeding_stage = 3
+	// Minor cuts have min_bleeding_stage set to the stage that bears the wound type's name.
+	// The major cut types have the min_bleeding_stage set to the clot stage (which is accordingly given the "blood soaked" descriptor).
+	min_bleeding_stage = 3
 	stages = list(
-		"ugly ripped cut" = 20,
-		"ripped cut" = 10,
-		"cut" = 5,
+		"small scab" = 0,
 		"healing cut" = 2,
-		"small scab" = 0
-		)
+		"cut" = 5,
+		"ripped cut" = 10,
+		"ugly ripped cut" = 20,
+	)
 
 /datum/wound/cut/deep
-	max_bleeding_stage = 3
+	min_bleeding_stage = 3
 	stages = list(
-		"ugly deep ripped cut" = 25,
-		"deep ripped cut" = 20,
-		"deep cut" = 15,
-		"clotted cut" = 8,
+		"fresh skin" = 0,
 		"scab" = 2,
-		"fresh skin" = 0
-		)
+		"clotted cut" = 8,
+		"deep cut" = 15,
+		"deep ripped cut" = 20,
+		"ugly deep ripped cut" = 25,
+	)
 
 /datum/wound/cut/flesh
-	max_bleeding_stage = 4
+	min_bleeding_stage = 3
 	stages = list(
-		"ugly ripped flesh wound" = 35,
-		"ugly flesh wound" = 30,
-		"flesh wound" = 25,
-		"blood soaked clot" = 15,
+		"fresh skin" = 0,
 		"large scab" = 5,
-		"fresh skin" = 0
-		)
+		"blood soaked clot" = 15,
+		"flesh wound" = 25,
+		"ugly flesh wound" = 30,
+		"ugly ripped flesh wound" = 35,
+	)
 
 /datum/wound/cut/gaping
-	max_bleeding_stage = 3
+	min_bleeding_stage = 3
 	stages = list(
-		"gaping wound" = 50,
-		"large blood soaked clot" = 25,
-		"blood soaked clot" = 15,
+		"small straight scar" = 0,
 		"small angry scar" = 5,
-		"small straight scar" = 0
-		)
+		"blood soaked clot" = 15,
+		"large blood soaked clot" = 25,
+		"gaping wound" = 50,
+	)
 
 /datum/wound/cut/gaping_big
-	max_bleeding_stage = 3
+	min_bleeding_stage = 3
 	stages = list(
-		"big gaping wound" = 60,
-		"healing gaping wound" = 40,
-		"large blood soaked clot" = 25,
+		"large straight scar" = 0,
 		"large angry scar" = 10,
-		"large straight scar" = 0
-		)
+		"large blood soaked clot" = 25,
+		"healing gaping wound" = 40,
+		"big gaping wound" = 60,
+	)
 
 /datum/wound/cut/massive
-	max_bleeding_stage = 3
+	min_bleeding_stage = 3
 	stages = list(
-		"massive wound" = 70,
-		"massive healing wound" = 50,
-		"massive blood soaked clot" = 25,
+		"massive jagged scar" = 0,
 		"massive angry scar" = 10,
-		"massive jagged scar" = 0
-		)
+		"massive blood soaked clot" = 25,
+		"massive healing wound" = 50,
+		"massive wound" = 70,
+	)

--- a/code/modules/surgery/bodyparts/wounds/lost_limb.dm
+++ b/code/modules/surgery/bodyparts/wounds/lost_limb.dm
@@ -10,25 +10,26 @@
 		if(DROPLIMB_EDGE, DROPLIMB_BLUNT)
 			wound_type = WOUND_CUT
 			if(!IS_ORGANIC_LIMB(lost_limb))
-				max_bleeding_stage = -1
-				bleed_threshold = INFINITY
+				min_bleeding_stage = INFINITY
+				always_bleed_threshold = INFINITY
 				stages = list("mangled robotic socket" = 0)
 			else
-				max_bleeding_stage = 3 //clotted stump and above can bleed.
+				min_bleeding_stage = 2 //clotted stump and above can bleed.
 				stages = list(
-					"ripped stump" = damage_amt*1.3,
-					"bloody stump" = damage_amt,
+					"scarred stump" = 0,
 					"clotted stump" = damage_amt*0.5,
-					"scarred stump" = 0
+					"bloody stump" = damage_amt,
+					"ripped stump" = damage_amt*1.3,
 				)
+
 		if(DROPLIMB_BURN)
 			wound_type = WOUND_BURN
 			stages = list(
-				"mangled charred stump" = damage_amt*1.3,
-				"charred stump" = damage_amt,
+				"scarred stump" = 0,
 				"scarred stump" = damage_amt*0.5,
-				"scarred stump" = 0
-				)
+				"charred stump" = damage_amt,
+				"mangled charred stump" = damage_amt*1.3,
+			)
 
 	..(damage_amt)
 

--- a/code/modules/surgery/bodyparts/wounds/neck_bite.dm
+++ b/code/modules/surgery/bodyparts/wounds/neck_bite.dm
@@ -1,7 +1,7 @@
 /// Used by the Neck Bite ability.
 /datum/wound/neck_bite
 	pain_factor = 0
-	auto_bleed_threshold = 0
+	always_bleed_threshold = 0
 	wound_type = WOUND_PIERCE
 
 	autoheal_cutoff = 10

--- a/code/modules/surgery/bodyparts/wounds/neck_bite.dm
+++ b/code/modules/surgery/bodyparts/wounds/neck_bite.dm
@@ -1,14 +1,14 @@
 /// Used by the Neck Bite ability.
 /datum/wound/neck_bite
 	pain_factor = 0
-	bleed_threshold = 0
+	auto_bleed_threshold = 0
 	wound_type = WOUND_PIERCE
 
 	autoheal_cutoff = 10
-	max_bleeding_stage = 1
+	min_bleeding_stage = 2
 	stages = list(
-		"afflicted bite" = 5,
 		"fading bite mark" = 0,
+		"afflicted bite" = 5,
 	)
 
 /datum/wound/neck_bite/can_worsen(damage_type, damage)

--- a/code/modules/surgery/bodyparts/wounds/punctures.dm
+++ b/code/modules/surgery/bodyparts/wounds/punctures.dm
@@ -1,55 +1,55 @@
 /** PUNCTURES **/
 /datum/wound/puncture
 	pain_factor = 1.25
-	bleed_threshold = 10
+	always_bleed_threshold = 10
 	wound_type = WOUND_PIERCE
 
 /datum/wound/puncture/can_worsen(damage_type, damage)
 	return 0 //puncture wounds cannot be enlargened
 
 /datum/wound/puncture/small
-	max_bleeding_stage = 2
+	min_bleeding_stage = 2
 	stages = list(
-		"puncture" = 5,
+		"small scab" = 0,
 		"healing puncture" = 2,
-		"small scab" = 0
-		)
+		"puncture" = 5,
+	)
 
 /datum/wound/puncture/flesh
-	max_bleeding_stage = 2
+	min_bleeding_stage = 3
 	stages = list(
-		"puncture wound" = 15,
-		"blood soaked clot" = 5,
+		"small round scar" = 0,
 		"large scab" = 2,
-		"small round scar" = 0
-		)
+		"blood soaked clot" = 5,
+		"puncture wound" = 15,
+	)
 
 /datum/wound/puncture/gaping
-	max_bleeding_stage = 3
+	min_bleeding_stage = 3
 	stages = list(
-		"gaping hole" = 30,
-		"large blood soaked clot" = 15,
-		"blood soaked clot" = 10,
+		"small round scar" = 0,
 		"small angry scar" = 5,
-		"small round scar" = 0
-		)
+		"blood soaked clot" = 10,
+		"large blood soaked clot" = 15,
+		"gaping hole" = 30,
+	)
 
 /datum/wound/puncture/gaping_big
-	max_bleeding_stage = 3
+	min_bleeding_stage = 3
 	stages = list(
-		"big gaping hole" = 50,
-		"healing gaping hole" = 20,
-		"large blood soaked clot" = 15,
+		"large round scar" = 0,
 		"large angry scar" = 10,
-		"large round scar" = 0
-		)
+		"large blood soaked clot" = 15,
+		"healing gaping hole" = 20,
+		"big gaping hole" = 50,
+	)
 
 /datum/wound/puncture/massive
-	max_bleeding_stage = 3
+	min_bleeding_stage = 3
 	stages = list(
-		"massive wound" = 60,
-		"massive healing wound" = 30,
-		"massive blood soaked clot" = 25,
+		"massive jagged scar" = 0,
 		"massive angry scar" = 10,
-		"massive jagged scar" = 0
-		)
+		"massive blood soaked clot" = 25,
+		"massive healing wound" = 30,
+		"massive wound" = 60,
+	)

--- a/daedalus.dme
+++ b/daedalus.dme
@@ -4441,6 +4441,7 @@
 #include "code\modules\station_goals\station_goal.dm"
 #include "code\modules\surgery\tools.dm"
 #include "code\modules\surgery\bodyparts\_bodyparts.dm"
+#include "code\modules\surgery\bodyparts\bodypart_examine.dm"
 #include "code\modules\surgery\bodyparts\digitigrade.dm"
 #include "code\modules\surgery\bodyparts\dismemberment.dm"
 #include "code\modules\surgery\bodyparts\germs_bodypart.dm"


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Unarmed attacks inflict different wounds based on their type.
add: 0-damage wounds (scars) persist for some time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
