### PR TITLE
Don't throw compile errors related to BYOND version for OpenDream

### DIFF
--- a/code/_byond_version_compact.dm
+++ b/code/_byond_version_compact.dm
@@ -3,7 +3,7 @@
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 516
 #define MIN_COMPILER_BUILD 1659
-#if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
+#if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM) && !defined(OPENDREAM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
 #error For a specific minimum version, check code/_byond_version_compact.dm


### PR DESCRIPTION
DD is currently broken on OpenDream's CI due to it reporting the DM version as 515 (despite supporting various 516 features), and other codebases just skip this check for OD, so this does the same.