### PR TITLE
Removes succumbing

### DIFF
--- a/code/__DEFINES/alerts.dm
+++ b/code/__DEFINES/alerts.dm
@@ -15,7 +15,6 @@
 #define ALERT_NOT_ENOUGH_NITRO "not_enough_nitro"
 
 /** Mob related */
-#define ALERT_SUCCUMB "succumb"
 #define ALERT_BLIND "blind"
 #define ALERT_BUCKLED "buckled"
 #define ALERT_HANDCUFFED "handcuffed"

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -469,27 +469,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	src.receiving = receiving
 	src.offerer = offerer
 
-/// Gives the player the option to succumb while in critical condition
-/atom/movable/screen/alert/succumb
-	name = "Succumb"
-	desc = "Shuffle off this mortal coil."
-	icon_state = ALERT_SUCCUMB
-
-/atom/movable/screen/alert/succumb/Click()
-	. = ..()
-	if(!.)
-		return
-
-	var/mob/living/living_owner = owner
-	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", "Final Words")
-	if (!last_whisper)
-		return
-
-	if (length(last_whisper))
-		living_owner.say("#[last_whisper]")
-
-	living_owner.succumb(whispered = length(last_whisper) > 0)
-
 //ALIENS
 
 /atom/movable/screen/alert/alien_plas

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -330,14 +330,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Ghost"
 	set desc = "Relinquish your life and enter the land of the dead."
 
-	if(stat != DEAD)
-		succumb()
 	if(stat == DEAD)
 		ghostize(TRUE)
 		return TRUE
+
 	var/response = tgui_alert(usr, "Are you sure you want to ghost? If you ghost whilst still alive you cannot re-enter your body!", "Confirm Ghost Observe", list("Ghost", "Stay in Body"))
 	if(response != "Ghost")
 		return FALSE//didn't want to ghost after-all
+
 	ghostize(FALSE) // FALSE parameter is so we can never re-enter our body. U ded.
 	return TRUE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -358,18 +358,6 @@
 	log_message("points at [pointing_at]", LOG_EMOTE)
 	visible_message("<span class='infoplain'>[span_name("[src]")] points at [pointing_at].</span>", span_notice("You point at [pointing_at]."))
 
-/mob/living/verb/succumb(whispered as null)
-	set hidden = TRUE
-	if (stat == CONSCIOUS)
-		to_chat(src, text="You are unable to succumb to death! This life continues.", type=MESSAGE_TYPE_INFO)
-		return
-	log_message("Has [whispered ? "whispered his final words" : "succumbed to death"] with [round(health, 0.1)] points of health!", LOG_ATTACK)
-	adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
-	updatehealth()
-	if(!whispered)
-		to_chat(src, span_notice("You have given up life and succumbed to death."))
-	death()
-
 /**
  * Checks if a mob is incapacitated
  *


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed the ability to succumb.
add: Using the ghost verb while unconscious now prompts you if you really want to ghost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
