### PR TITLE
Fixes fingerprints in the base_item_interaction chain

### DIFF
--- a/code/__DEFINES/fingerprint_flags.dm
+++ b/code/__DEFINES/fingerprint_flags.dm
@@ -1,0 +1,8 @@
+/// The item will have the user's fingerprints added if ITEM_INTERACT_SUCCESS is returned.
+#define FINGERPRINT_ITEM_SUCCESS (1<<0)
+/// The item will have the user's fingerprints added if ITEM_INTERACT_BLOCKING is returned.
+#define FINGERPRINT_ITEM_FAILURE (1<<1)
+/// The target atom will have the user's fingerprints added if ITEM_INTERACT_BLOCKING is returned.
+#define FINGERPRINT_OBJECT_SUCCESS (1<<2)
+/// The target atom will have the user's fingerprints added if ITEM_INTERACT_BLOCKING is returned.
+#define FINGERPRINT_OBJECT_FAILURE (1<<3)

--- a/code/__DEFINES/interaction_flags.dm
+++ b/code/__DEFINES/interaction_flags.dm
@@ -16,7 +16,6 @@
 #define INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND (1<<7)
 /// adds hiddenprints instead of fingerprints on interact
 #define INTERACT_ATOM_NO_FINGERPRINT_INTERACT (1<<8)
-
 /// attempt pickup on attack_hand for items
 #define INTERACT_ITEM_ATTACK_HAND_PICKUP (1<<0)
 

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -40,8 +40,8 @@
 #define IGNORE_DIGITIGRADE (1<<18)
 /// Has contextual screentips when HOVERING OVER OTHER objects
 #define ITEM_HAS_CONTEXTUAL_SCREENTIPS (1 << 19)
-/// Does not leave fingerprints or fibers on attack
-#define NO_EVIDENCE_ON_ATTACK (1<<20)
+/// Does not leave fingerprints or fibers when interacting with another atom. THIS INCLUDES ATTACKING.
+#define NO_EVIDENCE_ON_INTERACTION (1<<20)
 
 // Flags for the clothing_flags var on /obj/item/clothing
 /// SUIT and HEAD items which stop lava from hurting the wearer

--- a/code/datums/forensics.dm
+++ b/code/datums/forensics.dm
@@ -40,7 +40,7 @@
 	trace_DNA |= dna
 
 /// Adds the fingerprint of M to our fingerprint list
-/datum/forensics/proc/add_fingerprint(mob/living/M, ignoregloves = FALSE)
+/datum/forensics/proc/add_fingerprint(mob/living/M, ignoregloves = FALSE, log_touch = TRUE)
 	if(!isliving(M))
 		if(!iscameramob(M))
 			return
@@ -64,7 +64,7 @@
 			ignoregloves = TRUE
 
 		if(!ignoregloves)
-			H.gloves.add_fingerprint(H, TRUE) //ignoregloves = 1 to avoid infinite loop.
+			H.gloves.add_fingerprint(H, TRUE, FALSE) //ignoregloves = 1 to avoid infinite loop.
 			return
 
 	add_partial_print(H.get_fingerprints(ignoregloves, H.get_active_hand()))
@@ -73,6 +73,10 @@
 /datum/forensics/proc/add_partial_print(full_print)
 	PRIVATE_PROC(TRUE)
 	LAZYINITLIST(fingerprints)
+
+	#warn debug
+	if(usr?.client)
+		to_chat(world, "Added partial print to [parent].")
 
 	if(!fingerprints[full_print])
 		fingerprints[full_print] = stars(full_print, rand(0, 70)) //Initial touch, not leaving much evidence the first time.

--- a/code/datums/forensics.dm
+++ b/code/datums/forensics.dm
@@ -74,10 +74,6 @@
 	PRIVATE_PROC(TRUE)
 	LAZYINITLIST(fingerprints)
 
-	#warn debug
-	if(usr?.client)
-		to_chat(world, "Added partial print to [parent].")
-
 	if(!fingerprints[full_print])
 		fingerprints[full_print] = stars(full_print, rand(0, 70)) //Initial touch, not leaving much evidence the first time.
 		return

--- a/code/game/atom/atoms.dm
+++ b/code/game/atom/atoms.dm
@@ -96,6 +96,9 @@
 	///Intearaction flags
 	var/interaction_flags_atom = NONE
 
+	/// Determines behavior for how fingerprints are given during item_interaction()
+	var/fingerprint_flags_item_interaction = ALL
+
 	var/flags_ricochet = NONE
 
 	///When a projectile tries to ricochet off this atom, the projectile ricochet chance is multiplied by this

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -96,6 +96,15 @@ DEFINE_INTERACTABLE(/obj/item)
 
 	///Item flags for the item
 	var/item_flags = NONE
+
+	/// Determines behavior for how fingerprints are given during interact_with_atom().
+	var/fingerprint_flags_interact_with_atom = ALL
+	/// Determines behavior for how fingerprints are given during attack_self().
+	// Currently unimplemented as attack self is fucked.
+	// var/fingerprint_flags_attack_self = ALL
+	/// Determines behavior for how fingerprints are given during tool_act()
+	var/fingerprint_flags_tool_act = FINGERPRINT_ITEM_SUCCESS | FINGERPRINT_OBJECT_SUCCESS
+
 	/// If set to TRUE, skip item interaction and just attack the target. See ATTACK_IF_COMBAT_MODE()
 	var/combat_mode_force_attack = FALSE
 
@@ -1940,7 +1949,7 @@ DEFINE_INTERACTABLE(/obj/item)
 
 /// Leave evidence of a user on a target
 /obj/item/proc/leave_evidence(mob/user, atom/target)
-	if(!(item_flags & NO_EVIDENCE_ON_ATTACK))
+	if(!(item_flags & NO_EVIDENCE_ON_INTERACTION))
 		target.add_fingerprint(user)
 	else
 		target.log_touch(user)

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "evidenceobj"
 	inhand_icon_state = ""
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_SMALL
 
 	// Don't leave fingerprints on items moved into or out of the evidence bag.
 	fingerprint_flags_interact_with_atom = parent_type::fingerprint_flags_interact_with_atom &~ (FINGERPRINT_OBJECT_SUCCESS|FINGERPRINT_OBJECT_FAILURE)
@@ -38,8 +38,11 @@
 	if(!isitem(interacting_with))
 		return NONE
 
+	var/obj/item/I = interacting_with
+	var/old_item_turf = get_turf(I)
 	var/inserted = atom_storage.attempt_insert(interacting_with, user)
 	if(inserted)
+		I.do_pickup_animation(user, old_item_turf)
 		return ITEM_INTERACT_SUCCESS
 
 	return ITEM_INTERACT_BLOCKING
@@ -61,6 +64,6 @@
 /obj/item/storage/evidencebag/Exited(atom/movable/gone, direction)
 	. = ..()
 	cut_overlays() //remove the overlays
-	w_class = WEIGHT_CLASS_TINY
+	w_class = initial(w_class)
 	icon_state = "evidenceobj"
 	desc = "An empty evidence bag."

--- a/code/modules/detectivework/samples.dm
+++ b/code/modules/detectivework/samples.dm
@@ -1,7 +1,7 @@
 /obj/item/sample
 	name = "forensic sample"
 	icon = 'icons/obj/forensics.dmi'
-	item_flags = parent_type::item_flags | NOBLUDGEON | NO_EVIDENCE_ON_ATTACK
+	item_flags = parent_type::item_flags | NOBLUDGEON | NO_EVIDENCE_ON_INTERACTION
 	w_class = WEIGHT_CLASS_TINY
 	var/list/evidence = list()
 	var/label
@@ -149,7 +149,7 @@
 	icon = 'icons/obj/forensics.dmi'
 	icon_state = "m_glass"
 	w_class = WEIGHT_CLASS_SMALL
-	item_flags = parent_type::item_flags | NOBLUDGEON | NO_EVIDENCE_ON_ATTACK
+	item_flags = parent_type::item_flags | NOBLUDGEON | NO_EVIDENCE_ON_INTERACTION
 
 	var/evidence_type = "fiber"
 	var/evidence_path = /obj/item/sample/fibers

--- a/code/modules/detectivework/swab.dm
+++ b/code/modules/detectivework/swab.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/forensics.dmi'
 	icon_state = "swab"
 
-	item_flags = parent_type::item_flags | NOBLUDGEON | NO_EVIDENCE_ON_ATTACK
+	item_flags = parent_type::item_flags | NOBLUDGEON | NO_EVIDENCE_ON_INTERACTION
 
 	var/used = FALSE
 

--- a/code/modules/unit_tests/combat/__include.dm
+++ b/code/modules/unit_tests/combat/__include.dm
@@ -5,6 +5,7 @@
 #include "combat_cuffs.dm"
 #include "combat_door_click.dm"
 #include "combat_emp_flashlight.dm"
+#include "combat_evidencebag.dm"
 #include "combat_flash.dm"
 #include "combat_nested_inventory.dm"
 #include "combat_pistol_whip.dm"

--- a/code/modules/unit_tests/combat/combat_evidencebag.dm
+++ b/code/modules/unit_tests/combat/combat_evidencebag.dm
@@ -1,0 +1,19 @@
+/datum/unit_test/combat/evidencebag
+	name = "COMBAT/FINGERPRINTS: Evidence Bags Shall Not Leave Fingerprints."
+
+/datum/unit_test/combat/evidencebag/Run()
+	var/mob/living/carbon/human/consistent/user = ALLOCATE_BOTTOM_LEFT()
+	var/obj/item/storage/evidencebag/bag = ALLOCATE_BOTTOM_LEFT()
+	var/obj/item/wrench/evidence = ALLOCATE_BOTTOM_LEFT()
+
+	user.put_in_active_hand(bag)
+	click_wrapper(user, evidence)
+
+	TEST_ASSERT(evidence in bag, "Evidence bag did not pick up the wrench.")
+	TEST_ASSERT(isnull(evidence.forensics?.fingerprints), "Wrench has fingerprints after being picked up.")
+
+	var/turf/place_target = get_step(user, EAST)
+	click_wrapper(user, place_target)
+
+	TEST_ASSERT(!(evidence in bag), "Wrench did not leave the bag.")
+	TEST_ASSERT(isnull(evidence.forensics?.fingerprints), "Wrench has fingerprints after being put down.")

--- a/daedalus.dme
+++ b/daedalus.dme
@@ -100,6 +100,7 @@
 #include "code\__DEFINES\exports.dm"
 #include "code\__DEFINES\external_organs.dm"
 #include "code\__DEFINES\fantasy_affixes.dm"
+#include "code\__DEFINES\fingerprint_flags.dm"
 #include "code\__DEFINES\firealarm.dm"
 #include "code\__DEFINES\flags.dm"
 #include "code\__DEFINES\flavor.dm"


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now click on items with an Evidence Bag to pick them up without leaving your own prints on them. Additionally, you may click on another location to drop the item there.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
