### PR TITLE
Fixes SASS warnings while preserving current behavior.

### DIFF
--- a/tgui/packages/tgui/styles/base.scss
+++ b/tgui/packages/tgui/styles/base.scss
@@ -12,11 +12,13 @@ $color-bg-section: rgba(0, 0, 0, 0.25) !default;
 $color-bg-grad-spread: 0% !default; //Dummied out at kapu's request
 $color-bg-start: color.adjust(
   $color-bg,
-  $lightness: $color-bg-grad-spread
+  $lightness: $color-bg-grad-spread,
+  $space: hsl
 ) !default;
 $color-bg-end: color.adjust(
   $color-bg,
-  $lightness: -$color-bg-grad-spread
+  $lightness: -$color-bg-grad-spread,
+  $space: hsl
 ) !default;
 
 $border-radius: 0em !default;

--- a/tgui/packages/tgui/styles/colors.scss
+++ b/tgui/packages/tgui/styles/colors.scss
@@ -73,7 +73,7 @@ $bg-map-keys: map.keys($_gen_map) !default;
 
 $fg-map: ();
 @each $color-name in $fg-map-keys {
-  $fg-map: map-merge(
+  $fg-map: map.merge(
     $fg-map,
     (
       $color-name: fg(map.get($_gen_map, $color-name)),
@@ -83,7 +83,7 @@ $fg-map: ();
 
 $bg-map: ();
 @each $color-name in $bg-map-keys {
-  $bg-map: map-merge(
+  $bg-map: map.merge(
     $bg-map,
     (
       $color-name: bg(map.get($_gen_map, $color-name)),

--- a/tgui/packages/tgui/styles/components/Button.scss
+++ b/tgui/packages/tgui/styles/components/Button.scss
@@ -41,7 +41,7 @@ $bg-map: colors.$bg-map !default;
 
   &:hover,
   &:active {
-    background-color: lighten($color, 30%);
+    background-color: OLD_lighten($color, 30%);
     color: $text-color;
   }
 }

--- a/tgui/packages/tgui/styles/functions.scss
+++ b/tgui/packages/tgui/styles/functions.scss
@@ -28,10 +28,12 @@
 
 // Increases perceptual color lightness.
 @function lighten($color, $percent) {
+  $old-lightness: color.channel($color, 'lightness', $space: hsl);
+  $scaled-lightness: ($old-lightness) * (1 + num($percent));
   $scaled: hsl(
-    color.hue($color),
-    color.saturation($color),
-    color.lightness($color) * (1 + num($percent))
+    color.channel($color, 'hue', $space: hsl),
+    color.channel($color, 'saturation', $space: hsl),
+    $scaled-lightness
   );
   $mixed: color.mix(#ffffff, $color, 100% * num($percent));
   @return color.mix($scaled, $mixed, 75%);
@@ -41,9 +43,9 @@
 // 1 is pure white, 0 is pure black.
 @function luminance($color) {
   $colors: (
-    'red': color.red($color),
-    'green': color.green($color),
-    'blue': color.blue($color),
+    'red': color.channel($color, 'red', $space: rgb),
+    'green': color.channel($color, 'green', $space: rgb),
+    'blue': color.channel($color, 'blue', $space: rgb),
   );
 
   @each $name, $value in $colors {
@@ -73,7 +75,7 @@
   @return color.mix(
     color.change($color-rgba, $alpha: 1),
     $color-background,
-    color.alpha($color-rgba) * 100%
+    color.channel($color-rgba, 'alpha') * 100%
   );
 }
 
@@ -81,4 +83,12 @@
 // to ensure that they display correctly when using differently-scaled windows
 @function vp($viewportUnit) {
   @return calc(var(--scaling-amount) * $viewportUnit);
+}
+
+.testold {
+  color: lighten(#000000, 15%);
+}
+
+.testnew {
+  color: lightennew(#000000, 15%);
 }

--- a/tgui/packages/tgui/styles/functions.scss
+++ b/tgui/packages/tgui/styles/functions.scss
@@ -94,11 +94,3 @@
 @function vp($viewportUnit) {
   @return calc(var(--scaling-amount) * $viewportUnit);
 }
-
-.testold {
-  color: OLD_lighten(#000000, 15%);
-}
-
-.testnew {
-  color: lightennew(#000000, 15%);
-}

--- a/tgui/packages/tgui/styles/functions.scss
+++ b/tgui/packages/tgui/styles/functions.scss
@@ -26,8 +26,8 @@
 //  Color
 // --------------------------------------------------------
 
-// Increases perceptual color lightness.
-@function lighten($color, $percent) {
+// DEPRECATED, WHAT THE FUCK WAS STYLEMISTAKE THINKING?
+@function OLD_lighten($color, $percent) {
   $old-lightness: color.channel($color, 'lightness', $space: hsl);
   $scaled-lightness: ($old-lightness) * (1 + num($percent));
   $scaled: hsl(
@@ -37,6 +37,16 @@
   );
   $mixed: color.mix(#ffffff, $color, 100% * num($percent));
   @return color.mix($scaled, $mixed, 75%);
+}
+
+// Increases perceptual color lightness.
+@function lighten($color, $amount) {
+  @return color.adjust($color, $lightness: $amount * 1%, $space: hsl);
+}
+
+// Decreases perceptual color lightness.
+@function darken($color, $amount) {
+  @return color.adjust($color, $lightness: -$amount * 1%, $space: hsl);
 }
 
 // Returns the NTSC luminance of `$color` as a float (between 0 and 1).
@@ -86,7 +96,7 @@
 }
 
 .testold {
-  color: lighten(#000000, 15%);
+  color: OLD_lighten(#000000, 15%);
 }
 
 .testnew {

--- a/tgui/packages/tgui/styles/interfaces/Mecha.scss
+++ b/tgui/packages/tgui/styles/interfaces/Mecha.scss
@@ -37,7 +37,7 @@ $color-danger: #c92020 !default;
   padding-left: 0 !important;
   padding-right: 0 !important;
   &:hover {
-    background-color: lighten($color-danger, 15%) !important;
-    border-color: lighten($color-danger, 15%) !important;
+    background-color: OLD_lighten($color-danger, 15%) !important;
+    border-color: OLD_lighten($color-danger, 15%) !important;
   }
 }

--- a/tgui/packages/tgui/styles/interfaces/NuclearBomb.scss
+++ b/tgui/packages/tgui/styles/interfaces/NuclearBomb.scss
@@ -27,8 +27,8 @@ $background-beige: #e8e4c9;
   background-color: $background-beige;
   border-color: $background-beige;
   &:hover {
-    background-color: lighten($background-beige, 15%) !important;
-    border-color: lighten($background-beige, 15%) !important;
+    background-color: OLD_lighten($background-beige, 15%) !important;
+    border-color: OLD_lighten($background-beige, 15%) !important;
   }
 }
 
@@ -42,8 +42,8 @@ $background-beige: #e8e4c9;
   background-color: $color-caution !important;
   border-color: $color-caution !important;
   &:hover {
-    background-color: lighten($color-caution, 15%) !important;
-    border-color: lighten($color-caution, 15%) !important;
+    background-color: OLD_lighten($color-caution, 15%) !important;
+    border-color: OLD_lighten($color-caution, 15%) !important;
   }
 }
 
@@ -51,8 +51,8 @@ $background-beige: #e8e4c9;
   background-color: $color-danger !important;
   border-color: $color-danger !important;
   &:hover {
-    background-color: lighten($color-danger, 15%) !important;
-    border-color: lighten($color-danger, 15%) !important;
+    background-color: OLD_lighten($color-danger, 15%) !important;
+    border-color: OLD_lighten($color-danger, 15%) !important;
   }
 }
 

--- a/tgui/packages/tgui/styles/layouts/Window.scss
+++ b/tgui/packages/tgui/styles/layouts/Window.scss
@@ -65,7 +65,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: rgba(lighten(base.$color-bg, 30%), 0.25);
+  background-color: rgba(OLD_lighten(base.$color-bg, 30%), 0.25);
   pointer-events: none;
 }
 

--- a/tgui/packages/tgui/styles/themes/book.scss
+++ b/tgui/packages/tgui/styles/themes/book.scss
@@ -8,7 +8,7 @@
 @use '../functions.scss' as *;
 
 $color-pencil: #454442;
-$text-color: lighten($color-pencil, 15%);
+$text-color: OLD_lighten($color-pencil, 15%);
 
 $color-paper: rgba(248, 240, 227, 255);
 

--- a/tgui/packages/tgui/styles/themes/crt.scss
+++ b/tgui/packages/tgui/styles/themes/crt.scss
@@ -1,6 +1,6 @@
-@use 'sass:color';
 @use 'sass:math';
 @use 'sass:meta';
+@use '../functions.scss' as *;
 
 $background-radial-opacity: 0.2 !default;
 $color-bg: #ffffff !default;


### PR DESCRIPTION
Like https://github.com/DaedalusDock/daedalusdock/pull/1344 but maintains hex color usage and adds functions identical to SCSS's old darken() and lighten().