### PR TITLE
Rewrites movement speed

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -70,9 +70,6 @@
 /// The temperature the blue icon is displayed.
 #define BODYTEMP_COLD_WARNING_3 (BODYTEMP_COLD_DAMAGE_LIMIT - 150) //120k
 
-/// Humans are slowed by the difference between bodytemp and BODYTEMP_COLD_DAMAGE_LIMIT divided by this
-#define COLD_SLOWDOWN_FACTOR 17
-
 
 //CLOTHES
 

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -92,7 +92,7 @@
 //slowdown when in softcrit. Note that crawling slowdown will also apply at the same time!
 #define SOFTCRIT_MOVESPEED -1
 //slowdown when crawling
-#define CRAWLING_MOVESPEED -1.5
+#define CRAWLING_MOVESPEED_MULTIPLIER 0.4
 
 //Attack types for checking block reactions
 /// Attack was made with a melee weapon

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -90,9 +90,9 @@
 #define BASE_GRAB_RESIST_CHANCE 60 //base chance for whether or not you can escape from a grab
 
 //slowdown when in softcrit. Note that crawling slowdown will also apply at the same time!
-#define SOFTCRIT_ADD_SLOWDOWN 3
+#define SOFTCRIT_MOVESPEED -1
 //slowdown when crawling
-#define CRAWLING_ADD_SLOWDOWN 8
+#define CRAWLING_MOVESPEED -1.5
 
 //Attack types for checking block reactions
 /// Attack was made with a melee weapon
@@ -133,9 +133,10 @@
 #define SHOVE_KNOCKDOWN_TABLE 20
 #define SHOVE_KNOCKDOWN_COLLATERAL 1
 #define SHOVE_CHAIN_PARALYZE 30
+
 //Shove slowdown
 #define SHOVE_SLOWDOWN_LENGTH 30
-#define SHOVE_SLOWDOWN_STRENGTH 0.85 //multiplier
+#define SHOVE_SLOWDOWN_MOVESPEED -0.4 //multiplier
 //Shove disarming item list
 GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 	/obj/item/gun)))

--- a/code/__DEFINES/materials.dm
+++ b/code/__DEFINES/materials.dm
@@ -63,8 +63,8 @@
 
 
 
-// Slowdown values.
-/// The slowdown value of one [MINERAL_MATERIAL_AMOUNT] of plasteel.
-#define MATERIAL_SLOWDOWN_PLASTEEL (0.05)
-/// The slowdown value of one [MINERAL_MATERIAL_AMOUNT] of alien alloy.
-#define MATERIAL_SLOWDOWN_ALIEN_ALLOY (0.1)
+// Movespeed values values.
+/// The movespeed value of one [MINERAL_MATERIAL_AMOUNT] of plasteel.
+#define MATERIAL_MOVESPEED_PLASTEEL (-0.03)
+/// The movespeed value of one [MINERAL_MATERIAL_AMOUNT] of alien alloy.
+#define MATERIAL_MOVESPEED_ALIEN_ALLOY (-0.06)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -542,7 +542,7 @@
 #define GRAB_PIXEL_SHIFT_NECK 16
 
 #define PULL_PRONE_SLOWDOWN 1.5
-#define HUMAN_CARRY_SLOWDOWN 0.35
+#define HUMAN_CARRY_MOVESPEED -0.2
 
 //Flags that control what things can spawn species (whitelist) (changesource_flagx)
 //Badmin magic mirror

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -541,7 +541,7 @@
 #define GRAB_PIXEL_SHIFT_AGGRESSIVE 12
 #define GRAB_PIXEL_SHIFT_NECK 16
 
-#define PULL_PRONE_SLOWDOWN 1.5
+#define PULL_PRONE_MOVESPEED -0.7
 #define HUMAN_CARRY_MOVESPEED -0.2
 
 //Flags that control what things can spawn species (whitelist) (changesource_flagx)

--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -7,6 +7,14 @@
 /// Compensating for time dialation
 GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 
+// Movement speed defaults, in tiles-per-second.
+#define SPRINT_SPEED 5
+#define RUN_SPEED 2.5
+#define WALK_SPEED 2
+
+/// Converts a movement speed (tiles/second) to the delay-between-moves (ds)
+#define MOVESPEED_TO_DELAY(movespeed) ((10 / movespeed))
+
 ///Broken down, here's what this does:
 /// divides the world icon_size (32) by delay divided by ticklag to get the number of pixels something should be moving each tick.
 /// The division result is given a min value of 1 to prevent obscenely slow glide sizes from being set

--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -15,6 +15,11 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 /// Converts a movement speed (tiles/second) to the delay-between-moves (ds)
 #define MOVESPEED_TO_DELAY(movespeed) ((10 / movespeed))
 
+/// Movement speed modifier of hunger at zero nutrition.
+#define HUNGER_MOVESPEED -0.7
+/// Movement speed modifier of cold at max strength
+#define COLD_MOVESPEED -2
+
 ///Broken down, here's what this does:
 /// divides the world icon_size (32) by delay divided by ticklag to get the number of pixels something should be moving each tick.
 /// The division result is given a min value of 1 to prevent obscenely slow glide sizes from being set

--- a/code/__DEFINES/pain.dm
+++ b/code/__DEFINES/pain.dm
@@ -20,7 +20,7 @@
 
 /// The amount of pain where movement slowdown beings
 #define PAIN_AMT_BEGIN_SLOWDOWN (PAIN_AMT_PASSOUT * 0.075)
-#define PAIN_MAX_SLOWDOWN 3
+#define PAIN_MAX_SLOWDOWN -1
 
 #define PAIN_AMT_LOW (PAIN_AMT_PASSOUT * 0.05)
 #define PAIN_AMT_MEDIUM (PAIN_AMT_PASSOUT * 0.35)

--- a/code/__DEFINES/stamina.dm
+++ b/code/__DEFINES/stamina.dm
@@ -21,7 +21,7 @@
 /// Carbons will recover from Exhaustion above this point
 #define STAMINA_EXHAUSTION_RECOVERY_THRESHOLD_MODIFIER (0.7) //70% or more
 ///The slowdown when a mob is exhausted
-#define STAMINA_EXHAUSTION_MOVESPEED_SLOWDOWN 3
+#define STAMINA_EXHAUSTION_MOVESPEED -1
 ///Carbons will be exposed to stamina stuns upon dropping below this percentage
 #define STAMINA_STUN_THRESHOLD_MODIFIER (0.2) //20% or less
 

--- a/code/__DEFINES/stamina.dm
+++ b/code/__DEFINES/stamina.dm
@@ -21,7 +21,7 @@
 /// Carbons will recover from Exhaustion above this point
 #define STAMINA_EXHAUSTION_RECOVERY_THRESHOLD_MODIFIER (0.7) //70% or more
 ///The slowdown when a mob is exhausted
-#define STAMINA_EXHAUSTION_MOVESPEED -1
+#define STAMINA_EXHAUSTION_MOVESPEED_MULTIPLIER 0.6
 ///Carbons will be exposed to stamina stuns upon dropping below this percentage
 #define STAMINA_STUN_THRESHOLD_MODIFIER (0.2) //20% or less
 

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -77,21 +77,23 @@ GLOBAL_LIST_INIT(construct_radial_images, list(
 
 /proc/update_config_movespeed_type_lookup(update_mobs = TRUE)
 	var/list/mob_types = list()
-	var/list/entry_value = CONFIG_GET(keyed_list/multiplicative_movespeed)
+	var/list/entry_value = CONFIG_GET(keyed_list/default_movespeeds)
+
 	for(var/path in entry_value)
 		var/value = entry_value[path]
 		if(!value)
 			continue
 		for(var/subpath in typesof(path))
 			mob_types[subpath] = value
+
 	GLOB.mob_config_movespeed_type_lookup = mob_types
+
 	if(update_mobs)
 		update_mob_config_movespeeds()
 
 /proc/update_mob_config_movespeeds()
-	for(var/i in GLOB.mob_list)
-		var/mob/M = i
-		M.update_config_movespeed()
+	for(var/mob/M as anything in GLOB.mob_list)
+		M.apply_initial_movespeed()
 
 /proc/init_emote_list()
 	. = list()

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -164,40 +164,25 @@
 
 /datum/config_entry/flag/emojis
 
-#warn delete
-/datum/config_entry/keyed_list/multiplicative_movespeed
+/datum/config_entry/keyed_list/default_movespeeds
 	key_mode = KEY_MODE_TYPE
 	value_mode = VALUE_MODE_NUM
 	default = list( //DEFAULTS
-	/mob/living/simple_animal = 1,
-	/mob/living/silicon/pai = 1,
-	/mob/living/carbon/alien/humanoid/hunter = -1,
-	/mob/living/carbon/alien/humanoid/royal/praetorian = 1,
-	/mob/living/carbon/alien/humanoid/royal/queen = 3
+		/mob/living/silicon/pai = -0.5,
+		/mob/living/carbon/alien/humanoid/hunter = 0.8,
+		/mob/living/carbon/alien/humanoid/royal/praetorian = -0.5,
+		/mob/living/carbon/alien/humanoid/royal/queen = -1,
 	)
 
-/datum/config_entry/keyed_list/multiplicative_movespeed/ValidateAndSet()
+/datum/config_entry/keyed_list/default_movespeeds/ValidateAndSet()
 	. = ..()
 	if(.)
 		update_config_movespeed_type_lookup(TRUE)
 
-/datum/config_entry/keyed_list/multiplicative_movespeed/vv_edit_var(var_name, var_value)
+/datum/config_entry/keyed_list/default_movespeeds/vv_edit_var(var_name, var_value)
 	. = ..()
 	if(. && (var_name == NAMEOF(src, config_entry_value)))
 		update_config_movespeed_type_lookup(TRUE)
-
-/datum/config_entry/number/movedelay //Used for modifying movement speed for mobs.
-	abstract_type = /datum/config_entry/number/movedelay
-
-/datum/config_entry/number/movedelay/ValidateAndSet()
-	. = ..()
-	if(.)
-		update_mob_config_movespeeds()
-
-/datum/config_entry/number/movedelay/vv_edit_var(var_name, var_value)
-	. = ..()
-	if(. && (var_name == NAMEOF(src, config_entry_value)))
-		update_mob_config_movespeeds()
 
 /datum/config_entry/flag/roundstart_away //Will random away mission be loaded.
 

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -164,6 +164,7 @@
 
 /datum/config_entry/flag/emojis
 
+#warn delete
 /datum/config_entry/keyed_list/multiplicative_movespeed
 	key_mode = KEY_MODE_TYPE
 	value_mode = VALUE_MODE_NUM
@@ -197,52 +198,6 @@
 	. = ..()
 	if(. && (var_name == NAMEOF(src, config_entry_value)))
 		update_mob_config_movespeeds()
-
-/datum/config_entry/number/movedelay/run_delay
-	integer = FALSE
-
-/datum/config_entry/number/movedelay/run_delay/ValidateAndSet()
-	. = ..()
-	var/datum/movespeed_modifier/config_walk_run/M = get_cached_movespeed_modifier(/datum/movespeed_modifier/config_walk_run/run)
-	M.sync()
-
-/datum/config_entry/number/movedelay/walk_delay
-	integer = FALSE
-
-/datum/config_entry/number/movedelay/walk_delay/ValidateAndSet()
-	. = ..()
-	var/datum/movespeed_modifier/config_walk_run/M = get_cached_movespeed_modifier(/datum/movespeed_modifier/config_walk_run/walk)
-	M.sync()
-
-/datum/config_entry/number/movedelay/sprint_delay
-	integer = FALSE
-
-/datum/config_entry/number/movedelay/sprint_delay/ValidateAndSet()
-	. = ..()
-	var/datum/movespeed_modifier/config_walk_run/M = get_cached_movespeed_modifier(/datum/movespeed_modifier/config_walk_run/sprint)
-	M.sync()
-
-/////////////////////////////////////////////////Outdated move delay
-/datum/config_entry/number/outdated_movedelay
-	deprecated_by = /datum/config_entry/keyed_list/multiplicative_movespeed
-	abstract_type = /datum/config_entry/number/outdated_movedelay
-	integer = FALSE
-	var/movedelay_type
-
-/datum/config_entry/number/outdated_movedelay/DeprecationUpdate(value)
-	return "[movedelay_type] [value]"
-
-/datum/config_entry/number/outdated_movedelay/human_delay
-	movedelay_type = /mob/living/carbon/human
-/datum/config_entry/number/outdated_movedelay/robot_delay
-	movedelay_type = /mob/living/silicon/robot
-/datum/config_entry/number/outdated_movedelay/alien_delay
-	movedelay_type = /mob/living/carbon/alien
-/datum/config_entry/number/outdated_movedelay/slime_delay
-	movedelay_type = /mob/living/simple_animal/slime
-/datum/config_entry/number/outdated_movedelay/animal_delay
-	movedelay_type = /mob/living/simple_animal
-/////////////////////////////////////////////////
 
 /datum/config_entry/flag/roundstart_away //Will random away mission be loaded.
 

--- a/code/datums/components/riding/riding.dm
+++ b/code/datums/components/riding/riding.dm
@@ -53,7 +53,7 @@
 	ride_check_flags |= buckle_mob_flags
 
 	if(potion_boost)
-		vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 0.85, 0.01)
+		vehicle_move_delay = round(MOVESPEED_TO_DELAY(RUN_SPEED) * 0.85, 0.01)
 
 
 /datum/component/riding/RegisterWithParent()

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -237,7 +237,7 @@
 // special messaging for those without arms
 /datum/component/riding/vehicle/wheelchair/hand/driver_move(obj/vehicle/vehicle_parent, mob/living/user, direction)
 	var/delay_multiplier = 6.7 // magic number from wheelchair code
-	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * delay_multiplier) / clamp(user.usable_hands, 1, 2)
+	vehicle_move_delay = round(MOVESPEED_TO_DELAY(RUN_SPEED) * delay_multiplier) / clamp(user.usable_hands, 1, 2)
 	return ..()
 
 /datum/component/riding/vehicle/wheelchair/motorized/driver_move(obj/vehicle/vehicle_parent, mob/living/user, direction)
@@ -247,7 +247,7 @@
 	var/obj/vehicle/ridden/wheelchair/motorized/our_chair = parent
 	for(var/obj/item/stock_parts/manipulator/M in our_chair.contents)
 		speed += M.rating
-	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * delay_multiplier) / speed
+	vehicle_move_delay = round(MOVESPEED_TO_DELAY(RUN_SPEED) * delay_multiplier) / speed
 	return ..()
 
 /datum/component/riding/vehicle/wheelchair/motorized/handle_ride(mob/user, direction)

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -117,7 +117,7 @@
 	if(ridable_atom.has_buckled_mobs()) // effect won't take place til the next time someone mounts it, so just prevent that situation
 		to_chat(user, span_warning("It's too dangerous to smear [speed_potion] on [ridable_atom] while it's being ridden!"))
 		return
-	var/speed_limit = round(CONFIG_GET(number/movedelay/run_delay) * 0.85, 0.01)
+	var/speed_limit = round(MOVESPEED_TO_DELAY(RUN_SPEED) * 0.85, 0.01)
 	var/datum/component/riding/theoretical_riding_component = riding_component_type
 	var/theoretical_speed = initial(theoretical_riding_component.vehicle_move_delay)
 	if(theoretical_speed <= speed_limit) // i say speed but this is actually move delay, so you have to be ABOVE the speed limit to pass

--- a/code/datums/materials/alloys.dm
+++ b/code/datums/materials/alloys.dm
@@ -53,7 +53,7 @@
 	if(!istype(target_item))
 		return
 
-	target_item.slowdown += MATERIAL_SLOWDOWN_PLASTEEL * amount / MINERAL_MATERIAL_AMOUNT
+	target_item.worn_movespeed_modifier += MATERIAL_MOVESPEED_PLASTEEL * amount / MINERAL_MATERIAL_AMOUNT
 
 /datum/material/alloy/plasteel/on_removed_obj(obj/item/target_item, amount, material_flags)
 	. = ..()
@@ -61,7 +61,7 @@
 	if(!istype(target_item))
 		return
 
-	target_item.slowdown -= MATERIAL_SLOWDOWN_PLASTEEL * amount / MINERAL_MATERIAL_AMOUNT
+	target_item.worn_movespeed_modifier -= MATERIAL_MOVESPEED_PLASTEEL * amount / MINERAL_MATERIAL_AMOUNT
 
 /** Plastitanium
  *
@@ -170,7 +170,7 @@
 	if(!istype(target_item))
 		return
 
-	target_item.slowdown += MATERIAL_SLOWDOWN_ALIEN_ALLOY * amount / MINERAL_MATERIAL_AMOUNT
+	target_item.worn_movespeed_modifier += MATERIAL_MOVESPEED_ALIEN_ALLOY * amount / MINERAL_MATERIAL_AMOUNT
 
 /datum/material/alloy/alien/on_removed_obj(obj/item/target_item, amount, material_flags)
 	. = ..()
@@ -179,4 +179,4 @@
 	if(!istype(target_item))
 		return
 
-	target_item.slowdown -= MATERIAL_SLOWDOWN_ALIEN_ALLOY * amount / MINERAL_MATERIAL_AMOUNT
+	target_item.worn_movespeed_modifier -= MATERIAL_MOVESPEED_ALIEN_ALLOY * amount / MINERAL_MATERIAL_AMOUNT

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -508,7 +508,7 @@
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/status_speed_boost, update = TRUE)
 
 /datum/movespeed_modifier/status_speed_boost
-	slowdown = -1
+	modifier = 0.8
 
 ///this buff provides a max health buff and a heal.
 /datum/status_effect/limited_buff/health_buff

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -1237,7 +1237,7 @@
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/freezing_blast, update = TRUE)
 
 /datum/movespeed_modifier/freezing_blast
-	slowdown = 1
+	modifier = -0.5
 
 /datum/status_effect/discoordinated
 	id = "discoordinated"

--- a/code/datums/wires/mulebot.dm
+++ b/code/datums/wires/mulebot.dm
@@ -1,6 +1,6 @@
-#define FAST_MOTOR_SPEED 1
-#define AVERAGE_MOTOR_SPEED 2
-#define SLOW_MOTOR_SPEED 3
+#define FAST_MOTOR_SPEED -0.5
+#define AVERAGE_MOTOR_SPEED -0.8
+#define SLOW_MOTOR_SPEED -1
 
 /datum/wires/mulebot
 	holder_type = /mob/living/simple_animal/bot/mulebot
@@ -33,11 +33,11 @@
 				REMOVE_TRAIT(mule, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
 
 			if(is_cut(WIRE_MOTOR1))
-				mule.set_simple_move_delay(FAST_MOTOR_SPEED)
+				mule.set_simple_movespeed_modifier(FAST_MOTOR_SPEED)
 			else if(is_cut(WIRE_MOTOR2))
-				mule.set_simple_move_delay(AVERAGE_MOTOR_SPEED)
+				mule.set_simple_movespeed_modifier(AVERAGE_MOTOR_SPEED)
 			else
-				mule.set_simple_move_delay(SLOW_MOTOR_SPEED)
+				mule.set_simple_movespeed_modifier(SLOW_MOTOR_SPEED)
 
 /datum/wires/mulebot/on_pulse(wire)
 	var/mob/living/simple_animal/bot/mulebot/mule = holder

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -292,7 +292,7 @@ GLOBAL_LIST_INIT(dye_registry, list(
 /obj/item/clothing/shoes/sneakers/machine_wash(obj/machinery/washing_machine/washer)
 	if(chained)
 		chained = FALSE
-		slowdown = initial(slowdown)
+		worn_movespeed_modifier = initial(worn_movespeed_modifier)
 		new /obj/item/restraints/handcuffs(loc)
 	..()
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -158,7 +158,7 @@
 	buckled_mob.set_buckled(null)
 	buckled_mob.set_anchored(initial(buckled_mob.anchored))
 	buckled_mob.clear_alert(ALERT_BUCKLED)
-	buckled_mob.set_glide_size(DELAY_TO_GLIDE_SIZE(buckled_mob.total_slowdown()))
+	buckled_mob.set_glide_size(DELAY_TO_GLIDE_SIZE(buckled_mob.movement_delay))
 	buckled_mobs -= buckled_mob
 
 	if(anchored)
@@ -224,7 +224,7 @@
 	// No bucking you to yourself.
 	if(target == src)
 		return FALSE
-		
+
 	var/turf/ground = get_turf(src)
 	// If we're not already on the same turf as our target...
 	if(get_turf(target) != ground)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -169,8 +169,8 @@ DEFINE_INTERACTABLE(/obj/item)
 	var/permeability_coefficient = 1
 	/// for electrical admittance/conductance (electrocution checks and shit)
 	var/siemens_coefficient = 1
-	/// How much clothing is slowing you down. Negative values speeds you up
-	var/slowdown = 0
+	/// A movespeed modifier applied to the wearer (tiles/second). Does not apply in pockets, and only applies if held if it has the item flag SLOWS_WHILE_IN_HAND
+	var/worn_movespeed_modifier = 0
 	///percentage of armour effectiveness to remove
 	var/armor_penetration = 0
 	/// A multiplier applied to the target's armor. "2" means that their armor is twice as effective against this item.
@@ -861,7 +861,7 @@ DEFINE_INTERACTABLE(/obj/item)
 		playsound(src, drop_sound, DROP_SOUND_VOLUME, ignore_walls = FALSE)
 
 	if(!QDELETED(user))
-		if(slowdown)
+		if(worn_movespeed_modifier)
 			user.update_equipment_speed_mods()
 		user.update_mouse_pointer()
 
@@ -925,7 +925,7 @@ DEFINE_INTERACTABLE(/obj/item)
 		else if(slot == ITEM_SLOT_HANDS)
 			playsound(src, pickup_sound, PICKUP_SOUND_VOLUME, ignore_walls = FALSE)
 
-	if(slowdown)
+	if(worn_movespeed_modifier)
 		user.update_equipment_speed_mods()
 	visual_equipped(user, slot, initial)
 

--- a/code/game/objects/items/food/deepfried.dm
+++ b/code/game/objects/items/food/deepfried.dm
@@ -32,7 +32,7 @@
 	inhand_icon_state = fried.inhand_icon_state
 	desc = fried.desc
 	set_weight_class(fried.w_class)
-	slowdown = fried.slowdown
+	worn_movespeed_modifier = fried.worn_movespeed_modifier
 	equip_self_flags = fried.equip_self_flags
 	equip_delay_self = fried.equip_delay_self
 	equip_delay_other = fried.equip_delay_other

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -307,7 +307,7 @@ TYPEINFO_DEF(/obj/item/restraints/handcuffs/cable/zipties)
 	flags_1 = CONDUCT_1
 	throwforce = 0
 	w_class = WEIGHT_CLASS_NORMAL
-	slowdown = 7
+	worn_movespeed_modifier = -1.6
 	breakouttime = 30 SECONDS
 
 /**
@@ -523,7 +523,7 @@ TYPEINFO_DEF(/obj/item/restraints/handcuffs/cable/zipties)
 	icon_state = "gonbola"
 	inhand_icon_state = "bola_r"
 	breakouttime = 30 SECONDS
-	slowdown = 0
+	worn_movespeed_modifier = 0
 	var/datum/status_effect/gonbola_pacify/effectReference
 
 /obj/item/restraints/legcuffs/bola/gonbola/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -19,7 +19,7 @@ TYPEINFO_DEF(/obj/item/clothing/head/helmet/chaplain/clock)
 	icon_state = "clockwork_cuirass"
 	inhand_icon_state = "clockwork_cuirass_inhand"
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/cup/glass/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen)
-	slowdown = 0
+	worn_movespeed_modifier = 0
 	clothing_flags = NONE
 
 TYPEINFO_DEF(/obj/item/clothing/head/helmet/chaplain)
@@ -41,7 +41,7 @@ TYPEINFO_DEF(/obj/item/clothing/head/helmet/chaplain)
 	icon_state = "knight_templar"
 	inhand_icon_state = "knight_templar"
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/cup/glass/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen)
-	slowdown = 0
+	worn_movespeed_modifier = 0
 	clothing_flags = NONE
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION | CLOTHING_VOX_VARIATION
 
@@ -648,7 +648,7 @@ TYPEINFO_DEF(/obj/item/clothing/head/helmet/chaplain)
 	. = ..()
 
 /obj/item/nullrod/tribal_knife/process()
-	slowdown = rand(-10, 10)/10
+	worn_movespeed_modifier = rand(-0.4, 0.4)
 	if(iscarbon(loc))
 		var/mob/living/carbon/wielder = loc
 		if(wielder.is_holding(src))

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -276,7 +276,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/armor/plate/crusader)
 	desc = "Armour that's comprised of metal and cloth."
 	icon_state = "crusader"
 	w_class = WEIGHT_CLASS_BULKY
-	slowdown = 2.0 //gotta pretend we're balanced.
+	worn_movespeed_modifier = -0.8 //gotta pretend we're balanced.
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 
 /obj/item/clothing/suit/armor/plate/crusader/red

--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -143,7 +143,7 @@
 			var/obj/item/delivery/big/P = new(get_turf(O.loc))
 			P.base_icon_state = O.delivery_icon
 			P.update_icon()
-			P.drag_slowdown = O.drag_slowdown
+			P.drag_movespeed_modifier = O.drag_movespeed_modifier
 			O.forceMove(P)
 			P.add_fingerprint(user)
 			O.add_fingerprint(user)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -404,7 +404,7 @@ TYPEINFO_DEF(/obj/item/storage/backpack/holding)
 	desc = "A large duffel bag for holding extra things."
 	icon_state = "duffel"
 	inhand_icon_state = "duffel"
-	slowdown = 1
+	worn_movespeed_modifier = -0.5
 
 /obj/item/storage/backpack/duffelbag/Initialize()
 	. = ..()
@@ -415,7 +415,7 @@ TYPEINFO_DEF(/obj/item/storage/backpack/holding)
 	desc = "A cursed clown duffel bag that hungers for food of any kind.\n A warning label suggests that it eats food inside. If that food happens to be a horribly ruined, burned mess the chef scrapped out of the microwave, then it might have negative effects on the bag..."
 	icon_state = "duffel-curse"
 	inhand_icon_state = "duffel-curse"
-	slowdown = 2
+	worn_movespeed_modifier = -0.8
 	item_flags = DROPDEL
 	max_integrity = 100
 	///counts time passed since it ate food
@@ -569,7 +569,7 @@ TYPEINFO_DEF(/obj/item/storage/backpack/holding)
 	desc = "A large duffel bag for holding extra tactical supplies."
 	icon_state = "duffel-syndie"
 	inhand_icon_state = "duffel-syndieammo"
-	slowdown = 0
+	worn_movespeed_modifier = 0
 	resistance_flags = FIRE_PROOF
 	supports_variations_flags = NONE
 
@@ -727,7 +727,7 @@ TYPEINFO_DEF(/obj/item/storage/backpack/holding)
 // For ClownOps.
 /obj/item/storage/backpack/duffelbag/clown/syndie/Initialize()
 	. = ..()
-	slowdown = 0
+	worn_movespeed_modifier = 0
 	atom_storage.silent = TRUE
 
 /obj/item/storage/backpack/duffelbag/clown/syndie/PopulateContents()
@@ -748,6 +748,6 @@ TYPEINFO_DEF(/obj/item/storage/backpack/holding)
 /obj/item/storage/backpack/duffelbag/cops
 	name = "police bag"
 	desc = "A large duffel bag for holding extra police gear."
-	slowdown = 0
+	worn_movespeed_modifier = 0
 	supports_variations_flags = NONE
 

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -12,7 +12,7 @@ TYPEINFO_DEF(/obj/item/watertank)
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
-	slowdown = 1
+	worn_movespeed_modifier = -0.5
 	actions_types = list(/datum/action/item_action/toggle_mister)
 	max_integrity = 200
 	resistance_flags = FIRE_PROOF
@@ -211,7 +211,7 @@ TYPEINFO_DEF(/obj/item/watertank)
 	icon_state = "waterbackpackatmos"
 	worn_icon_state = "waterbackpackatmos"
 	volume = 200
-	slowdown = 0
+	worn_movespeed_modifier = 0
 
 /obj/item/watertank/atmos/Initialize(mapload)
 	. = ..()
@@ -392,7 +392,7 @@ TYPEINFO_DEF(/obj/item/watertank)
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
-	slowdown = 1
+	worn_movespeed_modifier = -0.5
 	actions_types = list(/datum/action/item_action/activate_injector)
 
 	var/on = FALSE

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -22,7 +22,8 @@
 
 	var/renamedByPlayer = FALSE //set when a player uses a pen on a renamable object
 
-	var/drag_slowdown // Amont of multiplicative slowdown applied if pulled. >1 makes you slower, <1 makes you faster.
+	/// If the object is pulled, apply a movespeed modifier (tiles/second) to the puller
+	var/drag_movespeed_modifier
 
 	vis_flags = VIS_INHERIT_PLANE //when this be added to vis_contents of something it inherit something.plane, important for visualisation of obj in openspace.
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -10,7 +10,7 @@ TYPEINFO_DEF(/obj/structure/closet)
 	icon = 'icons/obj/closet.dmi'
 	icon_state = "generic"
 	density = TRUE
-	drag_slowdown = 1.5 // Same as a prone mob
+	drag_movespeed_modifier = PULL_PRONE_MOVESPEED
 	max_integrity = 200
 	integrity_failure = 0.25
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -16,7 +16,7 @@
 	anchorable = FALSE
 	cutting_tool = null // Bodybags are not deconstructed by cutting
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
-	drag_slowdown = 0
+	drag_movespeed_modifier = 0
 	has_closed_overlay = FALSE
 	var/foldedbag_path = /obj/item/bodybag
 	var/obj/item/bodybag/foldedbag_instance = null
@@ -79,13 +79,13 @@
 /obj/structure/closet/body_bag/take_contents(mapload)
 	. = ..()
 	if(locate(/mob) in contents)
-		drag_slowdown = PULL_PRONE_SLOWDOWN
+		drag_movespeed_modifier = PULL_PRONE_MOVESPEED
 	else
-		drag_slowdown = initial(drag_slowdown)
+		drag_movespeed_modifier = initial(drag_movespeed_modifier)
 
 /obj/structure/closet/body_bag/dump_contents()
 	. = ..()
-	drag_slowdown = initial(drag_slowdown)
+	drag_movespeed_modifier = initial(drag_movespeed_modifier)
 
 /**
 	* Checks to see if we can fold. Return TRUE to actually perform the fold and delete.

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -30,7 +30,7 @@
 	var/oldloc = loc
 	step(src, direction)
 	if(oldloc != loc)
-		addtimer(CALLBACK(src, PROC_REF(ResetMoveDelay)), CONFIG_GET(number/movedelay/walk_delay) * move_speed_multiplier)
+		addtimer(CALLBACK(src, PROC_REF(ResetMoveDelay)), MOVESPEED_TO_DELAY(WALK_SPEED) * move_speed_multiplier)
 	else
 		move_delay = FALSE
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -14,7 +14,7 @@
 	close_sound = 'sound/machines/crate_close.ogg'
 	open_sound_volume = 35
 	close_sound_volume = 50
-	drag_slowdown = 0
+	drag_movespeed_modifier = 0
 	door_anim_time = 0 // no animation
 	pass_flags_self = PASSSTRUCTURE | LETPASSTHROW
 	var/crate_climb_time = 20

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -3,8 +3,8 @@
 	initial_gas = OPENTURF_DEFAULT_ATMOS
 	z_flags = Z_ATMOS_IN_UP|Z_ATMOS_OUT_UP
 
-	///negative for faster, positive for slower
-	var/slowdown = 0
+	/// A movement speed modifier for every mob that stands on the turf, in tiles/second
+	var/movespeed_modifier = 0
 	var/footstep = null
 	var/barefootstep = null
 	var/clawfootstep = null

--- a/code/game/turfs/open/ashplanet.dm
+++ b/code/game/turfs/open/ashplanet.dm
@@ -36,7 +36,7 @@
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_FLOOR_ASH
 	canSmoothWith = SMOOTH_GROUP_FLOOR_ASH + SMOOTH_GROUP_CLOSED_TURFS
 	layer = HIGH_TURF_LAYER
-	slowdown = 1
+	movespeed_modifier = -0.5
 
 /turf/open/misc/ashplanet/rocky
 	gender = PLURAL
@@ -58,7 +58,7 @@
 	smoothing_flags = NONE
 	icon_state = "wateryrock"
 	base_icon_state = "wateryrock"
-	slowdown = 2
+	movespeed_modifier = -0.8
 	footstep = FOOTSTEP_FLOOR
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -170,7 +170,7 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 	base_icon_state = "snow"
 	broken_state = "snow_dug"
 	temperature = 180
-	slowdown = 2
+	movespeed_modifier = -0.8
 	flags_1 = NONE
 
 	simulated = FALSE
@@ -184,7 +184,7 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 /turf/open/misc/asteroid/snow/burn_tile()
 	if(!burnt)
 		visible_message(span_danger("[src] melts away!."))
-		slowdown = 0
+		movespeed_modifier = 0
 		burnt = TRUE
 		icon_state = "snow_dug"
 		return TRUE
@@ -208,7 +208,7 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 /turf/open/misc/asteroid/snow/ice/icemoon
 	baseturfs = /turf/open/misc/asteroid/snow/ice/icemoon
 
-	slowdown = 0
+	movespeed_modifier = 0
 
 /turf/open/misc/asteroid/snow/ice/burn_tile()
 	return FALSE

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -154,7 +154,7 @@
 	bullet_bounce_sound = null
 	tiled_dirt = FALSE
 
-	slowdown = 1.5
+	movespeed_modifier = 0.7
 	bullet_sizzle = TRUE
 	footstep = FOOTSTEP_SAND
 	barefootstep = FOOTSTEP_SAND

--- a/code/game/turfs/open/floor/misc_floor.dm
+++ b/code/game/turfs/open/floor/misc_floor.dm
@@ -150,7 +150,7 @@
 	damaged_icon = 'icons/turf/floors.dmi'
 	broken_blend = BLEND_DEFAULT
 	burned_blend = BLEND_DEFAULT
-	slowdown = -0.3
+	movespeed_modifier = 0.2
 
 /turf/open/floor/noslip/setup_broken_states()
 	return list("noslip-damaged1","noslip-damaged2","noslip-damaged3")
@@ -167,14 +167,14 @@
 	floor_tile = /obj/item/stack/tile/iron/base
 
 /turf/open/floor/bluespace
-	slowdown = -1
+	movespeed_modifier = 0.8
 	icon_state = "bluespace"
 	desc = "Through a series of micro-teleports these tiles let people move at incredible speeds."
 	floor_tile = /obj/item/stack/tile/bluespace
 
 
 /turf/open/floor/sepia
-	slowdown = 2
+	movespeed_modifier = -0.8
 	icon_state = "sepia"
 	desc = "Time seems to flow very slowly around these tiles."
 	floor_tile = /obj/item/stack/tile/sepia

--- a/code/game/turfs/open/ice.dm
+++ b/code/game/turfs/open/ice.dm
@@ -7,7 +7,7 @@
 	temperature = 180
 
 	baseturfs = /turf/open/misc/ice
-	slowdown = 1
+	movespeed_modifier = -0.5
 	bullet_sizzle = TRUE
 	footstep = FOOTSTEP_FLOOR
 	barefootstep = FOOTSTEP_HARD_BAREFOOT

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -5,7 +5,7 @@
 	icon_state = "lava"
 	gender = PLURAL //"That's some lava."
 	baseturfs = /turf/open/lava //lava all the way down
-	slowdown = 2
+	movespeed_modifier = -0.8
 
 	light_outer_range = 2
 	light_power = 0.75

--- a/code/game/turfs/open/planet.dm
+++ b/code/game/turfs/open/planet.dm
@@ -19,7 +19,7 @@
 	base_icon_state = "greenerdirt"
 
 /turf/open/misc/dirt/jungle
-	slowdown = 0.5
+	movespeed_modifier = -0.27
 	initial_gas = OPENTURF_DEFAULT_ATMOS
 
 /turf/open/misc/dirt/jungle/dark
@@ -32,7 +32,7 @@
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "wasteland"
 	base_icon_state = "wasteland"
-	slowdown = 1
+	movespeed_modifier = -0.5
 	var/floor_variance = 15
 
 /turf/open/misc/dirt/jungle/wasteland/Initialize(mapload)

--- a/code/game/turfs/open/snow.dm
+++ b/code/game/turfs/open/snow.dm
@@ -6,7 +6,7 @@
 	icon_state = "snow"
 
 	temperature = 180
-	slowdown = 2
+	movespeed_modifier = -0.8
 	bullet_sizzle = TRUE
 	footstep = FOOTSTEP_SAND
 	barefootstep = FOOTSTEP_SAND
@@ -22,6 +22,6 @@
 	icon_state = "snow_dug"
 
 /turf/open/misc/snow/actually_safe
-	slowdown = 0
+	movespeed_modifier = 0
 
 	initial_gas = OPENTURF_DEFAULT_ATMOS

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -6,7 +6,7 @@
 	baseturfs = /turf/open/chasm/lavaland
 	initial_gas = OPENTURF_LOW_PRESSURE
 
-	slowdown = 1
+	movespeed_modifier = -0.5
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null //needs a splashing sound one day.
 	turf_flags = NO_RUST

--- a/code/modules/antagonists/clown_ops/clown_weapons.dm
+++ b/code/modules/antagonists/clown_ops/clown_weapons.dm
@@ -19,7 +19,7 @@ TYPEINFO_DEF(/obj/item/clothing/shoes/clown_shoes/combat)
 	name = "combat clown shoes"
 	desc = "advanced clown shoes that protect the wearer and render them nearly immune to slipping on their own peels. They also squeak at 100% capacity."
 	clothing_traits = list(TRAIT_NO_SLIP_WATER)
-	slowdown = /obj/item/clothing/shoes::slowdown
+	worn_movespeed_modifier = /obj/item/clothing/shoes::worn_movespeed_modifier
 	strip_delay = 70
 	resistance_flags = NONE
 
@@ -39,7 +39,7 @@ TYPEINFO_DEF(/obj/item/clothing/shoes/clown_shoes/banana_shoes/combat)
 /obj/item/clothing/shoes/clown_shoes/banana_shoes/combat
 	name = "mk-honk combat shoes"
 	desc = "The culmination of years of clown combat research, these shoes leave a trail of chaos in their wake. They will slowly recharge themselves over time, or can be manually charged with bananium."
-	slowdown = /obj/item/clothing/shoes::slowdown
+	worn_movespeed_modifier = /obj/item/clothing/shoes::worn_movespeed_modifier
 	strip_delay = 70
 	resistance_flags = NONE
 	always_noslip = TRUE

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -281,7 +281,7 @@ Striking a noncultist, however, will tear their flesh."}
 	sword.spinning = TRUE
 	sword.block_chance = 100
 	sword.block_angle = 180
-	sword.slowdown += 1.5
+	sword.worn_movespeed_modifier += -0.7
 	addtimer(CALLBACK(src, PROC_REF(stop_spinning)), 50)
 	holder?.update_mob_action_buttons()
 
@@ -289,7 +289,7 @@ Striking a noncultist, however, will tear their flesh."}
 	sword.spinning = FALSE
 	sword.block_chance = 50
 	sword.block_angle = 45
-	sword.slowdown -= 1.5
+	sword.worn_movespeed_modifier -= -0.7
 	sleep(sword.spin_cooldown)
 	holder?.update_mob_action_buttons()
 
@@ -493,7 +493,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/hooded/cultrobes/berserker)
 	name = "flagellant's robes"
 	desc = "Blood-soaked robes infused with dark magic; allows the user to move at inhuman speeds, but at the cost of increased damage."
 	allowed = list(/obj/item/tome, /obj/item/melee/cultblade)
-	slowdown = -0.6
+	worn_movespeed_modifier = 0.5
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/berserkerhood
 
 TYPEINFO_DEF(/obj/item/clothing/head/hooded/cult_hoodie/berserkerhood)

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -48,7 +48,7 @@
 	move_resist = MOVE_FORCE_OVERPOWERING
 	mob_size = MOB_SIZE_TINY
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	unique_name = TRUE
 	hud_type = /datum/hud/revenant
 

--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -17,7 +17,7 @@
 	icon_state = "imp"
 	icon_living = "imp"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	combat_mode = TRUE
 	stop_automated_movement = TRUE
 	status_flags = CANPUSH

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -195,7 +195,7 @@
 /turf/open/lava/plasma/mafia
 	initial_gas = OPENTURF_DEFAULT_ATMOS
 	baseturfs = /turf/open/lava/plasma/mafia
-	slowdown = 0
+	movespeed_modifier = 0
 
 //matches /turf/open/misc/asteroid/snow
 /turf/open/lava/plasma/snow_air

--- a/code/modules/capture_the_flag/ctf_equipment.dm
+++ b/code/modules/capture_the_flag/ctf_equipment.dm
@@ -220,7 +220,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/armor/vest/ctf)
 	icon_state = "light"
 	greyscale_config = /datum/greyscale_config/ctf_light
 	greyscale_config_worn = /datum/greyscale_config/ctf_light_worn
-	slowdown = -0.25
+	worn_movespeed_modifier = 0.2
 
 /obj/item/clothing/suit/armor/vest/ctf/light/setup_shielding()
 	AddComponent(/datum/component/shielded, max_charges = 30, recharge_start_delay = 20 SECONDS, charge_increment_delay = 1 SECONDS, charge_recovery = 30, lose_multiple_charges = TRUE, shield_icon = team_shield_icon)

--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -15,7 +15,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
 	desc = "A banner with Nanotrasen's logo on it."
-	slowdown = 2
+	worn_movespeed_modifier = -0.8
 	throw_speed = 0
 	throw_range = 1
 	force = 200

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -17,7 +17,7 @@
 /obj/item/clothing/gloves/color/yellow/heavy
 	name = "ceramic-lined insulated gloves"
 	desc = "A cheaper make of the standard insulated gloves, using internal ceramic lining to make up for the sub-par rubber material. The extra weight makes them more bulky to use."
-	slowdown = 1
+	worn_movespeed_modifier = -0.5
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/toy/sprayoncan

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -12,7 +12,7 @@
 	supports_variations_flags = CLOTHING_VOX_VARIATION | CLOTHING_DIGITIGRADE_VARIATION
 
 	permeability_coefficient = 0.5
-	slowdown = 0
+	worn_movespeed_modifier = 0
 
 	equip_self_flags = NONE
 	equip_delay_self = EQUIP_DELAY_SHOES

--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -58,7 +58,7 @@ TYPEINFO_DEF(/obj/item/clothing/shoes/jackboots)
 	create_storage(type = /datum/storage/pockets/shoes)
 
 /obj/item/clothing/shoes/jackboots/fast
-	slowdown = -1
+	worn_movespeed_modifier = 0.8
 
 /obj/item/clothing/shoes/winterboots
 	name = "winter boots"

--- a/code/modules/clothing/shoes/clown.dm
+++ b/code/modules/clothing/shoes/clown.dm
@@ -3,7 +3,7 @@
 	name = "clown shoes"
 	icon_state = "clown"
 	inhand_icon_state = "clown_shoes"
-	slowdown = parent_type::slowdown + 1 // Slower than normal
+	worn_movespeed_modifier = parent_type::worn_movespeed_modifier - 0.5 // Slower than normal
 	var/enabled_waddle = TRUE
 	lace_time = 20 SECONDS // how the hell do these laces even work??
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION | CLOTHING_TESHARI_VARIATION | CLOTHING_VOX_VARIATION

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -13,8 +13,8 @@
 
 	/// Whether the magpulse system is active
 	var/magpulse = FALSE
-	/// Slowdown applied wwhen magpulse is active. This is added onto existing slowdown
-	var/slowdown_active = 2
+	/// Additional movespeed modifier applied when magpulse is active. This is added onto existing slowdown
+	var/movespeed_modifier_active = -0.8
 	/// A list of traits we apply when we get activated
 	var/list/active_traits = list(TRAIT_NO_SLIP_WATER, TRAIT_NO_SLIP_ICE, TRAIT_NO_SLIP_SLIDE, TRAIT_NEGATES_GRAVITY)
 
@@ -27,7 +27,7 @@
 /obj/item/clothing/shoes/magboots/proc/on_speed_potioned(datum/source)
 	SIGNAL_HANDLER
 
-	slowdown_active = 0
+	movespeed_modifier_active = 0
 	// Don't need to touch the actual slowdown here, since the speed potion does it for us
 
 /obj/item/clothing/shoes/magboots/verb/toggle()
@@ -42,10 +42,10 @@
 	magpulse = !magpulse
 	if(magpulse)
 		attach_clothing_traits(active_traits)
-		slowdown += slowdown_active
+		worn_movespeed_modifier += movespeed_modifier_active
 	else
 		detach_clothing_traits(active_traits)
-		slowdown = max(initial(slowdown), slowdown - slowdown_active) // Just in case, for speed pot shenanigans
+		worn_movespeed_modifier = max(initial(worn_movespeed_modifier), worn_movespeed_modifier - movespeed_modifier_active) // Just in case, for speed pot shenanigans
 
 	update_appearance()
 	to_chat(user, span_notice("You turn [src] [magpulse ? "on" : "off"]."))
@@ -65,7 +65,7 @@
 	name = "advanced magboots"
 	icon_state = "advmag0"
 	base_icon_state = "advmag"
-	slowdown_active = parent_type::slowdown // ZERO active slowdown
+	movespeed_modifier_active = parent_type::worn_movespeed_modifier // ZERO active slowdown
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/clothing/shoes/magboots/syndie

--- a/code/modules/clothing/shoes/sneakers.dm
+++ b/code/modules/clothing/shoes/sneakers.dm
@@ -72,7 +72,7 @@
 /obj/item/clothing/shoes/sneakers/orange/attack_self(mob/user)
 	if (chained)
 		chained = FALSE
-		slowdown = initial(slowdown)
+		worn_movespeed_modifier = initial(worn_movespeed_modifier)
 		new /obj/item/restraints/handcuffs( user.loc )
 		icon_state = initial(icon_state)
 	return
@@ -83,7 +83,7 @@
 	if (H.type == /obj/item/restraints/handcuffs && !chained)
 		qdel(H)
 		chained = TRUE
-		slowdown = 15
+		worn_movespeed_modifier = -2
 		icon_state = "sneakers_chained"
 	return
 

--- a/code/modules/clothing/shoes/wheelys.dm
+++ b/code/modules/clothing/shoes/wheelys.dm
@@ -63,7 +63,7 @@
 	greyscale_colors = null
 	greyscale_config = null
 	worn_icon_state = "rollerskates"
-	slowdown = parent_type::slowdown + 1 // Slower than normal
+	worn_movespeed_modifier = parent_type::worn_movespeed_modifier - 0.5 // Slower than normal
 	wheels = /obj/vehicle/ridden/scooter/skateboard/wheelys/rollerskates
 	custom_premium_price = PAYCHECK_EASY * 5
 	custom_price = PAYCHECK_EASY * 5
@@ -75,7 +75,7 @@
 	greyscale_colors = null
 	greyscale_config = null
 	worn_icon_state = "skishoes"
-	slowdown = parent_type::slowdown + 1 // Slower than normal
+	worn_movespeed_modifier = parent_type::worn_movespeed_modifier - 0.5 // Slower than normal
 	wheels = /obj/vehicle/ridden/scooter/skateboard/wheelys/skishoes
 	custom_premium_price = PAYCHECK_EASY * 1.6
 	custom_price = PAYCHECK_EASY * 1.6

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -40,7 +40,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/space)
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals)
-	slowdown = 1
+	worn_movespeed_modifier = -0.5
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT_OFF

--- a/code/modules/clothing/spacesuits/freedom.dm
+++ b/code/modules/clothing/spacesuits/freedom.dm
@@ -22,4 +22,4 @@ TYPEINFO_DEF(/obj/item/clothing/suit/space/freedom)
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = ACID_PROOF | FIRE_PROOF
-	slowdown = 0
+	worn_movespeed_modifier = 0

--- a/code/modules/clothing/spacesuits/hardsuits/_hardsuits.dm
+++ b/code/modules/clothing/spacesuits/hardsuits/_hardsuits.dm
@@ -16,7 +16,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/space/hardsuit)
 	siemens_coefficient = 0
 	actions_types = list(/datum/action/item_action/toggle_spacesuit, /datum/action/item_action/toggle_helmet)
 	supports_variations_flags = CLOTHING_TESHARI_VARIATION
-	slowdown = 1
+	worn_movespeed_modifier = -0.5
 
 	var/obj/item/clothing/head/helmet/space/hardsuit/helmet
 	var/helmettype = /obj/item/clothing/head/helmet/space/hardsuit

--- a/code/modules/clothing/spacesuits/hardsuits/medical.dm
+++ b/code/modules/clothing/spacesuits/hardsuits/medical.dm
@@ -22,4 +22,4 @@ TYPEINFO_DEF(/obj/item/clothing/suit/space/hardsuit/medical)
 	inhand_icon_state = "medical_hardsuit"
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/storage/medkit, /obj/item/healthanalyzer, /obj/item/stack/medical)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/medical
-	slowdown = 0.5
+	worn_movespeed_modifier = -0.28

--- a/code/modules/clothing/spacesuits/pirate.dm
+++ b/code/modules/clothing/spacesuits/pirate.dm
@@ -22,6 +22,6 @@ TYPEINFO_DEF(/obj/item/clothing/suit/space/pirate)
 	icon_state = "spacepirate"
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/reagent_containers/cup/glass/bottle/rum)
-	slowdown = 0
+	worn_movespeed_modifier = 0
 	strip_delay = 40
 	equip_delay_other = 20

--- a/code/modules/clothing/spacesuits/santa.dm
+++ b/code/modules/clothing/spacesuits/santa.dm
@@ -11,5 +11,5 @@
 	desc = "Festive!"
 	icon_state = "santa"
 	inhand_icon_state = "santa"
-	slowdown = 0
+	worn_movespeed_modifier = 0
 	allowed = list(/obj/item) //for stuffing exta special presents

--- a/code/modules/clothing/spacesuits/softsuit.dm
+++ b/code/modules/clothing/spacesuits/softsuit.dm
@@ -25,7 +25,7 @@
 	icon_state = "void"
 	inhand_icon_state = "void"
 	desc = "A cumbersome spacesuit older than you are."
-	slowdown = 1.2
+	worn_movespeed_modifier = -0.6
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/multitool)
 
 	//EVA suit
@@ -86,7 +86,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/space/fragile)
 	var/torn = FALSE
 	icon_state = "syndicate-orange"
 	inhand_icon_state = "syndicate-orange"
-	slowdown = 2
+	worn_movespeed_modifier = -0.8
 	strip_delay = 65
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION | CLOTHING_TESHARI_VARIATION | CLOTHING_VOX_VARIATION
 

--- a/code/modules/clothing/spacesuits/specialops.dm
+++ b/code/modules/clothing/spacesuits/specialops.dm
@@ -23,7 +23,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/space/officer)
 	icon_state = "centcom_coat"
 	inhand_icon_state = "centcom"
 	blood_overlay_type = "coat"
-	slowdown = 0
+	worn_movespeed_modifier = 0
 	flags_inv = 0
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals)

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -150,7 +150,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/space/syndicate)
 /obj/item/clothing/suit/space/syndicate/contract
 	name = "contractor space suit"
 	desc = "A specialised black and gold space suit that's quicker, and more compact than its standard Syndicate counterpart. Can be ultra-compressed into even the tightest of spaces."
-	slowdown = 1
+	worn_movespeed_modifier = -0.5
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "syndicate-contract"
 	inhand_icon_state = "syndicate-contract"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -83,7 +83,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/armor/vest/marine)
 	desc = "Older generation Type 1 armored vest. Due to degradation over time the vest is far less maneuverable to move in."
 	icon_state = "armor"
 	inhand_icon_state = "armor"
-	slowdown = 1
+	worn_movespeed_modifier = -0.5
 
 /obj/item/clothing/suit/armor/vest/blueshirt
 	name = "large armor vest"
@@ -295,7 +295,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/armor/swat)
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT_OFF
 	heat_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
-	slowdown = 0.7
+	worn_movespeed_modifier = -0.37
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 
 //All of the armor below is mostly unused
@@ -311,7 +311,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/armor/heavy)
 	w_class = WEIGHT_CLASS_BULKY
 	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	slowdown = 3
+	worn_movespeed_modifier = -1
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 
 TYPEINFO_DEF(/obj/item/clothing/suit/armor/tdome)

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -25,7 +25,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/bio_suit)
 	permeability_coefficient = 0.01
 	clothing_flags = THICKMATERIAL | FIBERLESS
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	slowdown = 0.5
+	worn_movespeed_modifier = -0.28
 	allowed = list(/obj/item/tank/internals, /obj/item/reagent_containers/dropper, /obj/item/flashlight/pen, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/cup/beaker, /obj/item/gun/syringe)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	resistance_flags = ACID_PROOF

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -296,7 +296,7 @@ TYPEINFO_DEF(/obj/item/clothing/head/hooded/carp_hood/spaceproof)
 /obj/item/clothing/suit/hooded/carp_costume/spaceproof/old
 	name = "battered carp space suit"
 	desc = "It's covered in bite marks and scratches, yet seems to be still perfectly functional."
-	slowdown = 1
+	worn_movespeed_modifier = -0.5
 
 /obj/item/clothing/suit/hooded/ian_costume //It's Ian, rub his bell- oh god what happened to his inside parts?
 	name = "corgi costume"

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -22,7 +22,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/fire)
 	permeability_coefficient = 0.5
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/extinguisher, /obj/item/crowbar)
-	slowdown = 1
+	worn_movespeed_modifier = -0.5
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -45,7 +45,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/fire)
 	desc = "An old, bulky thermal protection suit."
 	icon_state = "thermal"
 	inhand_icon_state = "ro_suit"
-	slowdown = 1.5
+	worn_movespeed_modifier = -0.7
 
 /obj/item/clothing/suit/fire/atmos
 	name = "firesuit"
@@ -89,7 +89,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/bomb_suit)
 	permeability_coefficient = 0.01
 	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	slowdown = 2
+	worn_movespeed_modifier = -0.8
 	flags_inv = HIDEJUMPSUIT
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
@@ -155,7 +155,7 @@ TYPEINFO_DEF(/obj/item/clothing/suit/radiation)
 	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/geiger_counter)
-	slowdown = 1.5
+	worn_movespeed_modifier = -0.7
 	strip_delay = 60
 	equip_delay_other = 60
 	flags_inv = HIDEJUMPSUIT

--- a/code/modules/grab/grab_datum.dm
+++ b/code/modules/grab/grab_datum.dm
@@ -33,7 +33,8 @@ GLOBAL_LIST_EMPTY(all_grabstates)
 	/// If the grab acts like cuffs and prevents action from the victim.
 	var/restrains = FALSE
 
-	var/grab_slowdown = 0
+	/// The modifier applied to the grabber, in tiles/second
+	var/grab_movespeed_modifier = 0
 
 	var/shift = 0
 

--- a/code/modules/grab/grabs/grab_aggressive.dm
+++ b/code/modules/grab/grabs/grab_aggressive.dm
@@ -2,7 +2,7 @@
 	upgrab =   /datum/grab/normal/neck
 	downgrab = /datum/grab/normal/passive
 
-	grab_slowdown = 0.7
+	grab_movespeed_modifier = -0.4
 	shift = 12
 	stop_move = TRUE
 	reverse_facing = FALSE

--- a/code/modules/grab/grabs/grab_neck.dm
+++ b/code/modules/grab/grabs/grab_neck.dm
@@ -2,7 +2,7 @@
 	upgrab = /datum/grab/normal/kill
 	downgrab = /datum/grab/normal/aggressive
 
-	grab_slowdown = 4
+	grab_movespeed_modifier = -1.25
 
 	drop_headbutt = FALSE
 	shift = -10

--- a/code/modules/grab/grabs/grab_strangle.dm
+++ b/code/modules/grab/grabs/grab_strangle.dm
@@ -1,6 +1,6 @@
 /datum/grab/normal/kill
 	downgrab = /datum/grab/normal/neck
-	grab_slowdown = 1.4
+	grab_movespeed_modifier = -0.6
 
 	shift = 0
 	stop_move = TRUE

--- a/code/modules/grab/grabs/grab_struggle.dm
+++ b/code/modules/grab/grabs/grab_struggle.dm
@@ -6,7 +6,7 @@
 	reverse_facing = FALSE
 	same_tile = FALSE
 	breakability = 3
-	grab_slowdown = 0.7
+	grab_movespeed_modifier = -0.4
 	upgrade_cooldown = 2 SECONDS
 	can_downgrade_on_resist = 0
 	icon_state = "reinforce"

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -57,7 +57,7 @@
 	icon_state = "bunnyhead"
 	inhand_icon_state = "bunnyhead"
 	desc = "Considerably more cute than 'Frank'."
-	slowdown = -0.3
+	worn_movespeed_modifier = 0.2
 	clothing_flags = THICKMATERIAL | SNUG_FIT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
@@ -66,7 +66,7 @@
 	desc = "Hop Hop Hop!"
 	icon_state = "bunnysuit"
 	inhand_icon_state = "bunnysuit"
-	slowdown = -0.3
+	worn_movespeed_modifier = 0.2
 	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -167,7 +167,7 @@
 	desc = "Looks cold."
 	icon = 'icons/turf/snow.dmi'
 	icon_state = "snow"
-	slowdown = 2
+	movespeed_modifier = -0.8
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null
 	tiled_dirt = FALSE

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -10,8 +10,8 @@
 
 	var/basic_mob_flags = NONE
 
-	///Defines how fast the basic mob can move. This is a multiplier
-	var/speed = 1
+	/// The movespeed modifier of the mob in tiles/second
+	var/movement_speed_modifier = -0.5
 
 	///how much damage this basic mob does to objects, if any.
 	var/obj_damage = 0
@@ -124,20 +124,19 @@
 
 /mob/living/basic/vv_edit_var(vname, vval)
 	. = ..()
-	if(vname == NAMEOF(src, speed))
+	if(vname == NAMEOF(src, movement_speed_modifier))
 		datum_flags |= DF_VAR_EDITED
 		set_varspeed(vval)
 
 /mob/living/basic/proc/set_varspeed(var_value)
-	speed = var_value
+	movement_speed_modifier = var_value
 	update_basic_mob_varspeed()
 
 /mob/living/basic/proc/update_basic_mob_varspeed()
-	if(speed == 0)
+	if(movement_speed_modifier == 0)
 		remove_movespeed_modifier(/datum/movespeed_modifier/simplemob_varspeed)
 
-	#warn check if this is the only speed mod they have
-	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/simplemob_varspeed, modifier = speed)
+	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/simplemob_varspeed, modifier = movement_speed_modifier)
 	SEND_SIGNAL(src, POST_BASIC_MOB_UPDATE_VARSPEED)
 
 /mob/living/basic/relaymove(mob/living/user, direction)

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -135,7 +135,9 @@
 /mob/living/basic/proc/update_basic_mob_varspeed()
 	if(speed == 0)
 		remove_movespeed_modifier(/datum/movespeed_modifier/simplemob_varspeed)
-	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/simplemob_varspeed, slowdown = speed)
+
+	#warn check if this is the only speed mod they have
+	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/simplemob_varspeed, modifier = speed)
 	SEND_SIGNAL(src, POST_BASIC_MOB_UPDATE_VARSPEED)
 
 /mob/living/basic/relaymove(mob/living/user, direction)

--- a/code/modules/mob/living/basic/farm_animals/cows.dm
+++ b/code/modules/mob/living/basic/farm_animals/cows.dm
@@ -10,7 +10,7 @@
 	gender = FEMALE
 	mob_biotypes = MOB_ORGANIC | MOB_BEAST
 	speak_emote = list("moos","moos hauntingly")
-	speed = 1.1
+	movement_speed_modifier = -0.52
 	see_in_dark = 6
 	butcher_results = list(/obj/item/food/meat/slab = 6)
 	response_help_continuous = "pets"
@@ -122,7 +122,7 @@
 	icon_dead = "moonicorn_dead"
 	icon_gib = null //otherwise does the regular cow gib animation
 	faction = list("hostile")
-	speed = 1
+	movement_speed_modifier = -0.5
 	melee_damage_lower = 25
 	melee_damage_upper = 25
 	obj_damage = 35

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -8,7 +8,7 @@
 	mob_size = MOB_SIZE_TINY
 	health = 1
 	maxHealth = 1
-	speed = 1.25
+	movement_speed_modifier = -0.6
 	gold_core_spawnable = FRIENDLY_SPAWN
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -64,18 +64,19 @@
 
 /mob/living/carbon/on_movement_type_flag_disabled(datum/source, flag, old_movement_type)
 	. = ..()
-	if(old_movement_type & (FLYING | FLOATING) && !(movement_type & (FLYING | FLOATING)))
+	if((old_movement_type & (FLYING | FLOATING)) && !(movement_type & (FLYING | FLOATING)))
 		var/limbless_slowdown = 0
 		if(usable_legs < default_num_legs)
-			limbless_slowdown += (default_num_legs - usable_legs) * 3
+			limbless_slowdown += (default_num_legs - usable_legs) * -1 // 1 tile-per-second lost per missing leg.
 			if(!usable_legs)
 				ADD_TRAIT(src, TRAIT_FLOORED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
 				if(usable_hands < default_num_hands)
-					limbless_slowdown += (default_num_hands - usable_hands) * 3
+					limbless_slowdown += (default_num_hands - usable_hands) * -1 // 1 tile-per-second lost per missing hand.
 					if(!usable_hands)
 						ADD_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
+
 		if(limbless_slowdown)
-			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/limbless, slowdown = limbless_slowdown)
+			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/limbless, modifier = limbless_slowdown)
 		else
 			remove_movespeed_modifier(/datum/movespeed_modifier/limbless)
 
@@ -83,14 +84,14 @@
 /mob/living/carbon/proc/update_move_intent_slowdown()
 	var/modifier
 	if(m_intent == MOVE_INTENT_WALK)
-		modifier = /datum/movespeed_modifier/config_walk_run/walk
+		modifier = /datum/movespeed_modifier/move_intent/walk
 	else if(m_intent == MOVE_INTENT_RUN)
-		modifier =  /datum/movespeed_modifier/config_walk_run/run
+		modifier =  /datum/movespeed_modifier/move_intent/run
 	else
-		modifier = /datum/movespeed_modifier/config_walk_run/sprint
+		modifier = /datum/movespeed_modifier/move_intent/sprint
 	add_movespeed_modifier(modifier)
 
-/mob/living/carbon/update_config_movespeed()
+/mob/living/carbon/apply_initial_movespeed()
 	update_move_intent_slowdown()
 	return ..()
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -3,7 +3,7 @@
 	if(HAS_TRAIT(src, TRAIT_IGNORESLOWDOWN))
 		for(var/id in considering)
 			var/datum/movespeed_modifier/M = considering[id]
-			if(!(M.flags & IGNORE_NOSLOW) && M.slowdown > 0)
+			if(!(M.flags & IGNORE_NOSLOW) && M.modifier < 0)
 				considering -= id
 
 	return considering

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -213,7 +213,7 @@
 	. = ..()
 	for(var/sloties in get_equipped_items(FALSE))
 		var/obj/item/thing = sloties
-		. += thing?.slowdown
+		. += thing?.worn_movespeed_modifier
 
 /mob/living/carbon/human/tryUnequipItem(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE, use_unequip_delay = FALSE, slot = get_slot_by_item(I))
 	var/index = get_held_index_of_item(I)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1300,7 +1300,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		// clear any hot moods and apply cold mood
 		// Apply cold slow down
 
-		#warn test cold
 		humi.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/cold, modifier = COLD_MOVESPEED * max(1, ((cold_level_1 - humi.bodytemperature) / cold_level_1)))
 		// Display alerts based how cold it is
 		// Can't be a switch due to http://www.byond.com/forum/post/2750423

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	)
 
 	//* MODIFIERS *//
-	///Multiplier for the race's speed. Positive numbers make it move slower, negative numbers make it move faster.
+	/// Movement speed modifier (tiles/second).
 	var/speedmod = 0
 	///Percentage modifier for overall defense of the race, or less defense, if it's negative.
 	var/armor = 0
@@ -525,7 +525,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		fly = new
 		fly.Grant(C)
 
-	C.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/species, slowdown=speedmod)
+	C.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/species, modifier = speedmod)
 
 	SEND_SIGNAL(C, COMSIG_SPECIES_GAIN, src, old_species)
 
@@ -1299,7 +1299,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	else if(bodytemp < cold_level_1 && !HAS_TRAIT(humi, TRAIT_RESISTCOLD))
 		// clear any hot moods and apply cold mood
 		// Apply cold slow down
-		humi.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/cold, slowdown = ((cold_level_1 - humi.bodytemperature) / COLD_SLOWDOWN_FACTOR))
+
+		#warn test cold
+		humi.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/cold, modifier = COLD_MOVESPEED * max(1, ((cold_level_1 - humi.bodytemperature) / cold_level_1)))
 		// Display alerts based how cold it is
 		// Can't be a switch due to http://www.byond.com/forum/post/2750423
 		if(bodytemp in cold_level_1 to cold_level_2)

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -96,7 +96,7 @@
 	examine_limb_id = SPECIES_ZOMBIE
 	mutanthands = /obj/item/zombie_hand
 	armor = 20 // 120 damage to KO a zombie, which kills it
-	speedmod = 1.6
+	speedmod = -0.7
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
 	/// The rate the zombies regenerate at
 	var/heal_rate = 0.5

--- a/code/modules/mob/living/carbon/pain.dm
+++ b/code/modules/mob/living/carbon/pain.dm
@@ -312,7 +312,7 @@
 
 	var/pain_passout = min(PAIN_AMT_PASSOUT * brain_health_factor * blood_circulation_factor, PAIN_AMT_PASSOUT)
 
-	if(pain <= max((pain_passout * 0.075), 10))
+	if(pain >= (pain_passout * 0.075))
 		var/slowdown = min(pain * (PAIN_MAX_SLOWDOWN / pain_passout), PAIN_MAX_SLOWDOWN)
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/pain, TRUE, slowdown)
 	else

--- a/code/modules/mob/living/carbon/pain.dm
+++ b/code/modules/mob/living/carbon/pain.dm
@@ -313,8 +313,8 @@
 	var/pain_passout = min(PAIN_AMT_PASSOUT * brain_health_factor * blood_circulation_factor, PAIN_AMT_PASSOUT)
 
 	if(pain >= (pain_passout * 0.075))
-		var/slowdown = min(pain * (PAIN_MAX_SLOWDOWN / pain_passout), PAIN_MAX_SLOWDOWN)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/pain, TRUE, slowdown)
+		var/modifier = PAIN_MAX_SLOWDOWN * (pain / pain_passout)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/pain, TRUE, modifier)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/pain)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -968,9 +968,9 @@
 
 /mob/living/proc/update_gravity(gravity)
 	// Handle movespeed stuff
-	var/speed_change = max(0, gravity - STANDARD_GRAVITY)
+	var/speed_change = -1 * max(0, gravity - STANDARD_GRAVITY)
 	if(speed_change)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/gravity, slowdown=speed_change)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/gravity, modifier = speed_change)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/gravity)
 
@@ -1914,10 +1914,11 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 				ADD_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
 
 	if(usable_legs < default_num_legs)
-		var/limbless_slowdown = (default_num_legs - usable_legs) * 3
+		var/limbless_movespeed = (default_num_legs - usable_legs) * -1
 		if(!usable_legs && usable_hands < default_num_hands)
-			limbless_slowdown += (default_num_hands - usable_hands) * 3
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/limbless, slowdown = limbless_slowdown)
+			limbless_movespeed += (default_num_hands - usable_hands) * -1
+
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/limbless, modifier = limbless_movespeed)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/limbless)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -968,7 +968,7 @@
 
 /mob/living/proc/update_gravity(gravity)
 	// Handle movespeed stuff
-	var/speed_change = -1 * max(0, gravity - STANDARD_GRAVITY)
+	var/speed_change = -0.5 * max(0, gravity - STANDARD_GRAVITY)
 	if(speed_change)
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/gravity, modifier = speed_change)
 	else

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -73,9 +73,10 @@
 
 /mob/living/proc/update_turf_movespeed(turf/open/T)
 	if(isopenturf(T))
-		if(T.slowdown != current_turf_slowdown)
-			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, slowdown = T.slowdown)
-			current_turf_slowdown = T.slowdown
+		if(T.movespeed_modifier != current_turf_slowdown)
+			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, modifier = T.movespeed_modifier)
+			current_turf_slowdown = T.movespeed_modifier
+
 	else if(current_turf_slowdown)
 		remove_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown)
 		current_turf_slowdown = 0
@@ -86,19 +87,23 @@
 		remove_movespeed_modifier(/datum/movespeed_modifier/grabbing)
 		return
 
-	var/slowdown_total = 0
+	var/modifier_total = 0
 	for(var/obj/item/hand_item/grab/G as anything in grabs)
 		var/atom/movable/pulling = G.affecting
 		if(isliving(pulling))
 			var/mob/living/L = pulling
-			if(G.current_grab.grab_slowdown || L.body_position == LYING_DOWN)
-				slowdown_total += max(G.current_grab.grab_slowdown, PULL_PRONE_SLOWDOWN)
+			var/is_lying = L.body_position == LYING_DOWN
+			if(G.current_grab.grab_movespeed_modifier)
+				if(is_lying)
+					modifier_total += max(G.current_grab.grab_movespeed_modifier, PULL_PRONE_MOVESPEED)
+				else
+					modifier_total += G.current_grab.grab_movespeed_modifier
 
 		if(isobj(pulling))
 			var/obj/structure/S = pulling
-			slowdown_total += S.drag_slowdown
+			modifier_total += S.drag_movespeed_modifier
 
-	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/grabbing, slowdown = slowdown_total)
+	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/grabbing, modifier = modifier_total)
 
 /mob/living/can_z_move(direction, turf/start, z_move_flags, mob/living/rider)
 	// Check physical climbing ability

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -18,7 +18,7 @@
 	animate_movement = SLIDE_STEPS
 	health = 50
 	maxHealth = 50
-	move_delay_modifier = 3
+	movement_speed_modifier = -1
 	damage_coeff = list(BRUTE = 0.5, BURN = 0.7, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	combat_mode = TRUE //No swapping
 	buckle_lying = 0

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -14,7 +14,7 @@
 	response_harm_simple = "punch"
 	speak_chance = 1
 	icon = 'icons/mob/cult.dmi'
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	combat_mode = TRUE
 	stop_automated_movement = 1
 	status_flags = CANPUSH
@@ -140,7 +140,7 @@
 	melee_damage_upper = 25
 	attack_verb_continuous = "smashes their armored gauntlet into"
 	attack_verb_simple = "smash your armored gauntlet into"
-	move_delay_modifier = 2.5
+	movement_speed_modifier = -1
 	environment_smash = ENVIRONMENT_SMASH_WALLS
 	attack_sound = 'sound/weapons/punch3.ogg'
 	status_flags = 0

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -26,7 +26,7 @@
 	minbodytemp = 0
 	maxbodytemp = 0
 	wander = 0
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	healable = 0
 	density = FALSE
 	pass_flags = PASSTABLE | PASSMOB

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -145,7 +145,7 @@
 		set_shy(FALSE)
 		mind.special_role = "hacked drone"
 		REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
-		set_simple_move_delay(1)
+		set_simple_movespeed_modifier(-0.5)
 		message_admins("[ADMIN_LOOKUPFLW(src)] became a hacked drone hellbent on destroying the station!")
 	else
 		if(!hacked)
@@ -161,7 +161,7 @@
 		set_shy(initial(shy))
 		mind.special_role = null
 		ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
-		set_simple_move_delay(initial(move_delay_modifier))
+		set_simple_movespeed_modifier(initial(movement_speed_modifier))
 		message_admins("[ADMIN_LOOKUPFLW(src)], a hacked drone, was restored to factory defaults!")
 	update_drone_icon_hacked()
 

--- a/code/modules/mob/living/simple_animal/friendly/sloth.dm
+++ b/code/modules/mob/living/simple_animal/friendly/sloth.dm
@@ -24,7 +24,7 @@
 	melee_damage_upper = 18
 	health = 50
 	maxHealth = 50
-	move_delay_modifier = 1 SECOND
+	movement_speed_modifier = -1.5
 	held_state = "sloth"
 	///In the case 'melee_damage_upper' is somehow raised above 0
 	attack_verb_continuous = "bites"

--- a/code/modules/mob/living/simple_animal/friendly/slug.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slug.dm
@@ -13,7 +13,7 @@
 	response_harm_simple = "splat"
 	maxHealth = 5
 	health = 5
-	move_delay_modifier = 1 SECOND
+	movement_speed_modifier = -1.5
 	density = FALSE
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	mob_size = MOB_SIZE_TINY

--- a/code/modules/mob/living/simple_animal/friendly/trader.dm
+++ b/code/modules/mob/living/simple_animal/friendly/trader.dm
@@ -28,7 +28,7 @@
 	move_resist = MOVE_FORCE_STRONG
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	sentience_type = SENTIENCE_HUMANOID
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	stat_attack = UNCONSCIOUS
 	robust_searching = TRUE
 	check_friendly_fire = TRUE

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	icon_state = "magicbase"
 	icon_living = "magicbase"
 	icon_dead = "magicbase"
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	combat_mode = TRUE
 	stop_automated_movement = 1
 	attack_sound = SFX_PUNCH

--- a/code/modules/mob/living/simple_animal/guardian/types/charger.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/charger.dm
@@ -5,7 +5,7 @@
 	ranged = 1 //technically
 	ranged_message = "charges"
 	ranged_cooldown_time = 40
-	move_delay_modifier = -1
+	movement_speed_modifier = 0.8
 	damage_coeff = list(BRUTE = 0.6, BURN = 0.6, TOX = 0.6, CLONE = 0.6, STAMINA = 0, OXY = 0.6)
 	playstyle_string = "<span class='holoparasite'>As a <b>charger</b> type you do medium damage, have medium damage resistance, move very fast, and can charge at a location, damaging any target hit and forcing them to drop any items they are holding.</span>"
 	magic_fluff_string = "<span class='holoparasite'>..And draw the Hunter, an alien master of rapid assault.</span>"

--- a/code/modules/mob/living/simple_animal/guardian/types/protector.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/protector.dm
@@ -39,7 +39,7 @@
 		cut_overlay(shield_overlay)
 		melee_damage_lower = initial(melee_damage_lower)
 		melee_damage_upper = initial(melee_damage_upper)
-		set_simple_move_delay(initial(move_delay_modifier))
+		set_simple_movespeed_modifier(initial(movement_speed_modifier))
 		damage_coeff = list(BRUTE = 0.4, BURN = 0.4, TOX = 0.4, CLONE = 0.4, STAMINA = 0, OXY = 0.4)
 		to_chat(src, "[span_danger("<B>You switch to combat mode.")]</B>")
 		toggle = FALSE
@@ -51,7 +51,7 @@
 		add_overlay(shield_overlay)
 		melee_damage_lower = 2
 		melee_damage_upper = 2
-		set_simple_move_delay(1)
+		set_simple_movespeed_modifier(-0.5)
 		damage_coeff = list(BRUTE = 0.05, BURN = 0.05, TOX = 0.05, CLONE = 0.05, STAMINA = 0, OXY = 0.05) //damage? what's damage?
 		to_chat(src, "[span_danger("<B>You switch to protection mode.")]</B>")
 		toggle = TRUE

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -3,7 +3,7 @@
 	combat_mode = TRUE
 	friendly_verb_continuous = "heals"
 	friendly_verb_simple = "heal"
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	damage_coeff = list(BRUTE = 0.7, BURN = 0.7, TOX = 0.7, CLONE = 0.7, STAMINA = 0, OXY = 0.7)
 	melee_damage_lower = 15
 	melee_damage_upper = 15
@@ -46,7 +46,7 @@
 	if(src.loc == summoner)
 		if(toggle)
 			set_combat_mode(TRUE)
-			set_simple_move_delay(0)
+			set_simple_movespeed_modifier(0)
 			damage_coeff = list(BRUTE = 0.7, BURN = 0.7, TOX = 0.7, CLONE = 0.7, STAMINA = 0, OXY = 0.7)
 			melee_damage_lower = 15
 			melee_damage_upper = 15
@@ -54,7 +54,7 @@
 			toggle = FALSE
 		else
 			set_combat_mode(FALSE)
-			set_simple_move_delay(1)
+			set_simple_movespeed_modifier(-0.5)
 			damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 			melee_damage_lower = 0
 			melee_damage_upper = 0

--- a/code/modules/mob/living/simple_animal/heretic_monsters.dm
+++ b/code/modules/mob/living/simple_animal/heretic_monsters.dm
@@ -14,7 +14,7 @@
 	response_harm_simple = "tears"
 	speak_emote = list("screams")
 	speak_chance = 1
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	combat_mode = TRUE
 	stop_automated_movement = TRUE
 	AIStatus = AI_OFF

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -7,7 +7,7 @@
 	icon_dead = "alienh_dead"
 	icon_gib = "syndicate_gib"
 	gender = FEMALE
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	butcher_results = list(/obj/item/food/meat/slab/xeno = 4,
 							/obj/item/stack/sheet/animalhide/xeno = 1)
 	maxHealth = 125

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -22,7 +22,7 @@
 	response_disarm_simple = "gently push aside"
 	maxHealth = 60
 	health = 60
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 
 	obj_damage = 60
 	melee_damage_lower = 15 // i know it's like half what it used to be, but bears cause bleeding like crazy now so it works out

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -20,7 +20,7 @@
 	response_disarm_simple = "gently push aside"
 	emote_taunt = list("gnashes")
 	taunt_chance = 30
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	maxHealth = 25
 	health = 25
 	search_objects = 1

--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -8,7 +8,7 @@
 	icon_gib = "syndicate_gib"
 	speak_chance = 0
 	turns_per_move = 5
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	stat_attack = UNCONSCIOUS
 	robust_searching = 1
 	maxHealth = 100

--- a/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
@@ -11,7 +11,7 @@
 	obj_damage = 10
 	melee_damage_lower = 8
 	melee_damage_upper = 12
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	gender = NEUTER
 	mob_biotypes = MOB_ORGANIC
 	response_help_continuous = "pets"

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -12,7 +12,7 @@
 	response_help_simple = "pass through"
 	emote_taunt = list("wails")
 	taunt_chance = 25
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	maxHealth = 80
 	health = 80
 	stat_attack = UNCONSCIOUS

--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -17,7 +17,7 @@
 	response_harm_simple = "kick"
 	emote_taunt = list("hisses")
 	taunt_chance = 30
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	maxHealth = 25
 	health = 25
 	harm_intent_damage = 5

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -21,7 +21,7 @@
 	response_disarm_simple = "challenge"
 	response_harm_continuous = "thumps"
 	response_harm_simple = "thump"
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	melee_damage_lower = 15
 	melee_damage_upper = 18
 	damage_coeff = list(BRUTE = 1, BURN = 1.5, TOX = 1.5, CLONE = 0, STAMINA = 0, OXY = 1.5)

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/visuals_icons.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/visuals_icons.dm
@@ -21,11 +21,11 @@
 	if(!standing)
 		if(stat != DEAD)
 			icon_state = "crawling"
-			set_simple_move_delay(1)
+			set_simple_movespeed_modifier(-0.5)
 		return ..()
 	if(stat != DEAD)
 		icon_state = "standing"
-		set_simple_move_delay(3) // Gorillas are slow when standing up.
+		set_simple_movespeed_modifier(-1) // Gorillas are slow when standing up.
 
 	var/list/hands_overlays = list()
 

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -14,7 +14,7 @@
 	attack_verb_simple = "gore"
 	maxHealth = 100
 	health = 100
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	faction = list("illusion")
 	var/life_span = INFINITY //how long until they despawn
 	var/mob/living/parent_mob
@@ -69,7 +69,7 @@
 	minimum_distance = 10
 	melee_damage_lower = 0
 	melee_damage_upper = 0
-	move_delay_modifier = -1
+	movement_speed_modifier = 0.8
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
 

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -9,7 +9,7 @@
 	response_help_simple = "touch"
 	response_disarm_continuous = "pushes"
 	response_disarm_simple = "push"
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	maxHealth = 250
 	health = 250
 	gender = NEUTER

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -17,7 +17,7 @@
 	ranged_cooldown_time = 30
 	throw_message = "does nothing against the hard shell of"
 	vision_range = 2
-	move_delay_modifier = 3
+	movement_speed_modifier = -1
 	maxHealth = 200
 	health = 200
 	harm_intent_damage = 5
@@ -86,7 +86,7 @@
 			visible_message(span_warning("[src] begins to fire up!"))
 			fully_heal()
 			icon_state = "Basilisk_alert"
-			set_simple_move_delay(0)
+			set_simple_movespeed_modifier(0)
 			warmed_up = TRUE
 			projectiletype = /obj/projectile/temp/basilisk/heated
 			addtimer(CALLBACK(src, PROC_REF(cool_down)), 3000)
@@ -95,7 +95,7 @@
 	visible_message(span_warning("[src] appears to be cooling down..."))
 	if(stat != DEAD)
 		icon_state = "Basilisk"
-	set_simple_move_delay(3)
+	set_simple_movespeed_modifier(-1)
 	warmed_up = FALSE
 	projectiletype = /obj/projectile/temp/basilisk
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
@@ -17,7 +17,7 @@
 	ranged_cooldown_time = 5 SECONDS
 	vision_range = 9
 	retreat_distance = 2
-	move_delay_modifier = 3
+	movement_speed_modifier = -1
 	move_to_delay = 5
 	maxHealth = 250
 	health = 250

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -12,7 +12,7 @@
 	ranged = 1
 	vision_range = 5
 	aggro_vision_range = 9
-	move_delay_modifier = 3
+	movement_speed_modifier = -1
 	maxHealth = 75
 	health = 75
 	harm_intent_damage = 5
@@ -71,7 +71,7 @@
 	friendly_verb_continuous = "buzzes near"
 	friendly_verb_simple = "buzz near"
 	vision_range = 10
-	move_delay_modifier = 3
+	movement_speed_modifier = -1
 	maxHealth = 1
 	health = 1
 	harm_intent_damage = 5

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
@@ -9,7 +9,7 @@
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	mouse_opacity = MOUSE_OPACITY_ICON
 	speak_emote = list("telepathically cries")
-	move_delay_modifier = 2
+	movement_speed_modifier = -0.8
 	move_to_delay = 2
 	projectiletype = /obj/projectile/temp/basilisk/ice
 	projectilesound = 'sound/weapons/pierce.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/lobstrosity.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/lobstrosity.dm
@@ -15,7 +15,7 @@
 	friendly_verb_simple = "chits at"
 	speak_emote = list("chitters")
 	ranged = TRUE
-	move_delay_modifier = 3
+	movement_speed_modifier = -1
 	move_to_delay = 20
 	maxHealth = 150
 	health = 150

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
@@ -10,7 +10,7 @@
 	friendly_verb_continuous = "growls at"
 	friendly_verb_simple = "growl at"
 	speak_emote = list("growls")
-	move_delay_modifier = 3
+	movement_speed_modifier = -1
 	move_to_delay = 8
 	maxHealth = 300
 	health = 300

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
@@ -10,7 +10,7 @@
 	friendly_verb_continuous = "howls at"
 	friendly_verb_simple = "howl at"
 	speak_emote = list("howls")
-	move_delay_modifier = 5
+	movement_speed_modifier = -1.4
 	move_to_delay = 5
 	maxHealth = 130
 	health = 130

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -29,7 +29,7 @@
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	stat_attack = DEAD
 	mouse_opacity = MOUSE_OPACITY_ICON
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	robust_searching = 1
 	unique_name = 1
 	speak_emote = list("squeaks")

--- a/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
@@ -10,7 +10,7 @@
 	sentience_type = SENTIENCE_HUMANOID
 	speak_chance = 0
 	turns_per_move = 5
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	stat_attack = UNCONSCIOUS
 	robust_searching = 1
 	maxHealth = 100

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -93,7 +93,7 @@
 	icon_dead = "mi-go-dead"
 	attack_verb_continuous = "lacerates"
 	attack_verb_simple = "lacerate"
-	move_delay_modifier = -0.5
+	movement_speed_modifier = 0.35
 	var/static/list/migo_sounds
 	deathmessage = "wails as its form turns into a pulpy mush."
 	deathsound = 'sound/voice/hiss6.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -95,7 +95,7 @@
 /mob/living/simple_animal/hostile/ooze/gelatinous
 	name = "Gelatinous Cube"
 	desc = "A cubic ooze native to Sholus VII.\nSince the advent of space travel this species has established itself in the waste treatment facilities of several space colonies.\nIt is often considered to be the third most infamous invasive species due to its highly aggressive and predatory nature."
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	damage_coeff = list(BRUTE = 1, BURN = 0.6, TOX = 0.5, CLONE = 1.5, STAMINA = 0, OXY = 1)
 	melee_damage_lower = 20
 	melee_damage_upper = 20
@@ -270,7 +270,7 @@
 	icon_state = "grapes"
 	icon_living = "grapes"
 	icon_dead = "grapes_dead"
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	health = 200
 	maxHealth = 200
 	damage_coeff = list(BRUTE = 1, BURN = 0.8, TOX = 0.5, CLONE = 1.5, STAMINA = 0, OXY = 1)

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -11,7 +11,7 @@
 	turns_per_move = 5
 	response_help_continuous = "pushes"
 	response_help_simple = "push"
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	maxHealth = 100
 	health = 100
 	harm_intent_damage = 5
@@ -53,7 +53,7 @@
 	icon_dead = "piratespace_dead"
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 
 /mob/living/simple_animal/hostile/pirate/melee/space/Initialize(mapload)
 	. = ..()
@@ -92,7 +92,7 @@
 	icon_dead = "piratespaceranged_dead"
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 
 /mob/living/simple_animal/hostile/pirate/ranged/space/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -19,7 +19,7 @@
 	combat_mode = TRUE
 	maxHealth = 75
 	health = 75
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	harm_intent_damage = 8
 	melee_damage_lower = 10
 	melee_damage_upper = 10
@@ -84,7 +84,7 @@
 	emote_see = list("honks", "bites into the banana", "plucks a banana off its head", "photosynthesizes")
 	maxHealth = 120
 	health = 120
-	move_delay_modifier = -1
+	movement_speed_modifier = 0.8
 	loot = list(/obj/item/clothing/mask/gas/clown_hat, /obj/effect/gibspawner/human, /obj/item/soap, /obj/item/seeds/banana)
 	///Our peel dropping ability
 	var/datum/action/cooldown/rustle/banana_rustle
@@ -177,7 +177,7 @@
 	icon_state = "honkling"
 	icon_living = "honkling"
 	turns_per_move = 1
-	move_delay_modifier = -10
+	movement_speed_modifier = 0.80
 	harm_intent_damage = 1
 	melee_damage_lower = 1
 	melee_damage_upper = 1
@@ -203,7 +203,7 @@
 	dextrous = TRUE
 	maxHealth = 140
 	health = 140
-	move_delay_modifier = -5
+	movement_speed_modifier = 5
 	melee_damage_upper = 15
 	attack_verb_continuous = "limply slaps"
 	attack_verb_simple = "limply slap"
@@ -234,7 +234,7 @@
 	health = 150
 	pixel_x = -16
 	base_pixel_x = -16
-	move_delay_modifier = 10
+	movement_speed_modifier = -0.50
 	harm_intent_damage = 5
 	melee_damage_lower = 5
 	attack_verb_continuous = "YA-HONKs"
@@ -261,7 +261,7 @@
 	health = 400
 	pixel_x = -16
 	base_pixel_x = -16
-	move_delay_modifier = 2
+	movement_speed_modifier = -0.8
 	harm_intent_damage = 15
 	melee_damage_lower = 15
 	melee_damage_upper = 20
@@ -287,7 +287,7 @@
 	emote_see = list("asserts his dominance", "emasculates everyone implicitly")
 	maxHealth = 500
 	health = 500
-	move_delay_modifier = -2
+	movement_speed_modifier = 2.5
 	armor_penetration = 20
 	attack_verb_continuous = "steals the girlfriend of"
 	attack_verb_simple = "steal the girlfriend of"
@@ -308,7 +308,7 @@
 	speak_chance = 1
 	maxHealth = 200
 	health = 200
-	move_delay_modifier = -5
+	movement_speed_modifier = 5
 	harm_intent_damage = 5
 	melee_damage_lower = 5
 	melee_damage_upper = 10
@@ -328,7 +328,7 @@
 	speak = list("HONK!!!", "The Honkmother is merciful, so I must act out her wrath.", "parce mihi ad beatus honkmother placet mihi ut peccata committere,", "DIE!!!")
 	maxHealth = 400
 	health = 400
-	move_delay_modifier = 5
+	movement_speed_modifier = -1.4
 	harm_intent_damage = 30
 	melee_damage_lower = 20
 	melee_damage_upper = 40
@@ -360,7 +360,7 @@
 	health = 130
 	pixel_x = -16
 	base_pixel_x = -16
-	move_delay_modifier = -5
+	movement_speed_modifier = 5
 	harm_intent_damage = 10
 	melee_damage_lower = 10
 	melee_damage_upper = 20
@@ -369,7 +369,7 @@
 	loot = list(/obj/item/clothing/mask/gas/clown_hat, /obj/effect/gibspawner/xeno/bodypartless, /obj/item/soap, /obj/effect/gibspawner/generic, /obj/effect/gibspawner/generic/animal, /obj/effect/gibspawner/human/bodypartless, /obj/effect/gibspawner/human)
 
 /mob/living/simple_animal/hostile/retaliate/clown/mutant/slow
-	move_delay_modifier = 20
+	movement_speed_modifier = -2
 	move_to_delay = 60
 
 /mob/living/simple_animal/hostile/retaliate/clown/mutant/glutton
@@ -381,7 +381,7 @@
 	emote_see = list("jiggles", "wobbles")
 	health = 200
 	mob_size = MOB_SIZE_LARGE
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 2, STAMINA = 0, OXY = 1)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/ghost.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/ghost.dm
@@ -11,7 +11,7 @@
 	response_help_simple = "pass through"
 	combat_mode = TRUE
 	healable = 0
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	maxHealth = 40
 	health = 40
 	harm_intent_damage = 10

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/hog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/hog.dm
@@ -5,7 +5,7 @@
 	icon_living = "hog"
 	icon_dead = "hog_dead"
 	icon_gib = "brownbear_gib"
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	maxHealth = 80
 	health = 80
 	harm_intent_damage = 5

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/spaceman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/spaceman.dm
@@ -16,7 +16,7 @@
 	combat_mode = TRUE
 	maxHealth = 100
 	health = 100
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	harm_intent_damage = 8
 	melee_damage_lower = 10
 	melee_damage_upper = 10
@@ -37,7 +37,7 @@
 	icon_dead = null
 	icon_gib = "syndicate_gib"
 	turns_per_move = 5
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	stat_attack = UNCONSCIOUS
 	robust_searching = 1
 	vision_range = 3

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -10,7 +10,7 @@
 	sentience_type = SENTIENCE_HUMANOID
 	speak_chance = 0
 	turns_per_move = 5
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	maxHealth = 100
 	health = 100
 	harm_intent_damage = 5

--- a/code/modules/mob/living/simple_animal/hostile/skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/skeleton.dm
@@ -13,7 +13,7 @@
 	combat_mode = TRUE
 	maxHealth = 40
 	health = 40
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	harm_intent_damage = 5
 	melee_damage_lower = 15
 	melee_damage_upper = 15
@@ -64,7 +64,7 @@
 	maxHealth = 150
 	health = 150
 	weather_immunities = list(TRAIT_SNOWSTORM_IMMUNE)
-	move_delay_modifier = 2
+	movement_speed_modifier = -0.8
 	speak_chance = 1
 	speak = list("THE GODS WILL IT!","DEUS VULT!","REMOVE KABAB!")
 	damage_coeff = list(BRUTE = 0.5, BURN = 0.5, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0) //trying to simulate actually having armor
@@ -80,7 +80,7 @@
 /mob/living/simple_animal/hostile/skeleton/ice
 	name = "ice skeleton"
 	desc = "A reanimated skeleton protected by a thick sheet of natural ice armor. Looks slow, though."
-	move_delay_modifier = 5
+	movement_speed_modifier = -1.4
 	maxHealth = 75
 	health = 75
 	weather_immunities = list(TRAIT_SNOWSTORM_IMMUNE)

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -34,7 +34,7 @@
 	health = 320
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0.5, OXY = 1)
 	combat_mode = TRUE
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	movement_type = FLYING
 	attack_verb_continuous = "chomps"
 	attack_verb_simple = "chomp"

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -16,7 +16,7 @@
 	response_disarm_continuous = "pushes"
 	response_disarm_simple = "push"
 
-	move_delay_modifier = -1
+	movement_speed_modifier = 0.8
 	maxHealth = 50000
 	health = 50000
 	healable = 0

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -26,7 +26,7 @@
 	sentience_type = SENTIENCE_HUMANOID
 	speak_chance = 0
 	turns_per_move = 5
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	stat_attack = UNCONSCIOUS
 	robust_searching = 1
 	maxHealth = 100
@@ -59,7 +59,7 @@
 	health = 170
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 
 /mob/living/simple_animal/hostile/syndicate/space/Initialize(mapload)
 	. = ..()
@@ -94,7 +94,7 @@
 	health = 170
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	projectile_deflect_chance = 50
 
 /mob/living/simple_animal/hostile/syndicate/melee/space/Initialize(mapload)
@@ -146,7 +146,7 @@
 	health = 170
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	projectile_deflect_chance = 50
 
 /mob/living/simple_animal/hostile/syndicate/melee/sword/space/Initialize(mapload)
@@ -193,7 +193,7 @@
 	health = 170
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/Initialize(mapload)
 	. = ..()
@@ -226,7 +226,7 @@
 	health = 170
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 
 /mob/living/simple_animal/hostile/syndicate/ranged/smg/space/Initialize(mapload)
 	. = ..()
@@ -256,7 +256,7 @@
 	health = 170
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 
 /mob/living/simple_animal/hostile/syndicate/ranged/shotgun/space/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -16,7 +16,7 @@
 	response_disarm_continuous = "pushes"
 	response_disarm_simple = "push"
 	faction = list("hostile")
-	move_delay_modifier = 1
+	movement_speed_modifier = -0.5
 	maxHealth = 250
 	health = 250
 	mob_size = MOB_SIZE_LARGE

--- a/code/modules/mob/living/simple_animal/hostile/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wizard.dm
@@ -9,7 +9,7 @@
 	sentience_type = SENTIENCE_HUMANOID
 	speak_chance = 0
 	turns_per_move = 3
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	maxHealth = 100
 	health = 100
 	harm_intent_damage = 5

--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -26,7 +26,7 @@
 	friendly_verb_simple = "float near"
 	speak_emote = list("puffs")
 	vision_range = 5
-	move_delay_modifier = 0
+	movement_speed_modifier = 0
 	maxHealth = 50
 	health = 50
 	pixel_x = -16
@@ -107,7 +107,7 @@
 	F.move_to_delay = 6
 	F.environment_smash = ENVIRONMENT_SMASH_WALLS
 	F.mob_size = MOB_SIZE_LARGE
-	F.move_delay_modifier = 1
+	F.movement_speed_modifier = -0.5
 	addtimer(CALLBACK(F, TYPE_PROC_REF(/mob/living/simple_animal/hostile/asteroid/fugu, Deflate)), 100)
 
 /mob/living/simple_animal/hostile/asteroid/fugu/proc/Deflate()
@@ -126,7 +126,7 @@
 		inflate_cooldown = 4
 		environment_smash = ENVIRONMENT_SMASH_NONE
 		mob_size = MOB_SIZE_SMALL
-		move_delay_modifier = 0
+		movement_speed_modifier = 0
 
 /mob/living/simple_animal/hostile/asteroid/fugu/death(gibbed, cause_of_death = "Unknown")
 	Deflate()

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -26,7 +26,7 @@
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	move_delay_modifier = -1 //they don't have to lug a body made of runed metal around
+	movement_speed_modifier = 0.8 //they don't have to lug a body made of runed metal around
 	stop_automated_movement = 1
 	faction = list("cult")
 	status_flags = CANPUSH

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -103,7 +103,7 @@
 	var/environment_smash = ENVIRONMENT_SMASH_NONE
 
 	/// See simple_animal_movement.dm
-	var/move_delay_modifier = 1
+	var/movement_speed_modifier = -0.5
 
 	///Hot simple_animal baby making vars.
 	var/list/childtype = null
@@ -243,7 +243,7 @@
  */
 /mob/living/simple_animal/on_stamina_update()
 	. = ..()
-	set_simple_move_delay(initial(move_delay_modifier) + (stamina.loss * 0.06))
+	set_simple_movespeed_modifier(initial(movement_speed_modifier) - (2 * (stamina.loss_as_percent / 100)))
 
 /mob/living/simple_animal/proc/handle_automated_action()
 	set waitfor = FALSE

--- a/code/modules/mob/living/simple_animal/simple_animal_movement.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_movement.dm
@@ -4,10 +4,10 @@
  * move_delay_modifier adds to the delay between steps.
  * Please use actual movespeed modifiers and not that var.
 */
-/mob/living/simple_animal/update_config_movespeed()
+/mob/living/simple_animal/apply_initial_movespeed()
 	. = ..()
 	// By default, simple animals should move as fast as players on run intent.
-	add_movespeed_modifier(/datum/movespeed_modifier/config_walk_run/run)
+	add_movespeed_modifier(/datum/movespeed_modifier/move_intent/run)
 
 /// Update the simple variable movement delay value
 /mob/living/simple_animal/proc/set_simple_move_delay(var_value)

--- a/code/modules/mob/living/simple_animal/simple_animal_movement.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_movement.dm
@@ -1,7 +1,7 @@
 /*
  * A note on how simplemob movespeed works.
- * With a move_delay_modifier value of 0, simple mobs move at the same speed as a running human.
- * move_delay_modifier adds to the delay between steps.
+ * With a movement_speed_modifier value of 0, simple mobs move at the same speed as a running human.
+ * movement_speed_modifier adjusts the number of tiles moved per second.
  * Please use actual movespeed modifiers and not that var.
 */
 /mob/living/simple_animal/apply_initial_movespeed()
@@ -10,13 +10,13 @@
 	add_movespeed_modifier(/datum/movespeed_modifier/move_intent/run)
 
 /// Update the simple variable movement delay value
-/mob/living/simple_animal/proc/set_simple_move_delay(var_value)
-	move_delay_modifier = var_value
+/mob/living/simple_animal/proc/set_simple_movespeed_modifier(var_value)
+	movement_speed_modifier = var_value
 	update_simple_move_delay()
 
 /mob/living/simple_animal/proc/update_simple_move_delay()
-	if(move_delay_modifier == 0)
+	if(movement_speed_modifier == 0)
 		remove_movespeed_modifier(/datum/movespeed_modifier/simplemob_varspeed)
 		return
 
-	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/simplemob_varspeed, slowdown = move_delay_modifier)
+	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/simplemob_varspeed, modifier = movement_speed_modifier)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -149,24 +149,24 @@
 
 /mob/living/simple_animal/slime/updatehealth(cause_of_death)
 	. = ..()
-	var/mod = 0
+	var/mod = 1
 	if(!HAS_TRAIT(src, TRAIT_IGNOREDAMAGESLOWDOWN))
 		var/health_deficiency = (maxHealth - health)
 		if(health_deficiency >= 45)
-			mod += (health_deficiency / 25)
-		if(health <= 0)
-			mod += 2
-	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/slime_healthmod, slowdown = mod)
+			mod = 0.5 * (1 - (health_deficiency / maxHealth)) // 50% speed if health == 0
+
+	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/slime_healthmod, modifier = mod)
 
 /mob/living/simple_animal/slime/adjust_bodytemperature()
 	. = ..()
-	var/mod = 0
+	var/mod = 1
 	if(bodytemperature >= 330.23) // 135 F or 57.08 C
-		mod = -1 // slimes become supercharged at high temperatures
+		mod = 1.4 // slimes become supercharged at high temperatures
 	else if(bodytemperature < 283.222)
-		mod = ((283.222 - bodytemperature) / 10) * 1.75
+		mod = 0.5 * ((283.222 - bodytemperature) / 283.222) // 50% speed if bodytemp == 0
+
 	if(mod)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/slime_tempmod, slowdown = mod)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/slime_tempmod, modifier = mod)
 
 /mob/living/simple_animal/slime/ObjBump(obj/O)
 	if(!client && powerlevel > 0)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1562,14 +1562,14 @@
 	if(!speedies)
 		remove_movespeed_modifier(/datum/movespeed_modifier/equipment_speedmod)
 	else
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/equipment_speedmod, slowdown = speedies)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/equipment_speedmod, modifier = speedies)
 
 /// Gets the combined speed modification of all worn items
 /// Except base mob type doesnt really wear items
 /mob/proc/equipped_speed_mods()
 	for(var/obj/item/I in held_items)
 		if(I.item_flags & SLOWS_WHILE_IN_HAND)
-			. += I.slowdown
+			. += I.worn_movespeed_modifier
 
 /mob/proc/set_stat(new_stat)
 	if(new_stat == stat)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -92,7 +92,7 @@
 	if(ispath(ai_controller))
 		ai_controller = new ai_controller(src)
 
-	update_config_movespeed()
+	apply_initial_movespeed()
 	initialize_actionspeed()
 	update_movespeed(TRUE)
 	become_hearing_sensitive()
@@ -1607,16 +1607,16 @@
 		datum_flags |= DF_VAR_EDITED
 		return
 
-	var/slowdown_edit = (var_name == NAMEOF(src, movement_delay))
+	var/delay_edit = (var_name == NAMEOF(src, movement_delay))
 	var/diff
-	if(slowdown_edit && isnum(movement_delay) && isnum(var_value))
+	if(delay_edit && isnum(movement_delay) && isnum(var_value))
 		remove_movespeed_modifier(/datum/movespeed_modifier/admin_varedit)
 		diff = var_value - movement_delay
 
 	. = ..()
 
-	if(. && slowdown_edit && isnum(diff))
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/admin_varedit, slowdown = diff)
+	if(. && delay_edit && isnum(diff))
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/admin_varedit, modifier = (10 / diff)) // I'm not sure this math is correct
 
 /mob/proc/set_active_storage(new_active_storage)
 	if(active_storage)

--- a/code/modules/mod/mod_ai.dm
+++ b/code/modules/mod/mod_ai.dm
@@ -81,7 +81,7 @@
 		return FALSE
 	else if(!wearer && (!has_gravity() || !isturf(loc)))
 		return FALSE
-	COOLDOWN_START(src, cooldown_mod_move, movedelay * timemodifier + slowdown_active)
+	COOLDOWN_START(src, cooldown_mod_move, movedelay * timemodifier + movespeed_active)
 	subtract_charge(CHARGE_PER_STEP)
 	playsound(src, 'sound/mecha/mechmove01.ogg', 25, TRUE)
 	if(ismovable(wearer?.loc))

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -59,10 +59,10 @@ TYPEINFO_DEF(/obj/item/mod/control)
 	var/complexity = 0
 	/// Power usage of the MOD.
 	var/charge_drain = DEFAULT_CHARGE_DRAIN
-	/// Slowdown of the MOD when not active.
-	var/slowdown_inactive = 0
-	/// Slowdown of the MOD when active.
-	var/slowdown_active = 0
+	/// Movespeed modifier while inactive.
+	var/movespeed_active = 0
+	/// Movespeed modifier when active.
+	var/movespeed_inactive = 0
 	/// How long this MOD takes each part to seal.
 	var/activation_step_time = MOD_ACTIVATION_STEP_TIME
 	/// Extended description of the theme.
@@ -634,7 +634,7 @@ TYPEINFO_DEF(/obj/item/mod/control)
 
 /obj/item/mod/control/proc/update_speed()
 	for(var/obj/item/part as anything in get_parts(include_control = TRUE))
-		part.slowdown = (active ? slowdown_active : slowdown_inactive) / length(mod_parts)
+		part.worn_movespeed_modifier = (active ? movespeed_active : movespeed_inactive) / length(mod_parts)
 	wearer?.update_equipment_speed_mods()
 
 /obj/item/mod/control/proc/power_off()
@@ -702,16 +702,18 @@ TYPEINFO_DEF(/obj/item/mod/control)
 /obj/item/mod/control/proc/on_potion(atom/movable/source, obj/item/slimepotion/speed/speed_potion, mob/living/user)
 	SIGNAL_HANDLER
 
-	if(slowdown_inactive <= 0)
+	if(movespeed_inactive >= 0)
 		to_chat(user, span_warning("[src] has already been coated with red, that's as fast as it'll go!"))
 		return SPEED_POTION_STOP
+
 	if(active)
 		to_chat(user, span_warning("It's too dangerous to smear [speed_potion] on [src] while it's active!"))
 		return SPEED_POTION_STOP
+
 	to_chat(user, span_notice("You slather the red gunk over [src], making it faster."))
 	set_mod_color("#FF0000")
-	slowdown_inactive = 0
-	slowdown_active = 0
+	movespeed_inactive = 0
+	movespeed_active = 0
 	update_speed()
 	qdel(speed_potion)
 	return SPEED_POTION_STOP

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -117,7 +117,7 @@ TYPEINFO_DEF(/obj/item/mod/control)
 
 	RegisterSignal(src, COMSIG_ATOM_EXITED, PROC_REF(on_exit))
 	RegisterSignal(src, COMSIG_SPEED_POTION_APPLIED, PROC_REF(on_potion))
-	movedelay = CONFIG_GET(number/movedelay/run_delay)
+	movedelay = MOVESPEED_TO_DELAY(RUN_SPEED)
 	START_PROCESSING(SSobj, src)
 
 /obj/item/mod/control/Destroy()

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -39,10 +39,10 @@
 	var/complexity_max = DEFAULT_MAX_COMPLEXITY
 	/// How much battery power the MOD uses by just being on
 	var/charge_drain = DEFAULT_CHARGE_DRAIN
-	/// Slowdown of the MOD when not active.
-	var/slowdown_inactive = 0
-	/// Slowdown of the MOD when active.
-	var/slowdown_active = 0
+	/// Movespeed modifier of the MOD when not active.
+	var/movespeed_inactive = 0
+	/// Movespeed modifier of the MOD when active.
+	var/movespeed_active = 0
 	/// How long this MOD takes each part to seal.
 	var/activation_step_time = MOD_ACTIVATION_STEP_TIME
 	/// Theme used by the MOD TGUI.
@@ -144,8 +144,8 @@
 	var/list/parts = list(mod)
 	mod.slot_flags = slot_flags
 	mod.extended_desc = extended_desc
-	mod.slowdown_inactive = slowdown_inactive
-	mod.slowdown_active = slowdown_active
+	mod.movespeed_active = movespeed_active
+	mod.movespeed_inactive = movespeed_inactive
 	mod.activation_step_time = activation_step_time
 	mod.complexity_max = complexity_max
 	mod.ui_theme = ui_theme
@@ -734,7 +734,7 @@
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
-	slowdown_active = 1.25
+	movespeed_active = -0.6
 	inbuilt_modules = list(/obj/item/mod/module/reagent_scanner/advanced)
 	allowed_suit_storage = list(
 		/obj/item/flashlight,
@@ -1257,8 +1257,8 @@
 	resistance_flags = FIRE_PROOF
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
-	slowdown_inactive = 2
-	slowdown_active = 1.5
+	movespeed_inactive = -1
+	movespeed_active = -0.7
 	ui_theme = "hackerman"
 	inbuilt_modules = list(/obj/item/mod/module/anomaly_locked/kinesis/prototype)
 	allowed_suit_storage = list(

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -40,7 +40,7 @@
 
 /obj/item/mod/module/armor_booster/on_activation()
 	playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	mod.slowdown += added_slowdown
+	mod.worn_movespeed_modifier += added_slowdown
 	mod.wearer.update_equipment_speed_mods()
 
 	for(var/obj/item/part as anything in mod.get_parts(include_control = TRUE))
@@ -57,7 +57,7 @@
 	if(!deleting)
 		playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
-	mod.slowdown -= added_slowdown
+	mod.worn_movespeed_modifier -= added_slowdown
 	mod.wearer.update_equipment_speed_mods()
 	var/list/removed_armor = armor_values.Copy()
 	for(var/armor_type in removed_armor)

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -58,28 +58,29 @@
 	incompatible_modules = list(/obj/item/mod/module/magboot, /obj/item/mod/module/atrocinator)
 	cooldown_time = 0.5 SECONDS
 	required_slots = list(ITEM_SLOT_FEET)
-	/// Slowdown added onto the suit.
-	var/slowdown_active = 0.5
+
+	/// Movespeed modifier delta when active
+	var/movespeed_modifier_active = -0.25
 	/// A list of traits to add to the wearer when we're active (see: Magboots)
 	var/list/active_traits = list(TRAIT_NO_SLIP_WATER, TRAIT_NO_SLIP_ICE, TRAIT_NO_SLIP_SLIDE, TRAIT_NEGATES_GRAVITY)
 
 /obj/item/mod/module/magboot/on_activation()
 	for(var/new_trait in active_traits)
 		ADD_TRAIT(mod.wearer, new_trait, MOD_TRAIT)
-	mod.slowdown += slowdown_active
+	mod.worn_movespeed_modifier += movespeed_modifier_active
 	mod.wearer.update_equipment_speed_mods()
 
 /obj/item/mod/module/magboot/on_deactivation(display_message = TRUE, deleting = FALSE)
 	for(var/old_trait in active_traits)
 		REMOVE_TRAIT(mod.wearer, old_trait, MOD_TRAIT)
-	mod.slowdown -= slowdown_active
+	mod.worn_movespeed_modifier -= movespeed_modifier_active
 	mod.wearer.update_equipment_speed_mods()
 
 /obj/item/mod/module/magboot/advanced
 	name = "MOD advanced magnetic stability module"
 	removable = FALSE
 	complexity = 0
-	slowdown_active = 0
+	movespeed_modifier_active = 0
 
 ///Emergency Tether - Shoots a grappling hook projectile in 0g that throws the user towards it.
 /obj/item/mod/module/tether

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -22,7 +22,7 @@
 	var/start_open = TRUE // unless this var is set to 1
 	var/icon_state_closed = "laptop-closed"
 	var/w_class_open = WEIGHT_CLASS_BULKY
-	var/slowdown_open = TRUE
+	var/slowdown_open = -0.5
 
 /obj/item/modular_computer/laptop/examine(mob/user)
 	. = ..()
@@ -105,11 +105,11 @@
 /obj/item/modular_computer/laptop/proc/toggle_open(mob/living/user=null)
 	if(screen_on)
 		to_chat(user, span_notice("You close \the [src]."))
-		slowdown = initial(slowdown)
+		worn_movespeed_modifier = initial(worn_movespeed_modifier)
 		set_weight_class(initial(w_class))
 	else
 		to_chat(user, span_notice("You open \the [src]."))
-		slowdown = slowdown_open
+		worn_movespeed_modifier = slowdown_open
 		set_weight_class(w_class_open)
 
 	screen_on = !screen_on

--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -36,8 +36,8 @@ Key procs
 	var/priority = 0
 	var/flags = NONE
 
-	/// How many deciseconds of delay to add between each movement. Can be negative.
-	var/slowdown = 0
+	/// How many steps-per-second to add or subtract from the final amount.
+	var/modifier = 0
 
 	/// Movetypes this applies to
 	var/movetypes = ALL
@@ -112,10 +112,10 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 	1. Ensures type_id_datum one way or another refers to a /variable datum. This makes sure it can't be cached. This includes if it's already in the modification list.
 	2. Instantiate a new datum if type_id_datum isn't already instantiated + in the list, using the type. Obviously, wouldn't work for ID only.
 	3. Add the datum if necessary using the regular add proc
-	4. If any of the rest of the args are not null (see: slowdown), modify the datum
+	4. If any of the rest of the args are not null (see: modifier), modify the datum
 	5. Update if necessary
 */
-/mob/proc/add_or_update_variable_movespeed_modifier(datum/movespeed_modifier/type_id_datum, update = TRUE, slowdown)
+/mob/proc/add_or_update_variable_movespeed_modifier(datum/movespeed_modifier/type_id_datum, update = TRUE, modifier)
 	var/modified = FALSE
 	var/inject = FALSE
 	var/datum/movespeed_modifier/final
@@ -142,8 +142,8 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 			inject = TRUE
 			modified = TRUE
 
-	if(!isnull(slowdown))
-		final.slowdown = slowdown
+	if(!isnull(modifier))
+		final.modifier = modifier
 		modified = TRUE
 
 	if(inject)
@@ -167,7 +167,7 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 
 /// Set or update the global movespeed config on a mob
 /mob/proc/update_config_movespeed()
-	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/mob_config_speedmod, slowdown = get_config_move_delay())
+	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/mob_config_speedmod, modifier = get_config_move_delay())
 
 /// Get the global config movespeed of a mob by type
 /mob/proc/get_config_move_delay()
@@ -184,10 +184,13 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 		var/datum/movespeed_modifier/M = movespeed_modification[key]
 		if(!(M.movetypes & movement_type)) // We don't affect any of these move types, skip
 			continue
+
 		if(M.blacklisted_movetypes & movement_type) // There's a movetype here that disables this modifier, skip
 			continue
+
 		var/conflict = M.conflicts_with
-		var/amt = M.slowdown
+		var/amt = M.modifier
+
 		if(conflict)
 			// Conflicting modifiers prioritize the larger slowdown or the larger speedup
 			// We purposefuly don't handle mixing speedups and slowdowns on the same id
@@ -195,9 +198,12 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 				conflict_tracker[conflict] = amt
 			else
 				continue
-		. += amt
 
-	movement_delay = .
+		. += modifier
+
+	. = round(., 0.01)
+	movement_delay = . == 0 ? 0 : round(10 / ., 0.01)
+
 	SEND_SIGNAL(src, COMSIG_MOB_MOVESPEED_UPDATED)
 
 /// Get the move speed modifiers list of the mob

--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -165,8 +165,8 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 		key = datum_type_id.id
 	return LAZYACCESS(movespeed_modification, key)
 
-/// Set or update the global movespeed config on a mob
-/mob/proc/update_config_movespeed()
+/// Applies any default movement speed modifiers to the mob.
+/mob/proc/apply_initial_movespeed()
 	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/mob_config_speedmod, modifier = get_config_move_delay())
 
 /// Get the global config movespeed of a mob by type
@@ -199,7 +199,7 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 			else
 				continue
 
-		. += modifier
+		. += amt
 
 	. = round(., 0.01)
 	movement_delay = . == 0 ? 0 : round(10 / ., 0.01)
@@ -210,11 +210,3 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 /mob/proc/get_movespeed_modifiers()
 	. = LAZYCOPY(movespeed_modification)
 	(.):Remove(movespeed_mod_immunities)
-
-/// Calculate the total slowdown of all movespeed modifiers
-/mob/proc/total_slowdown()
-	. = 0
-	for(var/id in get_movespeed_modifiers())
-		var/datum/movespeed_modifier/M = movespeed_modification[id]
-		. += M.slowdown
-

--- a/code/modules/movespeed/modifiers/components.dm
+++ b/code/modules/movespeed/modifiers/components.dm
@@ -1,14 +1,14 @@
 /datum/movespeed_modifier/shrink_ray
 	movetypes = GROUND
-	slowdown = 4
+	modifier = -1.25
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/snail_crawl
-	slowdown = -7
+	modifier = -1.6
 	movetypes = GROUND
 
 /datum/movespeed_modifier/tenacious
-	slowdown = -0.7
+	modifier = 0.5
 	movetypes = GROUND
 
 /datum/movespeed_modifier/sanity
@@ -16,10 +16,10 @@
 	movetypes = (~FLYING)
 
 /datum/movespeed_modifier/sanity/insane
-	slowdown = 1
+	modifier = -0.5
 
 /datum/movespeed_modifier/sanity/crazy
-	slowdown = 0.5
+	modifier = -0.27
 
 /datum/movespeed_modifier/sanity/disturbed
-	slowdown = 0.25
+	modifier = -0.14

--- a/code/modules/movespeed/modifiers/drugs.dm
+++ b/code/modules/movespeed/modifiers/drugs.dm
@@ -1,4 +1,4 @@
 /datum/movespeed_modifier/stimulants
 	movetypes = GROUND
-	slowdown = 1
+	modifier = -0.5
 	id = MOVESPEED_ID_STIMULANTS

--- a/code/modules/movespeed/modifiers/innate.dm
+++ b/code/modules/movespeed/modifiers/innate.dm
@@ -1,9 +1,9 @@
 /datum/movespeed_modifier/strained_muscles
-	slowdown = -0.55
+	modifier = -0.3
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/pai_spacewalk
-	slowdown = 2
+	modifier = -0.83
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/species
@@ -12,4 +12,4 @@
 
 /datum/movespeed_modifier/dna_vault_speedup
 	blacklisted_movetypes = (FLYING|FLOATING)
-	slowdown = -0.4
+	modifier = 0.27

--- a/code/modules/movespeed/modifiers/items.dm
+++ b/code/modules/movespeed/modifiers/items.dm
@@ -3,19 +3,19 @@
 	movetypes = FLOATING
 
 /datum/movespeed_modifier/jetpack/cybernetic
-	slowdown = -0.5
+	modifier = 0.35
 
 /datum/movespeed_modifier/jetpack/fullspeed
-	slowdown = -0.5
+	modifier = 0.35
 
 /datum/movespeed_modifier/die_of_fate
-	slowdown = 1
+	modifier = -0.5
 
 /datum/movespeed_modifier/berserk
-	slowdown = -0.2
+	modifier = 0.13
 
 /datum/movespeed_modifier/sphere
-	slowdown = -0.5
+	modifier = 0.35
 
 /datum/movespeed_modifier/equipping
-	slowdown = 1.5
+	modifier = -0.68

--- a/code/modules/movespeed/modifiers/misc.dm
+++ b/code/modules/movespeed/modifiers/misc.dm
@@ -2,14 +2,14 @@
 	variable = TRUE
 
 /datum/movespeed_modifier/yellow_orb
-	slowdown = -0.65
+	modifier = 0.48
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/vampire_bloodlust
-	slowdown = -1
+	modifier = 0.83
 
 /datum/movespeed_modifier/vampire_starving
-	slowdown = 1
+	modifier = -0.5
 
 /datum/movespeed_modifier/vampire_wasting
-	slowdown = 1
+	modifier = -0.5

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -28,9 +28,10 @@
 	blacklisted_movetypes = FLOATING
 
 /datum/movespeed_modifier/asystole
-	#warn TODO: make this multiplicative
-	modifier = -2
+	multiply = TRUE
+	modifier = 0.8
 	blacklisted_movetypes = FLOATING
+	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/equipment_speedmod
 	variable = TRUE
@@ -53,7 +54,7 @@
 	variable = TRUE
 
 /datum/movespeed_modifier/slime_healthmod
-	#warn TODO: make multiplier
+	multiply = TRUE
 	variable = TRUE
 
 /datum/movespeed_modifier/move_intent
@@ -105,7 +106,6 @@
 	modifier = -1.4
 
 /datum/movespeed_modifier/gravity
-	#warn TODO: make multiplicative
 	blacklisted_movetypes = FLOATING
 	variable = TRUE
 	flags = IGNORE_NOSLOW
@@ -115,21 +115,21 @@
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/slime_tempmod
-	#warn TODO make a multiplier
+	multiply = TRUE
 	variable = TRUE
 
 /datum/movespeed_modifier/living_exhaustion
-	#warn TODO make a multiplier?
-	modifier = STAMINA_EXHAUSTION_MOVESPEED
+	multiply = TRUE
+	modifier = STAMINA_EXHAUSTION_MOVESPEED_MULTIPLIER
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/carbon_crawling
-	#warn TODO make a multiplier?
-	modifier = CRAWLING_MOVESPEED
+	multiply = TRUE
+	modifier = CRAWLING_MOVESPEED_MULTIPLIER
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/mob_config_speedmod
-	#warn TODO make a multiplier
+	multiply = TRUE
 	variable = TRUE
 	flags = IGNORE_NOSLOW
 

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -47,12 +47,13 @@
 	modifier = -1.5
 
 /datum/movespeed_modifier/grab_slowdown/kill
-	slowdown = -2
+	modifier = -2
 
 /datum/movespeed_modifier/slime_reagentmod
 	variable = TRUE
 
 /datum/movespeed_modifier/slime_healthmod
+	#warn TODO: make multiplier
 	variable = TRUE
 
 /datum/movespeed_modifier/move_intent
@@ -60,13 +61,13 @@
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/move_intent/walk
-	slowdown = WALK_SPEED
+	modifier = WALK_SPEED
 
 /datum/movespeed_modifier/move_intent/run
-	slowdown = RUN_SPEED
+	modifier = RUN_SPEED
 
 /datum/movespeed_modifier/move_intent/sprint
-	slowdown = SPRINT_SPEED
+	modifier = SPRINT_SPEED
 
 /datum/movespeed_modifier/turf_slowdown
 	movetypes = GROUND
@@ -91,6 +92,11 @@
 	movetypes = GROUND
 	flags = IGNORE_NOSLOW
 
+// See /mob/living/simple_animal/apply_initial_movespeed()
+/datum/movespeed_modifier/simplemob_initial
+	modifier = -0.5
+	flags = IGNORE_NOSLOW
+
 /datum/movespeed_modifier/simplemob_varspeed
 	variable = TRUE
 	flags = IGNORE_NOSLOW
@@ -99,20 +105,22 @@
 	modifier = -1.4
 
 /datum/movespeed_modifier/gravity
+	#warn TODO: make multiplicative
 	blacklisted_movetypes = FLOATING
 	variable = TRUE
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/carbon_softcrit
-	slowdown = SOFTCRIT_MOVESPEED
+	modifier = SOFTCRIT_MOVESPEED
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/slime_tempmod
+	#warn TODO make a multiplier
 	variable = TRUE
 
 /datum/movespeed_modifier/living_exhaustion
 	#warn TODO make a multiplier?
-	slowdown = STAMINA_EXHAUSTION_MOVESPEED
+	modifier = STAMINA_EXHAUSTION_MOVESPEED
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/carbon_crawling
@@ -121,6 +129,7 @@
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/mob_config_speedmod
+	#warn TODO make a multiplier
 	variable = TRUE
 	flags = IGNORE_NOSLOW
 

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -1,5 +1,5 @@
 /datum/movespeed_modifier/obesity
-	slowdown = 1.5
+	modifier = -0.68
 
 /datum/movespeed_modifier/monkey_reagent_speedmod
 	variable = TRUE
@@ -14,21 +14,22 @@
 	variable = TRUE
 
 /datum/movespeed_modifier/slaughter
-	slowdown = -1
+	modifier = 0.83
 
 /datum/movespeed_modifier/resonance
-	slowdown = 0.75
+	modifier = -0.4
 
 /datum/movespeed_modifier/pain
 	blacklisted_movetypes = FLOATING
 	variable = TRUE
 
 /datum/movespeed_modifier/shock
-	slowdown = 3
+	modifier = -1
 	blacklisted_movetypes = FLOATING
 
 /datum/movespeed_modifier/asystole
-	slowdown = 10
+	#warn TODO: make this multiplicative
+	modifier = -2
 	blacklisted_movetypes = FLOATING
 
 /datum/movespeed_modifier/equipment_speedmod
@@ -40,13 +41,13 @@
 	blacklisted_movetypes = FLOATING
 
 /datum/movespeed_modifier/grab_slowdown/aggressive
-	slowdown = 3
+	modifier = -1
 
 /datum/movespeed_modifier/grab_slowdown/neck
-	slowdown = 6
+	modifier = -1.5
 
 /datum/movespeed_modifier/grab_slowdown/kill
-	slowdown = 9
+	slowdown = -2
 
 /datum/movespeed_modifier/slime_reagentmod
 	variable = TRUE
@@ -54,24 +55,18 @@
 /datum/movespeed_modifier/slime_healthmod
 	variable = TRUE
 
-/datum/movespeed_modifier/config_walk_run
-	slowdown = 1
+/datum/movespeed_modifier/move_intent
 	id = MOVESPEED_ID_MOB_WALK_RUN
 	flags = IGNORE_NOSLOW
 
-/datum/movespeed_modifier/config_walk_run/proc/sync()
+/datum/movespeed_modifier/move_intent/walk
+	slowdown = WALK_SPEED
 
-/datum/movespeed_modifier/config_walk_run/walk/sync()
-	var/mod = CONFIG_GET(number/movedelay/walk_delay)
-	slowdown = isnum(mod)? mod : initial(slowdown)
+/datum/movespeed_modifier/move_intent/run
+	slowdown = RUN_SPEED
 
-/datum/movespeed_modifier/config_walk_run/run/sync()
-	var/mod = CONFIG_GET(number/movedelay/run_delay)
-	slowdown = isnum(mod)? mod : initial(slowdown)
-
-/datum/movespeed_modifier/config_walk_run/sprint/sync()
-	var/mod = CONFIG_GET(number/movedelay/sprint_delay)
-	slowdown = isnum(mod) ? mod : initial(slowdown)
+/datum/movespeed_modifier/move_intent/sprint
+	slowdown = SPRINT_SPEED
 
 /datum/movespeed_modifier/turf_slowdown
 	movetypes = GROUND
@@ -86,10 +81,10 @@
 	variable = TRUE
 
 /datum/movespeed_modifier/shove
-	slowdown = SHOVE_SLOWDOWN_STRENGTH
+	modifier = SHOVE_SLOWDOWN_MOVESPEED
 
 /datum/movespeed_modifier/human_carry
-	slowdown = HUMAN_CARRY_SLOWDOWN
+	modifier = HUMAN_CARRY_MOVESPEED
 
 /datum/movespeed_modifier/limbless
 	variable = TRUE
@@ -101,7 +96,7 @@
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/tarantula_web
-	slowdown = 5
+	modifier = -1.4
 
 /datum/movespeed_modifier/gravity
 	blacklisted_movetypes = FLOATING
@@ -109,18 +104,20 @@
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/carbon_softcrit
-	slowdown = SOFTCRIT_ADD_SLOWDOWN
+	slowdown = SOFTCRIT_MOVESPEED
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/slime_tempmod
 	variable = TRUE
 
 /datum/movespeed_modifier/living_exhaustion
-	slowdown = STAMINA_EXHAUSTION_MOVESPEED_SLOWDOWN
+	#warn TODO make a multiplier?
+	slowdown = STAMINA_EXHAUSTION_MOVESPEED
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/carbon_crawling
-	slowdown = CRAWLING_ADD_SLOWDOWN
+	#warn TODO make a multiplier?
+	modifier = CRAWLING_MOVESPEED
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/mob_config_speedmod
@@ -128,24 +125,24 @@
 	flags = IGNORE_NOSLOW
 
 /datum/movespeed_modifier/metabolicboost
-	slowdown = -1.5
+	modifier = 1.5
 
 /datum/movespeed_modifier/dragon_rage
-	slowdown = -0.5
+	modifier = 0.35
 
 /datum/movespeed_modifier/dragon_depression
-	slowdown = 5
+	modifier = -1.4
 
 /datum/movespeed_modifier/morph_disguised
-	slowdown = 1
+	modifier = -0.5
 
 /datum/movespeed_modifier/auto_wash
-	slowdown = 3
+	modifier = -1
 
 /datum/movespeed_modifier/atmos_pressure
-	slowdown = 3
+	modifier = -1
 	id = MOVESPEED_ID_MOB_ATMOS_AFFLICTION
 	variable = TRUE
 
 /datum/movespeed_modifier/flockphase
-	slowdown = -0.4
+	modifier = 0.27

--- a/code/modules/movespeed/modifiers/reagent.dm
+++ b/code/modules/movespeed/modifiers/reagent.dm
@@ -2,55 +2,55 @@
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/reagent/stimulants
-	slowdown = -0.55
+	modifier = 0.4
 
 /datum/movespeed_modifier/reagent/ephedrine
-	slowdown = -0.5
+	modifier = 0.35
 
 /datum/movespeed_modifier/reagent/pepperspray
-	slowdown = 0.25
+	modifier = 0.14
 
 /datum/movespeed_modifier/reagent/monkey_energy
-	slowdown = -0.35
+	modifier = 0.23
 
 /datum/movespeed_modifier/reagent/changelinghaste
-	slowdown = -0.8
+	modifier = 0.625
 
 /datum/movespeed_modifier/reagent/methamphetamine
-	slowdown = -0.25
+	modifier = 0.16
 
 /datum/movespeed_modifier/reagent/nitrium
-	slowdown = -0.65
+	modifier = 0.48
 
 /datum/movespeed_modifier/reagent/cannabis
-	slowdown = 0.4
+	modifier = -0.22
 
 /datum/movespeed_modifier/reagent/freon
-	slowdown = 1.6
+	modifier = -0.7
 
 /datum/movespeed_modifier/reagent/halon
-	slowdown = 1.8
+	modifier = -0.77
 
 /datum/movespeed_modifier/reagent/lenturi
-	slowdown = 1.5
+	modifier = -0.68
 
 /datum/movespeed_modifier/reagent/nuka_cola
-	slowdown = -0.35
+	modifier = 0.23
 
 /datum/movespeed_modifier/reagent/nooartrium
-	slowdown = 2
+	modifier = -0.83
 
 /datum/movespeed_modifier/inaprovaline
-	slowdown = 1.5
+	modifier = -0.68
 
 /datum/movespeed_modifier/tramadol
-	slowdown = 1.5
+	modifier = -0.68
 
 /datum/movespeed_modifier/morphine
-	slowdown = 1.5
+	modifier = -0.68
 
 /datum/movespeed_modifier/hyperzine
-	slowdown = -0.4
+	modifier = 0.27
 
 /datum/movespeed_modifier/impedrezene
-	slowdown = 2
+	modifier = -0.83

--- a/code/modules/movespeed/modifiers/status_effects.dm
+++ b/code/modules/movespeed/modifiers/status_effects.dm
@@ -1,15 +1,15 @@
 /datum/movespeed_modifier/status_effect/bloodchill
-	slowdown = 3
+	modifier = -1
 
 /datum/movespeed_modifier/status_effect/bonechill
-	slowdown = 3
+	modifier = -1
 
 /datum/movespeed_modifier/status_effect/lightpink
-	slowdown = -0.5
+	modifier = 0.35
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/status_effect/tarfoot
-	slowdown = 0.5
+	modifier = -0.27
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/status_effect/sepia
@@ -17,17 +17,17 @@
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/status_effect/power_chord
-	slowdown = -0.2
+	modifier = 0.13
 
 /datum/movespeed_modifier/status_effect/hazard_area
-	slowdown = 4
+	modifier = -1.25
 
 /datum/movespeed_modifier/status_effect/disorient
-	slowdown = 1
+	modifier = -0.5
 
 // technically not a status effect but like, close enough
 /datum/movespeed_modifier/status_effect/drowsy
-	slowdown = 4
+	modifier = -1.25
 
 /datum/movespeed_modifier/status_effect/holdup
-	slowdown = 5
+	modifier = -1.4

--- a/code/modules/ninja/suit/shoes.dm
+++ b/code/modules/ninja/suit/shoes.dm
@@ -23,4 +23,4 @@ TYPEINFO_DEF(/obj/item/clothing/shoes/space_ninja)
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
-	slowdown = -1
+	worn_movespeed_modifier = 0.8

--- a/code/modules/projectiles/guns/energy/beam_rifle.dm
+++ b/code/modules/projectiles/guns/energy/beam_rifle.dm
@@ -37,7 +37,7 @@ TYPEINFO_DEF(/obj/item/gun/energy/beam_rifle)
 	var/aiming_time_fire_threshold = 5
 	var/aiming_time_left = 12
 	var/aiming_time_increase_user_movement = 3
-	var/scoped_slow = 1
+	var/scoped_slow = -0.5
 	var/aiming_time_increase_angle_multiplier = 0.3
 	var/last_process = 0
 
@@ -154,9 +154,9 @@ TYPEINFO_DEF(/obj/item/gun/energy/beam_rifle)
 
 /obj/item/gun/energy/beam_rifle/proc/update_slowdown()
 	if(aiming)
-		slowdown = scoped_slow
+		worn_movespeed_modifier = scoped_slow
 	else
-		slowdown = initial(slowdown)
+		worn_movespeed_modifier = initial(worn_movespeed_modifier)
 
 /obj/item/gun/energy/beam_rifle/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -106,7 +106,7 @@ TYPEINFO_DEF(/obj/item/gun/energy/minigun)
 	icon = 'icons/obj/guns/minigun.dmi'
 	icon_state = "minigun_spin"
 	inhand_icon_state = "minigun"
-	slowdown = 1
+	worn_movespeed_modifier = -0.5
 	slot_flags = null
 	w_class = WEIGHT_CLASS_HUGE
 

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -668,11 +668,11 @@
 /datum/status_effect/stabilized/sepia/tick()
 	if(prob(50) && mod > -1)
 		mod--
-		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, slowdown = -0.5)
+		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, modifier = 0.35)
 	else if(mod < 1)
 		mod++
 		// yeah a value of 0 does nothing but replacing the trait in place is cheaper than removing and adding repeatedly
-		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, slowdown = 0)
+		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, modifier = 0)
 	return ..()
 
 /datum/status_effect/stabilized/sepia/on_remove()

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -840,10 +840,10 @@
 
 	if(isitem(interacting_with))
 		var/obj/item/I = interacting_with
-		if(I.slowdown <= 0 || I.obj_flags & IMMUTABLE_SLOW)
+		if(I.worn_movespeed_modifier >= 0 || I.obj_flags & IMMUTABLE_SLOW)
 			to_chat(user, span_warning("The [interacting_with] can't be made any faster!"))
 			return ITEM_INTERACT_BLOCKING
-		I.slowdown = 0
+		I.worn_movespeed_modifier = 0
 
 	to_chat(user, span_notice("You slather the red gunk over the [interacting_with], making it faster."))
 	interacting_with.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -668,7 +668,7 @@
 	name = "emergency space suit"
 	icon_state = "syndicate-orange"
 	inhand_icon_state = "syndicate-orange"
-	slowdown = 3
+	worn_movespeed_modifier = -1
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION | CLOTHING_TESHARI_VARIATION | CLOTHING_VOX_VARIATION
 
 /obj/item/pickaxe/emergency

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -8,7 +8,7 @@
 	body_part = HEAD
 	plaintext_zone = "head"
 	w_class = WEIGHT_CLASS_BULKY //Quite a hefty load
-	slowdown = 1 //Balancing measure
+	worn_movespeed_modifier = -0.5 //Balancing measure
 	throw_range = 2 //No head bowling
 	px_x = 0
 	px_y = -8

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -209,9 +209,9 @@
 
 ///for when mood is disabled and hunger should handle slowdowns
 /obj/item/organ/stomach/proc/handle_hunger_slowdown(mob/living/carbon/human/human)
-	var/hungry = (500 - human.nutrition) / 5 //So overeat would be 100 and default level would be 80
-	if(!CHEM_EFFECT_MAGNITUDE(human, CE_HIDE_HUNGER) && (hungry >= 70))
-		human.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/hunger, slowdown = (hungry / 50))
+	var/hungry = max(0, NUTRITION_LEVEL_FED - human.nutrition)
+	if(!CHEM_EFFECT_MAGNITUDE(human, CE_HIDE_HUNGER) && hungry)
+		human.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/hunger, modifier = (HUNGER_MOVESPEED * (hungry / NUTRITION_LEVEL_FED)))
 	else
 		human.remove_movespeed_modifier(/datum/movespeed_modifier/hunger)
 

--- a/code/modules/surgery/organs/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/stomach/stomach_ethereal.dm
@@ -32,7 +32,7 @@
 	return ..()
 
 /obj/item/organ/stomach/ethereal/handle_hunger_slowdown(mob/living/carbon/human/human)
-	human.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/hunger, slowdown = (1.5 * (1 - crystal_charge / 100)))
+	human.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/hunger, modifier = (HUNGER_MOVESPEED * (1 - crystal_charge / 100)))
 
 /obj/item/organ/stomach/ethereal/proc/charge(datum/source, amount, repairs)
 	SIGNAL_HANDLER

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -29,6 +29,13 @@ COMMENDATION_PERCENT_POLL 0.05
 ## These values get directly added to values and totals ingame.
 ## To speed things up make the number negative, to slow things down, make the number positive.
 
+## The variables below affect the movement of specific mob types. THIS AFFECTS ALL SUBTYPES OF THE TYPE YOU CHOOSE!
+## Entries completely override all subtypes. Later entries have precedence over earlier entries.
+## This means if you put /mob 0 on the last entry, it will null out all changes, while if you put /mob as the first entry and
+## /mob/living/carbon/human on the last entry, the last entry will override the first.
+MOVESPEED_MODIFIER /mob/living/simple_animal 0
+
+
 ## NAMES ###
 ## If uncommented this adds a random surname to a player's name if they only specify one name.
 HUMANS_NEED_SURNAMES

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -29,22 +29,6 @@ COMMENDATION_PERCENT_POLL 0.05
 ## These values get directly added to values and totals ingame.
 ## To speed things up make the number negative, to slow things down, make the number positive.
 
-## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
-RUN_DELAY 4
-WALK_DELAY 5
-SPRINT_DELAY 2
-
-## The variables below affect the movement of specific mob types. THIS AFFECTS ALL SUBTYPES OF THE TYPE YOU CHOOSE!
-## Entries completely override all subtypes. Later entries have precedence over earlier entries.
-## This means if you put /mob 0 on the last entry, it will null out all changes, while if you put /mob as the first entry and
-## /mob/living/carbon/human on the last entry, the last entry will override the first.
-##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/human 0
-##MULTIPLICATIVE_MOVESPEED /mob/living/silicon/robot 0
-##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/alien 0
-##MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal/slime 0
-MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 0
-
-
 ## NAMES ###
 ## If uncommented this adds a random surname to a player's name if they only specify one name.
 HUMANS_NEED_SURNAMES


### PR DESCRIPTION
Rewrites movement speed to be based on tiles-per-second instead of deciseconds-between-steps. Values were converted based on the default run speed of 0.4 seconds between steps, or 2.5 tiles-per-second.

Additionally adds multiplicative modifiers which are applied after additive modifiers.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Rewrote how movement speed is calculated, most buffs and debuffs are now scale linearly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
