### PR TITLE
Independent Airlocks start unbolted.

### DIFF
--- a/code/__DEFINES/rtos_defines.dm
+++ b/code/__DEFINES/rtos_defines.dm
@@ -15,6 +15,7 @@
 #define RTOS_CONFIG_ALLOW_HOLD_OPEN "allow_doorstop"
 #define RTOS_CONFIG_HOLD_OPEN_TIME "doorstop_time"
 #define RTOS_CONFIG_SLAVE_ID "tag_slave" //! Slaved pinpad ID. Mirrors the UI/stdin to a secona pad. Can be null.
+#define RTOS_CONFIG_BOLT_ON_STARTUP "bolt_on_startup"
 
 #define RTOS_CONFIG_CMODE "control_mode"
 	#define RTOS_CMODE_SECURE "secure"

--- a/code/modules/computer4/data/terminal/rtos/access_door.dm
+++ b/code/modules/computer4/data/terminal/rtos/access_door.dm
@@ -27,6 +27,8 @@
 	var/allow_lock_open
 	/// Control Mode
 	var/control_mode
+	/// If TRUE, the door will be bolted on startup
+	var/bolt_on_startup = FALSE
 
 	/// Current state machine state
 	var/tmp/current_state
@@ -65,6 +67,7 @@
 	allow_lock_open = fields[RTOS_CONFIG_ALLOW_HOLD_OPEN] //OPTIONAL
 	control_mode = fields[RTOS_CONFIG_CMODE]
 	tag_slave = fields[RTOS_CONFIG_SLAVE_ID]
+	bolt_on_startup = fields[RTOS_CONFIG_BOLT_ON_STARTUP]
 
 	// there *HAS* to be a better way than this but it's 3am
 	if(tag_target && allow_lock_open && (control_mode in list(RTOS_CMODE_BOLTS, RTOS_CMODE_SECURE)))
@@ -82,7 +85,7 @@
 	fault_string = null
 
 	COOLDOWN_START(src, door_state_timeout, (10 SECONDS))
-	control_airlock(AC_COMMAND_CLOSE)
+	control_airlock(bolt_on_startup ? AC_COMMAND_CLOSE : AC_COMMAND_UPDATE)
 	current_state = STATE_AWAIT
 	update_screen()
 

--- a/code/modules/computer4/data/terminal/rtos/pincode_door.dm
+++ b/code/modules/computer4/data/terminal/rtos/pincode_door.dm
@@ -35,6 +35,8 @@
 	var/pin_length
 	/// Control Mode
 	var/control_mode
+	/// If TRUE, the door will be bolted on startup
+	var/bolt_on_startup = FALSE
 
 	/// Current state machine state
 	var/tmp/current_state
@@ -74,6 +76,7 @@
 	correct_pin = fields[RTOS_CONFIG_PINCODE] //OPTIONAL
 	control_mode = fields[RTOS_CONFIG_CMODE]
 	tag_slave = fields[RTOS_CONFIG_SLAVE_ID]
+	bolt_on_startup = fields[RTOS_CONFIG_BOLT_ON_STARTUP]
 
 	pin_length = length(correct_pin)
 	if(correct_pin) //If we don't have a known pin, get ready to learn one.
@@ -101,7 +104,7 @@
 	fault_string = null
 
 	COOLDOWN_START(src, door_state_timeout, (10 SECONDS))
-	control_airlock(AC_COMMAND_BOLT)
+	control_airlock(bolt_on_startup ? AC_COMMAND_BOLT : AC_COMMAND_UPDATE)
 	update_screen()
 
 /datum/c4_file/terminal_program/operating_system/rtos/pincode_door/tick(delta_time)

--- a/code/modules/computer4/embedded_controller/access_door.dm
+++ b/code/modules/computer4/embedded_controller/access_door.dm
@@ -18,6 +18,8 @@
 	var/control_mode
 	/// Slaved pad ID.
 	var/tag_slave
+	/// If TRUE, the airlock will be closed on startup.
+	var/bolt_on_startup = TRUE
 
 /obj/machinery/c4_embedded_controller/airlock_access/secure
 	dwell_time = 10
@@ -41,5 +43,4 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/c4_embedded_controller/airlock_access
 	fields[RTOS_CONFIG_ALLOW_HOLD_OPEN] = allow_lock_open
 	fields[RTOS_CONFIG_CMODE] = control_mode
 	fields[RTOS_CONFIG_SLAVE_ID] = tag_slave
-
-
+	fields[RTOS_CONFIG_BOLT_ON_STARTUP] = bolt_on_startup

--- a/code/modules/computer4/embedded_controller/pincode_door.dm
+++ b/code/modules/computer4/embedded_controller/pincode_door.dm
@@ -22,6 +22,8 @@
 	var/control_mode
 	/// Slaved pad ID.
 	var/tag_slave
+	/// If TRUE, the door will be bolted on startup.
+	var/bolt_on_startup = FALSE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/c4_embedded_controller/airlock_pinpad, 24)
 
@@ -52,7 +54,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/c4_embedded_controller/airlock_pinpad
 	fields[RTOS_CONFIG_PINCODE] = final_pin
 	fields[RTOS_CONFIG_CMODE] = control_mode
 	fields[RTOS_CONFIG_SLAVE_ID] = tag_slave
-
+	fields[RTOS_CONFIG_BOLT_ON_STARTUP] = bolt_on_startup
 
 /obj/item/disk/data/floppy/ec_test/airlock_pinpad
 	name = "secure mode test"


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Independent airlocks are unbolted by default. Except the Private Investigator, he is too paranoid for that.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
