### PR TITLE
Fix Air Alarms

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -502,12 +502,14 @@ TYPEINFO_DEF(/obj/machinery/airalarm)
 	else
 		return FALSE
 
-/obj/machinery/airalarm/proc/send_signal(target, list/command, atom/user)//sends signal 'command' to 'target'. Returns 0 if no radio connection, 1 otherwise
+/obj/machinery/airalarm/proc/send_signal(target, list/payload, atom/user)//sends signal 'command' to 'target'. Returns 0 if no radio connection, 1 otherwise
 	if(!radio_connection)
 		return FALSE
 
-	var/datum/signal/signal = create_signal(payload = list("tag" = "target", "sigtype" = "command"), transmission_method = TRANSMISSION_RADIO)
+	var/datum/signal/signal = create_signal(payload = list("tag" = target, "sigtype" = "command"), transmission_method = TRANSMISSION_RADIO)
 	signal.logging_data = list("user_keyname" = key_name(usr))
+	signal.data[PKT_PAYLOAD] += payload
+
 	radio_connection.post_signal(signal, RADIO_FROM_AIRALARM)
 	return TRUE
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -21,7 +21,7 @@
 	net_class = NETCLASS_DP_VENT_PUMP
 
 	connection_frequency = FREQ_ATMOS_CONTROL
-	default_connection_frequency_inbound_filter = RADIO_TO_AIRALARM
+	default_connection_frequency_inbound_filter = RADIO_FROM_AIRALARM
 
 	hide = TRUE
 	initial_volume = ATMOS_DEFAULT_VOLUME_PUMP
@@ -157,12 +157,12 @@
 		update_appearance(UPDATE_NAME)
 		GLOB.air_vent_names[id_tag] = name
 
-	vent_area.air_vent_info[id_tag] = signal.data
+	vent_area.air_vent_info[id_tag] = astype(signal.data[PKT_PAYLOAD], /list).Copy()
 	radio_connection.post_signal(signal, filter = radio_filter_out)
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/atmos_init()
-	default_connection_frequency_inbound_filter = connection_frequency ==FREQ_ATMOS_CONTROL?(RADIO_FROM_AIRALARM):null
-	radio_filter_out = connection_frequency ==FREQ_ATMOS_CONTROL?(RADIO_TO_AIRALARM):null
+	default_connection_frequency_inbound_filter = connection_frequency ==FREQ_ATMOS_CONTROL ? RADIO_FROM_AIRALARM :null
+	radio_filter_out = connection_frequency ==FREQ_ATMOS_CONTROL ? RADIO_TO_AIRALARM :null
 	// Refreshes the filter on the inbound connection.
 	if(connection_frequency)
 		set_connection_frequency(connection_frequency, filter = default_connection_frequency_inbound_filter)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -22,7 +22,7 @@
 	pipe_state = "uvent"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
-	network_flags = NETWORK_FLAG_GEN_ID
+	network_flags = NETWORK_FLAG_GEN_ID | NETWORK_FLAG_JOIN_FREQUENCY
 	net_class = NETCLASS_VENT_PUMP
 
 	power_rating = 30000
@@ -188,7 +188,7 @@
 		update_appearance(UPDATE_NAME)
 		GLOB.air_vent_names[id_tag] = name
 
-	vent_area.air_vent_info[id_tag] = signal.data
+	vent_area.air_vent_info[id_tag] = astype(signal.data[PKT_PAYLOAD], /list).Copy()
 
 	radio_connection.post_signal(signal, radio_filter_out)
 
@@ -202,7 +202,7 @@
 
 /obj/machinery/atmospherics/components/unary/vent_pump/atmos_init()
 	//some vents work his own spesial way
-	default_connection_frequency_inbound_filter = connection_frequency == FREQ_ATMOS_CONTROL ? (RADIO_FROM_AIRALARM):null
+	default_connection_frequency_inbound_filter = connection_frequency == FREQ_ATMOS_CONTROL ? (RADIO_FROM_AIRALARM) : null
 	radio_filter_out = connection_frequency == FREQ_ATMOS_CONTROL ? (RADIO_TO_AIRALARM) : null
 
 	// Refreshes the inbound radio filter

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -164,7 +164,7 @@
 		update_appearance(UPDATE_NAME)
 		GLOB.air_scrub_names[id_tag] = name
 
-	scrub_area.air_scrub_info[id_tag] = signal.data
+	scrub_area.air_scrub_info[id_tag] = astype(signal.data[PKT_PAYLOAD], /list).Copy()
 
 	radio_connection.post_signal(signal, radio_filter_out)
 


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Air Alarms can configure vent pumps again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
