### PR TITLE
Fix `send_appearance` not properly removing the container from the vis holder

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1728,20 +1728,10 @@
 	if(!hud_used || isnull(appearance))
 		return
 
-	var/atom/movable/screen/container
-	if(isatom(container))
-		container = appearance
-	else
-		container = new()
-		container.appearance = appearance
+	var/atom/movable/screen/container = new
+	container.appearance = appearance
 
 	hud_used.vis_holder.add_viscontents(container)
-	addtimer(CALLBACK(src, PROC_REF(remove_appearance), appearance), 5 SECONDS, TIMER_DELETE_ME)
+	addtimer(CALLBACK(hud_used.vis_holder, TYPE_PROC_REF(/atom, remove_viscontents), container), 5 SECONDS, TIMER_DELETE_ME)
 
 	return container
-
-/mob/proc/remove_appearance(atom/movable/appearance)
-	if(!hud_used)
-		return
-
-	hud_used.vis_holder.remove_viscontents(appearance)


### PR DESCRIPTION
## About The Pull Request

`/mob/proc/send_appearance` was making a 5 second timer to remove the *appearance* from `hud_used.vis_holder.vis_contents` - which... does nothing, as it's the _container_ that's in the `vis_contents`. 

And now, due to vis_contents wrappers, we don't need an extra wrapper proc at all - we can just... call `remove_viscontents` directly on a timer, properly passing the _container_ as the argument, rather than the appearance.

also that `isatom(container)` was always false because `container` was always uninitialized. I presume it might've been intended to be `isatom(appearance)` but I'm not gonna make any assumptions.

## Why It's Good For The Game

better code that works properly is always good for the game, I think? prolly. hopefully.

## Changelog

no user-facing changes I believe.