### PR TITLE
Hunger additions

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -49,7 +49,10 @@
 #define BROKEN_SKULL_EFFECT "broken_head"
 /// Missing or dead liver.
 #define DEAD_LIVER_EFFECT "dead_liver"
+/// Hunger.
+#define HUNGER_EFFECT "hunger"
 
+/// Vampire thirst
 #define VAMPIRE_EFFECT "vampire_effect"
 
 // Status effect application helpers.

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -125,11 +125,21 @@
 				ghost.show_message("[FOLLOW_LINK(ghost, user)]<span class='emote'> [dchatmsg]</span>")
 
 	if(emote_type == EMOTE_AUDIBLE)
-	//PARIAH EDIT
-		user.audible_message(msg, deaf_message = "<span class='emote'>You see how <b>[user]</b>[space][msg]</span>", audible_message_flags = EMOTE_MESSAGE, separation = space)
+
+		user.audible_message(
+			msg,
+			deaf_message = "<span class='emote'>You see how <b>[user]</b>[space][msg]</span>",
+			audible_message_flags = EMOTE_MESSAGE,
+			separation = space
+		)
 	else
-		user.visible_message(msg, blind_message = "<span class='emote'>You hear how <b>[user]</b>[space][msg]</span>", visible_message_flags = EMOTE_MESSAGE, separation = space)
-	//PARIAH EDIT END
+		user.visible_message(
+			msg,
+			blind_message = span_hear("You hear how <b>[user]</b>[space][msg]"),
+			visible_message_flags = EMOTE_MESSAGE,
+			separation = space
+	)
+
 	SEND_SIGNAL(user, COMSIG_MOB_EMOTED(key))
 
 /**

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -389,7 +389,8 @@
 
 	if(nutrition < 100 && !blood && !force)
 		if(message)
-			visible_message(span_notice("<b>[src]</b> dry heaves."), blind_message = span_hear("You hear someone dry heave."))
+			spawn(-1)
+				emote(/datum/emote/living/carbon/gasp_air/dry_heave)
 		if(stun)
 			Paralyze(200)
 		return TRUE
@@ -407,7 +408,7 @@
 
 	playsound(get_turf(src), 'sound/effects/splat.ogg', 50, TRUE)
 	var/turf/T = get_turf(src)
-	if(!blood)
+	if(!blood && lost_nutrition)
 		adjust_nutrition(-lost_nutrition)
 		adjustToxLoss(-3)
 

--- a/code/modules/mob/living/carbon/carbon_health.dm
+++ b/code/modules/mob/living/carbon/carbon_health.dm
@@ -136,6 +136,9 @@
 	if(!damtype)
 		CRASH("No damage type given to can_autoheal")
 
+	if(nutrition <= NUTRITION_LEVEL_STARVING)
+		return FALSE
+
 	switch(damtype)
 		if(BRUTE)
 			return getBruteLoss() < (maxHealth/2)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -41,7 +41,7 @@
 /datum/emote/living/carbon/human/mumble
 	key = "mumble"
 	key_third_person = "mumbles"
-	message = "mumbles!"
+	message = "mumbles."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/human/scream
@@ -333,3 +333,9 @@
 	key = "gasp_air_unconscious"
 	message = "gasps for air!"
 	stat_allowed = UNCONSCIOUS
+
+/datum/emote/living/carbon/gasp_air/dry_heave
+	key = "dry_heave"
+	message = "dry heaves."
+	emote_type = EMOTE_AUDIBLE
+	can_player_use = FALSE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -835,8 +835,8 @@
 /mob/living/carbon/human/vomit(lost_nutrition = 10, blood = FALSE, stun = TRUE, distance = 1, message = TRUE, vomit_type = VOMIT_TOXIC, harm = TRUE, force = FALSE, purge_ratio = 0.1)
 	if(blood && (NOBLOOD in dna.species.species_traits) && !HAS_TRAIT(src, TRAIT_TOXINLOVER))
 		if(message)
-			visible_message(span_warning("[src] dry heaves!"), \
-							span_userdanger("You try to throw up, but there's nothing in your stomach!"))
+			spawn(-1)
+				emote(/datum/emote/living/carbon/gasp_air/dry_heave)
 		if(stun)
 			Paralyze(200)
 		return 1

--- a/code/modules/mob/living/carbon/pain.dm
+++ b/code/modules/mob/living/carbon/pain.dm
@@ -372,24 +372,40 @@
 
 
 	// Damage to internal organs hurts a lot.
+	var/list/organ_pain_zones
 	for(var/obj/item/organ/I as anything in organs)
 		if(istype(I, /obj/item/organ/brain))
 			continue
 
-		if(prob(1) && (!(I.organ_flags & (ORGAN_SYNTHETIC|ORGAN_DEAD)) && I.damage > 5))
-			var/obj/item/bodypart/parent = I.ownerlimb
-			if(parent.bodypart_flags & BP_NO_PAIN)
-				continue
+		if(!I.is_causing_pain())
+			continue
 
-			var/pain_given = 10
-			var/message = "You feel a dull pain in your [parent.plaintext_zone]"
-			if(I.damage > I.low_threshold)
-				pain_given = 25
-				message = "You feel a pain in your [parent.plaintext_zone]"
-			if(I.damage > (I.high_threshold * I.maxHealth))
-				pain_given = 40
-				message = "You feel a sharp pain in your [parent.plaintext_zone]"
-			apply_pain(pain_given, parent.body_zone, message, TRUE)
+		var/obj/item/bodypart/parent = I.ownerlimb
+		if(parent.bodypart_flags & BP_NO_PAIN)
+			continue
+
+		LAZYINITLIST(organ_pain_zones)
+
+		if(I.damage > (I.low_threshold * I.maxHealth))
+			organ_pain_zones[parent] += 25
+		if(I.damage > (I.high_threshold * I.maxHealth))
+			organ_pain_zones[parent] += 40
+		else
+			organ_pain_zones[parent] += 10
+
+
+	for(var/obj/item/bodypart/painful_part as anything in organ_pain_zones)
+		var/organ_pain_applied = organ_pain_zones[painful_part]
+		var/message
+		switch(organ_pain_applied)
+			if(0 to 10)
+				message = "You feel a dull pain in your [painful_part.plaintext_zone]"
+			if(11 to 44)
+				message = "You feel a pain in your [painful_part.plaintext_zone]"
+			else
+				message = "You feel a sharp pain in your [painful_part.plaintext_zone]"
+
+		apply_pain(organ_pain_applied, painful_part, message, TRUE, updating_health = FALSE)
 
 	if(prob(1))
 		var/systemic_organ_failure = getToxLoss()
@@ -404,6 +420,8 @@
 				pain_message("Your whole body hurts badly.", PAIN_AMT_MEDIUM, TRUE)
 			if(100 to INFINITY)
 				pain_message("Your body aches all over, it's driving you mad.", PAIN_AMT_AGONIZING, TRUE)
+
+	update_health_hud()
 
 /// Called by handle_pain() to consider dropping an item based on Willpower.
 /mob/living/carbon/proc/pain_drop_item(pain_amt)

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -542,6 +542,10 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		spawn(-1)
 			owner.emote(/datum/emote/living/carbon/gasp_air)
 
+/// Returns TRUE if this organ is able to cause pain to the parent during handle_pain()
+/obj/item/organ/proc/is_causing_pain()
+	return prob(1) && (damage >= 5) && !(organ_flags & (ORGAN_SYNTHETIC|ORGAN_DEAD))
+
 /mob/living/proc/regenerate_organs()
 	return FALSE
 


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The "Starving" state of hunger now has the following effects: Stomach pain, vision impairment, an dry heaving. 
fix: Fixed an issue that caused pain messages induced by damaged organs to appear far more often than intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
