### PR TITLE
Fixes the corners of the map crashing clients

### DIFF
--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -140,7 +140,7 @@ GLOBAL_REAL_VAR(space_appearances) = make_space_appearances()
 
 /turf/open/space/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
-	if(!arrived || src != arrived.loc)
+	if(!arrived || src != arrived.loc || istype(arrived, /atom/movable/mirage_holder))
 		return
 
 	if(destination_z && destination_x && destination_y && !LAZYLEN(arrived.grabbed_by) && !arrived.currently_z_moving)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

trans-z-level space tiles are covered by mirages
mirages spawn on space tiles after they've already been made to teleport you.
https://github.com/DaedalusDock/Daedalusdock/issues/296 made it so that atoms spawned on turfs enter said turf.
mirages were thus being teleported around. The result of this is unpredictable as inspecting it visually would kill your client.

this quietly band-aids that.

## Changelog



:cl:
fix: the corners of space will no longer result in the BYOND equivalent of a chunk ban.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
