### PR TITLE
Enables engine level client macros

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -173,3 +173,28 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 
 /obj/machinery/telecomms/proc/de_emp()
 	set_machine_stat(machine_stat & ~EMPED)
+
+
+/obj/machinery/telecomms/examine(mob/user)
+	. = ..()
+
+	var/datum/roll_result/result = user.get_examine_result("telecom_equipment", 11)
+	if(result?.outcome >= SUCCESS)
+		result.do_skill_sound(user)
+		. += result.create_tooltip("Lit in lights, the facade of complexity. Nothing more.", body_only = TRUE)
+
+/obj/machinery/telecomms/disco_flavor(mob/living/carbon/human/user, nearby, is_station_level)
+	. = ..()
+	var/datum/roll_result/result = user.get_examine_result("telecom_equipment_flavor", 11, only_once = TRUE)
+	if(result?.outcome >= SUCCESS)
+		result.do_skill_sound(user)
+		to_chat(
+			user,
+			result.create_tooltip("The hum sounds hollow, as if there was almost nothing inside it. You wonder if it's doing that much at all."),
+		)
+	if(result?.outcome == CRIT_FAILURE)
+		result.do_skill_sound(user)
+		to_chat(
+			user,
+			result.create_tooltip("It glows! It hums! Surely, this is the most complex and important equipment around."),
+		)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -290,7 +290,6 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 /client/proc/add_admin_verbs()
 	if(holder)
-		control_freak = CONTROL_FREAK_SKIN | CONTROL_FREAK_MACROS
 
 		var/rights = holder.rank.rights
 		add_verb(src, GLOB.admin_verbs_default)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -93,8 +93,8 @@
 		////////////
 		//SECURITY//
 		////////////
-	// comment out the line below when debugging locally to enable the options & messages menu
-	control_freak = 1
+
+	control_freak = CONTROL_FREAK_SKIN
 
 		////////////////////////////////////
 		//things that require the database//

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1412,3 +1412,5 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	popup.set_window_options("can_close=1;can_resize=0")
 	popup.set_content(content)
 	popup.open()
+
+

--- a/code/modules/three_dsix/skills/fourteen_eyes.dm
+++ b/code/modules/three_dsix/skills/fourteen_eyes.dm
@@ -2,4 +2,5 @@
 	name = "Eyes Fourteen"
 	desc = "Recall information from other perspectives."
 
-	parent_stat_type = /datum/rpg_stat/psyche
+	parent_stat_type = /datum/rpg_stat/pneuma
+

--- a/code/modules/three_dsix/stats/pneuma.dm
+++ b/code/modules/three_dsix/stats/pneuma.dm
@@ -1,0 +1,6 @@
+/datum/rpg_stat/pneuma
+	name = "Pneuma"
+	desc = ""
+
+	value = STATS_BASELINE_VALUE
+	sound = 'sound/three_dsix/pneuma.ogg'

--- a/daedalus.dme
+++ b/daedalus.dme
@@ -4611,6 +4611,7 @@
 #include "code\modules\three_dsix\skills\willpower.dm"
 #include "code\modules\three_dsix\stats\_stat.dm"
 #include "code\modules\three_dsix\stats\kinesis.dm"
+#include "code\modules\three_dsix\stats\pneuma.dm"
 #include "code\modules\three_dsix\stats\psyche.dm"
 #include "code\modules\three_dsix\stats\soma.dm"
 #include "code\modules\tooltip\tooltip.dm"

--- a/html/changelogs/4-15-25-client-macros.yml
+++ b/html/changelogs/4-15-25-client-macros.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ""
+author: "francinum"
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -55,5 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - balance: "Allows all clients to use engine macros."
+  - admin: "Don't make me regret this."


### PR DESCRIPTION
A wonderful idea, with the best of intentions.

also fixes fourteen eyes being a subskill of the wrong stat group.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Enables the clientside custom macro system

Bay does it, We have the `.click` and etc. protections. We have admins willing to smack people.

![](https://file.house/noT9y_IfP5kqTxOs1qSSTg==.png) ![image](https://github.com/user-attachments/assets/734f0477-a4fb-41e0-87c4-6b92b08e3ed4)


## Why It's Good For The Game

It's clientside anyways, This is nothing you couldn't do with AHK.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Manual CL
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
