### PR TITLE
Fix a couple of subsystems improperly setting `SS_HIBERNATE`

### DIFF
--- a/code/controllers/subsystem/augury.dm
+++ b/code/controllers/subsystem/augury.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(augury)
 	name = "Augury"
-	flags = SS_NO_INIT
-	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME | SS_HIBERNATE
+	flags = SS_NO_INIT | SS_HIBERNATE
+	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/list/watchers = list()
 	var/list/doombringers = list()
@@ -12,7 +12,8 @@ SUBSYSTEM_DEF(augury)
 	. = ..()
 	hibernate_checks= list(
 		NAMEOF(src, watchers),
-		NAMEOF(src, doombringers)
+		NAMEOF(src, doombringers),
+		NAMEOF(src, observers_given_action),
 	)
 
 /datum/controller/subsystem/augury/stat_entry(msg)

--- a/code/controllers/subsystem/processing/obj_tab_items.dm
+++ b/code/controllers/subsystem/processing/obj_tab_items.dm
@@ -1,7 +1,7 @@
 PROCESSING_SUBSYSTEM_DEF(obj_tab_items)
 	name = "Obj Tab Items"
-	flags = SS_NO_INIT
-	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT | SS_HIBERNATE
+	flags = SS_NO_INIT | SS_HIBERNATE
+	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 	wait = 0.1 SECONDS
 
 // I know this is mostly copypasta, but I want to change the processing logic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

`SSaugury` and `SSobj_tab_items` accidentally included `SS_HIBERNATE` as a run level instead of a flag...

Also, I included `observers_given_action` in `SSaugury`'s `hibernate_checks` bc it can cause observer hard deletes otherwise.

## Why It's Good For The Game

things working properly is nice

## Changelog

No player-facing changes.