### PR TITLE
Chat size restoration

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -297,7 +297,7 @@ window "outputwindow"
 		left = "output_selector"
 		right = "input_and_buttons"
 		is-vert = false
-		splitter = 96
+		splitter = 94.9
 		show-splitter = false
 
 window "output_selector"
@@ -358,7 +358,7 @@ window "inputwindow"
 		anchor1 = 0,0
 		anchor2 = 100,100
 		is-default = true
-		border = line
+		border = sunken
 		saved-params = "command"
 
 window "inputbuttons"

--- a/tgui/packages/tgui-panel/settings/scaling.ts
+++ b/tgui/packages/tgui-panel/settings/scaling.ts
@@ -33,7 +33,7 @@ export async function setDisplayScaling() {
 const PANE_SPLITTERS = {
   info_button_child: 2,
   input_buttons_child: 80,
-  output_input_child: 96,
+  output_input_child: 94.9,
 };
 
 export function setEditPaneSplitters(editing: boolean) {


### PR DESCRIPTION
Nudges the default chat separator up, and re-sinks the chat border.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The chat splitter has been adjusted to return it to the old size. You may need to reset or adjust the sizing splitters in your chat settings window.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
