### PR TITLE
[516] Fixes Knob element rings being slightly cropped

### DIFF
--- a/tgui/packages/tgui/styles/components/Knob.scss
+++ b/tgui/packages/tgui/styles/components/Knob.scss
@@ -14,6 +14,7 @@ $knob-color: #333333 !default;
 $popup-background-color: #000000 !default;
 $popup-text-color: #ffffff !default;
 
+$pi: 3.1416;
 $inner-padding: 0.1em;
 
 .Knob {
@@ -83,14 +84,13 @@ $inner-padding: 0.1em;
 
 .Knob__ring {
   position: absolute;
+  overflow: visible;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
   padding: $inner-padding;
 }
-
-$pi: 3.1416;
 
 .Knob__ringTrackPivot {
   transform: rotateZ(135deg);


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
TGUI-Core makes knob rings overflow if needed while we don't, so I just copied that over.
Also moved the pi variable cause it makes diffing current and tgui-core ever-so-slightly easier.
fixes #1238 

<img width="79" height="73" alt="image" src="https://github.com/user-attachments/assets/7dca3105-ce9a-4458-9270-1ff0e2cd772e" />

## Changelog
