### PR TITLE
fixes cargo not being able to order the full chemistry cart pack 

### DIFF
--- a/code/modules/cargo/supply_packs/reagent_packs.dm
+++ b/code/modules/cargo/supply_packs/reagent_packs.dm
@@ -6,9 +6,8 @@
 	crate_type = /obj/structure/closet/crate/medical
 
 /datum/supply_pack/reagent/chemical_carts
-	name = "Full Chemistry Cartridge Pack"
-	desc = "Contains a full set of chem dispenser cartridges with every chemical you'll need for making pharmaceuticals."
-	cost = PAYCHECK_ASSISTANT * 50 + CARGO_CRATE_VALUE //price may need balancing
+	name = "Generic Chemistry Cartridge Pack"
+	desc = "You shouldn't see this."
 	crate_name = "chemical cartridges crate"
 
 /datum/supply_pack/reagent/chemical_carts/New()
@@ -42,8 +41,16 @@
 					/obj/item/reagent_containers/chem_cartridge/small)
 	crate_name = "empty chemical cartridges crate"
 
-/datum/supply_pack/reagent/chemical_carts/soft_drinks_chem_cartridge //IGNORE THE TYPEPATH PLEASE
-	name = "Soft Drinks Cartridge Luxury Pack (Full Dispenser)"
+/datum/supply_pack/reagent/chemical_carts/chemistry_starter_pack
+	name = "Full Chemistry Cartridge Pack"
+	desc = "Contains a full set of chem dispenser cartridges with every chemical you'll need for making pharmaceuticals."
+	cost = PAYCHECK_ASSISTANT * 50 + CARGO_CRATE_VALUE //price may need balancing
+
+/datum/supply_pack/reagent/chemical_carts/chemistry_starter_pack/set_cart_list()
+	contains = GLOB.cartridge_list_chems.Copy()
+
+/datum/supply_pack/reagent/chemical_carts/soft_drinks_chem_cartridge
+	name = "Drinks Cartridge Luxury Pack (Full Dispenser)"
 	desc = "Contains a full set of chem cartridges of the same size inside a soft drinks dispenser at shift start."
 	cost = PAYCHECK_ASSISTANT * 8.7 + CARGO_CRATE_VALUE
 
@@ -73,7 +80,7 @@
 	for(var/datum/reagent/reagent_path as anything in GLOB.cartridge_list_chems | GLOB.cartridge_list_botany | GLOB.cartridge_list_booze | GLOB.cartridge_list_drinks)
 		var/datum/supply_pack/reagent/individual_chem_cart/pack = new
 		var/name = initial(reagent_path.name)
-		pack.name = "Crate of [name]"
+		pack.name = "Single Crate of [name]"
 		pack.desc = "Contains [volume]u of [name]."
 		pack.crate_name = "reagent crate ([name])"
 		pack.id = "[type]([name])"


### PR DESCRIPTION
## About The Pull Request

Somehow, among testing everything, i didn't make sure that the cargo crate for every chem pack that chemistry should get actually existed and could be bought. Unless something broke it. But it looks like I just never coded it in right.

Don't actually merge this i'm going to test it later this is a draft thanks

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Cargo can now order a crate with one of every chemical cartridge the chemistry dispenser starts with. This was supposed to already be a thing. Oops!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
