### PR TITLE
Omen slip tweak

### DIFF
--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -99,8 +99,12 @@
 
 	playsound(get_turf(our_guy), 'sound/effects/tableheadsmash.ogg', 90, TRUE)
 	our_guy.visible_message(span_danger("[our_guy] hits [our_guy.p_their()] head really badly falling down!"), span_userdanger("You hit your head really badly falling down!"))
-	the_head.receive_damage(75)
-	our_guy.adjustOrganLoss(ORGAN_SLOT_BRAIN, 100)
+	the_head.receive_damage(40) //OUCH
+	the_head.break_bones()
+	our_guy.adjustOrganLoss(ORGAN_SLOT_BRAIN, 50)
+	if(iscarbon(our_guy)) //For some reason Omen checks for living instead of carbon, so we need this check
+		var/mob/living/carbon/our_guy_carbon = our_guy
+		our_guy_carbon.gain_trauma(/datum/brain_trauma/mild/concussion) //Our guy just had his head bounce like a basketball
 	if(!permanent)
 		qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces the Omen slip insta-kill with a more agony oriented "accident". Causes a head fracture and concussion, ontop of decent damage to the head and brain.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less insta-kill game removal methods, while still keeping things like Bad Luck smites funny as shit, among other Omen uses.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Slipping while under a Omen curse no longer causes your head to pop like a grape
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
