### PR TITLE
Fixes chat log saving for 516 clients

### DIFF
--- a/tgui/global.d.ts
+++ b/tgui/global.d.ts
@@ -93,6 +93,11 @@ type ByondType = {
   parseJson(text: string): any;
 
   /**
+   * Downloads a blob, platform-agnostic
+   */
+  saveBlob(blob: Blob, filename: string, ext: string): void;
+
+  /**
    * Sends a message to `/datum/tgui_window` which hosts this window instance.
    */
   sendMessage(type: string, payload?: any): void;

--- a/tgui/packages/tgui-panel/chat/renderer.jsx
+++ b/tgui/packages/tgui-panel/chat/renderer.jsx
@@ -544,13 +544,13 @@ class ChatRenderer {
       '</body>\n' +
       '</html>\n';
     // Create and send a nice blob
-    const blob = new Blob([pageHtml]);
+    const blob = new Blob([pageHtml], { type: 'text/plain' });
     const timestamp = new Date()
       .toISOString()
       .substring(0, 19)
       .replace(/[-:]/g, '')
       .replace('T', '-');
-    window.navigator.msSaveBlob(blob, `ss13-chatlog-${timestamp}.html`);
+    Byond.saveBlob(blob, `ss13-chatlog-${timestamp}.html`, '.html');
   }
 }
 

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -354,6 +354,37 @@
   Byond.loadCss = function (url, sync) {
     loadAsset({ url: url, sync: sync, type: 'css' });
   };
+
+  Byond.saveBlob = function (blob, filename, ext) {
+    if (window.navigator.msSaveBlob) {
+      window.navigator.msSaveBlob(blob, filename);
+    } else if (window.showSaveFilePicker) {
+      var accept = {};
+      accept[blob.type] = [ext];
+
+      var opts = {
+        suggestedName: filename,
+        types: [
+          {
+            description: 'SS13 file',
+            accept: accept,
+          },
+        ],
+      };
+
+      window
+        .showSaveFilePicker(opts)
+        .then(function (file) {
+          return file.createWritable();
+        })
+        .then(function (file) {
+          return file.write(blob).then(function () {
+            return file.close();
+          });
+        })
+        .catch(function () {});
+    }
+  };
 })();
 
 // Error handling

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -357,7 +357,7 @@
 
   Byond.saveBlob = function (blob, filename, ext) {
     if (window.navigator.msSaveBlob) {
-      window.navigator.msSaveBlob(blob, filename);
+      window.navigator.msSaveBlob(blob, filename); //515/IE11 compatibility
     } else if (window.showSaveFilePicker) {
       var accept = {};
       accept[blob.type] = [ext];


### PR DESCRIPTION
## About The Pull Request

Ports a tgstation PR which fixes #1236:
- https://github.com/tgstation/tgstation/pull/89864

> Ports https://github.com/VOREStation/VOREStation/pull/16713

## Why It's Good For The Game

> No more NTOS error screens when you want to save your chat history

## Changelog

:cl: Vallat (ported by tontyGH)
fix: [516] saving the chat log will no longer crash tgchat
/:cl:
