### PR TITLE
Mo' Animation

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -128,13 +128,38 @@
 		add_to.images += image_to_show
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_images_from_clients), image_to_show, show_to), duration, TIMER_CLIENT_TIME)
 
-///wrapper for flick_overlay(), flicks to everyone who can see the target atom
-/proc/flick_overlay_view(image/image_to_show, atom/target, duration)
-	var/list/viewing = list()
-	for(var/mob/viewer as anything in viewers(target))
-		if(viewer.client)
-			viewing += viewer.client
-	flick_overlay(image_to_show, viewing, duration)
+/**
+ * Helper atom that copies an appearance and exists for a period
+*/
+/atom/movable/flick_visual
+
+/// Takes the passed in MA/icon_state, mirrors it onto ourselves, and displays that in world for duration seconds
+/// Returns the displayed object, you can animate it and all, but you don't own it, we'll delete it after the duration
+/atom/proc/flick_overlay_view(mutable_appearance/display, duration)
+	if(!display)
+		return null
+
+	var/mutable_appearance/passed_appearance = \
+		istext(display) \
+			? mutable_appearance(icon, display, layer) \
+			: display
+
+	// If you don't give it a layer, we assume you want it to layer on top of this atom
+	// Because this is vis_contents, we need to set the layer manually (you can just set it as you want on return if this is a problem)
+	if(passed_appearance.layer == FLOAT_LAYER)
+		passed_appearance.layer = layer + 0.1
+	// This is faster then pooling. I promise
+	var/atom/movable/flick_visual/visual = new()
+	visual.appearance = passed_appearance
+	visual.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	// I hate /area
+	var/atom/movable/lies_to_children = src
+	lies_to_children.vis_contents += visual
+	QDEL_IN_CLIENT_TIME(visual, duration)
+	return visual
+
+/area/flick_overlay_view(mutable_appearance/display, duration)
+	return
 
 ///Get active players who are playing in the round
 /proc/get_active_player_count(alive_check = 0, afk_check = 0, human_check = 0)

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -162,6 +162,7 @@
 		if(!istype(underlay))
 			underlay = image(underlay, dir = SOUTH)
 			underlay.filters += filter(type = "outline", size = 1)
+			underlay.maptext = null
 
 		underlay.pixel_y = 2
 		underlay.alpha = 200

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -410,6 +410,9 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	item_insertion_feedback(user, to_insert, override)
 	real_location.update_appearance()
 	SEND_SIGNAL(src, COMSIG_STORAGE_INSERTED_ITEM, to_insert, user, override, force)
+
+	if(get(real_location, /mob) != user)
+		to_insert.do_pickup_animation(real_location, get_turf(user))
 	return TRUE
 
 /**

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -389,9 +389,9 @@ GLOBAL_REAL_VAR(machinery_default_armor) = list()
  * * object (obj) The object to be moved in to the users hand.
  * * user (mob/living) The user to recive the object
  */
-/obj/machinery/proc/try_put_in_hand(obj/object, mob/living/user)
-	if(!issilicon(user) && in_range(src, user))
-		user.put_in_hands(object)
+/obj/machinery/proc/try_put_in_hand(obj/item/object, mob/living/user)
+	if(!issilicon(user) && IsReachableBy(user) && user.put_in_hands(object))
+		object.do_pickup_animation(user, get_turf(src))
 	else
 		object.forceMove(drop_location())
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1740,16 +1740,20 @@ DEFINE_INTERACTABLE(/obj/item)
 /obj/item/proc/attackby_storage_insert(datum/storage, atom/storage_holder, mob/user)
 	return TRUE
 
-/obj/item/proc/do_pickup_animation(atom/target)
-	if(!istype(loc, /turf))
+/obj/item/proc/do_pickup_animation(atom/target, turf/source)
+	if(!source && !isturf(loc))
 		return
-	var/image/pickup_animation = image(icon = src, loc = loc, layer = layer + 0.1)
+
+	source ||= loc
+	if(!in_range(target, source))
+		return
+
+	var/image/pickup_animation = image(icon = src)
 	pickup_animation.plane = GAME_PLANE
 	pickup_animation.transform.Scale(0.75)
 	pickup_animation.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 
-	var/turf/current_turf = get_turf(src)
-	var/direction = get_dir(current_turf, target)
+	var/direction = get_dir(source, target)
 	var/to_x = target.base_pixel_x
 	var/to_y = target.base_pixel_y
 
@@ -1765,12 +1769,12 @@ DEFINE_INTERACTABLE(/obj/item)
 		to_y += 10
 		pickup_animation.pixel_x += 6 * (prob(50) ? 1 : -1) //6 to the right or left, helps break up the straight upward move
 
-	flick_overlay(pickup_animation, GLOB.clients, 4)
-	var/matrix/animation_matrix = new(pickup_animation.transform)
+	var/atom/movable/flick_visual/pickup = source.flick_overlay_view(pickup_animation, 0.4 SECONDS)
+	var/matrix/animation_matrix = new(pickup.transform)
 	animation_matrix.Turn(pick(-30, 30))
 	animation_matrix.Scale(0.65)
 
-	animate(pickup_animation, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, transform = animation_matrix, easing = CUBIC_EASING)
+	animate(pickup, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, transform = animation_matrix, easing = CUBIC_EASING)
 	animate(alpha = 0, transform = matrix().Scale(0.7), time = 1)
 
 /obj/item/proc/do_drop_animation(atom/moving_from)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1748,6 +1748,10 @@ DEFINE_INTERACTABLE(/obj/item)
 	if(!in_range(target, source))
 		return
 
+	// If you're at the stage where you're picking up the item, just remove the outline.
+	if(length(filter_data))
+		remove_filter("hover_outline")
+
 	var/image/pickup_animation = image(icon = src)
 	pickup_animation.plane = GAME_PLANE
 	pickup_animation.transform.Scale(0.75)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -174,7 +174,7 @@
 			return
 
 	// If the item was in a storage object the mob isn't holding, play the pickup animation
-	if(was_in_storage && item_old_loc && (get(item_old_loc.atom_storage?.real_location, /mob) != src))
+	if(was_in_storage && item_old_loc && (get(item_old_loc, /mob) != src))
 		I.do_pickup_animation(src, get_turf(item_old_loc))
 
 	I.pickup(src)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -372,7 +372,7 @@
 		I.pixel_y = clamp(text2num(LAZYACCESS(user_click_modifiers, ICON_Y)) - 16, -(world.icon_size/2), world.icon_size/2)
 
 	if(animate)
-		I.do_drop_animation(src)
+		I.do_pickup_animation(newloc, get_turf(src))
 
 //visibly unequips I but it is NOT MOVED AND REMAINS IN SRC
 //item MUST BE FORCEMOVE'D OR QDEL'D

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -158,7 +158,8 @@
 		return
 
 	//If the item is in a storage item, take it out
-	var/was_in_storage = I.item_flags & IN_STORAGE
+	var/was_in_storage = !!(I.item_flags & IN_STORAGE)
+	var/atom/item_old_loc = I.loc
 	if(was_in_storage && !I.loc.atom_storage?.attempt_remove(I, src, user = src))
 		return
 
@@ -171,6 +172,10 @@
 	if(I.loc == src)
 		if(!I.allow_attack_hand_drop(src) || !temporarilyRemoveItemFromInventory(I, use_unequip_delay = TRUE))
 			return
+
+	// If the item was in a storage object the mob isn't holding, play the pickup animation
+	if(was_in_storage && item_old_loc && (get(item_old_loc.atom_storage?.real_location, /mob) != src))
+		I.do_pickup_animation(src, get_turf(item_old_loc))
 
 	I.pickup(src)
 	. = put_in_hand(I, hand_index, ignore_anim = ignore_anim || was_in_storage)

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -282,6 +282,8 @@
 
 	visible_message(span_notice("[src] takes [I] from [offerer]."), \
 					span_notice("You take [I] from [offerer]."))
+
+	I.do_pickup_animation(src, get_turf(src))
 	put_in_hands(I)
 
 ///Returns a list of all body_zones covered by clothing

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -996,6 +996,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	R.amount--
 	if(IsReachableBy(usr) && usr.put_in_hands(vended_item))
 		to_chat(usr, span_notice("You take [R.name] out of the slot."))
+		vended_item.do_pickup_animation(usr, get_turf(src))
 	else
 		to_chat(usr, span_warning("[capitalize(R.name)] falls onto the floor!"))
 	SSblackbox.record_feedback("nested tally", "vending_machine_usage", 1, list("[type]", "[R.product_path]"))


### PR DESCRIPTION
Partial port of
- https://github.com/tgstation/tgstation/pull/90895

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Metek, Kapu1178
add: Removing items from and placing items into storage containers now has an animation.
fix: Public do_after() strips maptext.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
