### PR TITLE
Saves 20 seconds on init due to reduced cargocult

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -16,14 +16,6 @@ on:
 jobs:
   run_integration_tests:
     runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: mysql:latest
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
       - name: Restore BYOND cache


### PR DESCRIPTION
As it turns out, most servers running a variant of TG's CI script, are losing ~20 seconds on every Unit Test job to starting a completely redundant and misconfigured SQL docker container.

This PR stops doing that

NUFC
:cl:
/:cl: