### PR TITLE
Stepping on needles

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -304,7 +304,7 @@
 
 	var/ant_flags = (CALTROP_NOCRAWL | CALTROP_NOSTUN) /// Small amounts of ants won't be able to bite through shoes.
 	if(ant_bite_damage > 1)
-		ant_flags = (CALTROP_NOCRAWL | CALTROP_NOSTUN | CALTROP_BYPASS_SHOES)
+		ant_flags |= CALTROP_BYPASS_SHOES
 
 	switch(ant_bite_damage)
 		if(0 to 1)

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -94,7 +94,7 @@
 /obj/item/dice/d4/Initialize(mapload)
 	. = ..()
 	// 1d4 damage
-	AddComponent(/datum/component/caltrop, min_damage = 1, max_damage = 4, probability = 4)
+	AddComponent(/datum/component/caltrop, min_damage = 1, max_damage = 4, probability = 4, flags = CALTROP_IGNORE_WALKERS)
 
 /obj/item/dice/d6
 	name = "d6"

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -299,7 +299,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 
 /obj/item/shard/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/caltrop, min_damage = force)
+	AddComponent(/datum/component/caltrop, min_damage = force, flags = CALTROP_IGNORE_WALKERS)
 	AddComponent(/datum/component/butchering, 150, 65)
 	icon_state = pick("large", "medium", "small")
 	switch(icon_state)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -140,7 +140,7 @@
 
 /obj/item/broken_bottle/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/caltrop, min_damage = force, probability = 4)
+	AddComponent(/datum/component/caltrop, min_damage = force, probability = 4, flags = CALTROP_IGNORE_WALKERS)
 	AddComponent(/datum/component/butchering, 200, 55)
 
 /// Mimics the appearance and properties of the passed in bottle.

--- a/code/modules/food_and_drinks/plate.dm
+++ b/code/modules/food_and_drinks/plate.dm
@@ -163,4 +163,4 @@
 
 /obj/item/plate_shard/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/caltrop, min_damage = force, probability = 4)
+	AddComponent(/datum/component/caltrop, min_damage = force, probability = 4, flags = CALTROP_IGNORE_WALKERS)

--- a/code/modules/hydroponics/plants/towercap.dm
+++ b/code/modules/hydroponics/plants/towercap.dm
@@ -113,7 +113,7 @@
 
 /obj/structure/punji_sticks/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/caltrop, min_damage = 20, max_damage = 30, flags = CALTROP_BYPASS_SHOES)
+	AddComponent(/datum/component/caltrop, min_damage = 20, max_damage = 30, flags = CALTROP_BYPASS_SHOES | CALTROP_IGNORE_WALKERS)
 	stab_overlay = mutable_appearance(icon, "[icon_state]_stab", layer = ABOVE_MOB_LAYER, plane = GAME_PLANE)
 
 /obj/structure/punji_sticks/intercept_zImpact(list/falling_movables, levels)

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -117,7 +117,7 @@
 
 /mob/living/basic/cockroach/hauberoach/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/caltrop, min_damage = 10, max_damage = 15, flags = (CALTROP_BYPASS_SHOES | CALTROP_SILENT))
+	AddComponent(/datum/component/caltrop, min_damage = 10, max_damage = 15, flags = (CALTROP_BYPASS_SHOES | CALTROP_SILENT | CALTROP_IGNORE_WALKERS))
 	AddComponent(/datum/component/squashable, squash_chance = 100, squash_damage = 1, squash_callback = TYPE_PROC_REF(/mob/living/basic/cockroach/hauberoach, on_squish))
 
 ///Proc used to override the squashing behavior of the normal cockroach.

--- a/code/modules/power/lighting/light_items.dm
+++ b/code/modules/power/lighting/light_items.dm
@@ -79,7 +79,7 @@
 /obj/item/light/Initialize(mapload)
 	. = ..()
 	create_reagents(LIGHT_REAGENT_CAPACITY, INJECTABLE | DRAINABLE)
-	AddComponent(/datum/component/caltrop, min_damage = force)
+	AddComponent(/datum/component/caltrop, min_damage = force, flags = CALTROP_IGNORE_WALKERS)
 	update()
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -35,6 +35,7 @@
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 	AddElement(/datum/element/eyestab)
+	AddComponent(/datum/component/caltrop, min_damage = force, probability = 10, flags = CALTROP_IGNORE_WALKERS, on_trigger = CALLBACK(src, PROC_REF(on_caltrop_trigger)))
 
 /obj/item/reagent_containers/syringe/attackby(obj/item/I, mob/user, params)
 	return
@@ -282,6 +283,10 @@
 		H.try_contract_pathogen(P, make_copy = TRUE) // It's probably a good idea to not leave refs to an active disease in the syringe.
 
 	H.germ_level = max(H.germ_level, INFECTION_LEVEL_TWO)
+
+/// Called when a human triggers the caltrop component, to infect the mob.
+/obj/item/reagent_containers/syringe/proc/on_caltrop_trigger(mob/living/carbon/human/H)
+	contaminate_mob(H)
 
 /obj/item/reagent_containers/syringe/epinephrine
 	name = "syringe (epinephrine)"


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Syringes can now be stepped on while barefoot, contaminated syringes will infect the victim.
tweak: All "caltrop" items now no longer trigger while walking. This does NOT apply to crawling over them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
