### PR TITLE
[C4] Implements "dir [path_dir]" and "tree [path_dir]", adds some base cases to directory parsing

### DIFF
--- a/code/modules/computer4/data/c4_file/_c4_file.dm
+++ b/code/modules/computer4/data/c4_file/_c4_file.dm
@@ -106,13 +106,8 @@
 	if(!origin)
 		origin = containing_folder
 
-	// Base cases so we don't need to do any text processing
-	if(!text || text == "." || text == "./") // Current
+	if(!text)
 		return origin
-	else if(text == "/") // Root
-		return origin.drive.root
-	else if(text == ".." || text == "../") // Parent
-		return origin.containing_folder
 
 	var/datum/c4_file/folder/destination = origin
 


### PR DESCRIPTION
## Why It's Good For The Game
Having to switch to a directory to see what's inside it is somewhat cumbersome. Letting people supply a path makes things easier.

## Changelog

:cl:
qol: [COMPUTER4] You can now do "dir [path_dir]" and "tree [path_dir]" to list a path other than cd.
/:cl: