### PR TITLE
fix title music due to the ref being unclear

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -787,11 +787,6 @@ SUBSYSTEM_DEF(ticker)
 	if(!credits_music)
 		credits_music = login_music
 
-/datum/controller/subsystem/ticker/proc/get_login_song(idx)
-	RETURN_TYPE(/datum/media)
-	idx = (idx %% (length(login_music) + 1)) || 1
-	return login_music[idx]
-
 ///Generate a list of gamemodes we can play.
 /datum/controller/subsystem/ticker/proc/draft_gamemodes()
 	var/list/datum/game_mode/runnable_modes = list()

--- a/code/modules/client/playlist.dm
+++ b/code/modules/client/playlist.dm
@@ -16,18 +16,23 @@
 
 /// Plays the current selected track.
 /datum/playlist/proc/play_track()
-	if(!selected_track || !(parent.client?.prefs.toggles & SOUND_LOBBY))
+	if(!selected_track || !(parent.client?.prefs.toggles & SOUND_LOBBY) || !isnewplayer(parent.client.mob))
 		return
 
 	var/sound/S = sound(selected_track.path, repeat = 0, wait = 0, volume = 85, channel = CHANNEL_LOBBYMUSIC)
-	S.params = "on-end=.cycle_title_music&on-preempt="
+	S.params = list(
+		"on-end" = ".cycle_title_music",
+		"on-preempt" = null,
+	)
+
 	SEND_SOUND(parent.client, S)
 
 	announce_track()
 
 /// Stops the current track.
 /datum/playlist/proc/stop_track()
-	SEND_SOUND(parent.client, sound(wait = FALSE, channel = CHANNEL_LOBBYMUSIC))
+	var/sound/S = sound(wait = FALSE, channel = CHANNEL_LOBBYMUSIC)
+	SEND_SOUND(parent.client, S)
 
 /// Cycles the playlist, refreshing the queue if it is empty.
 /datum/playlist/proc/cycle_track()


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed cases where title music would continue to play into the round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
