### PR TITLE
Fix Z-Mimic Space Rendering

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -11,10 +11,10 @@
 #define PLANE_SPACE -95
 #define PLANE_SPACE_PARALLAX -90
 
-/*
-Z-Mimic uses planes -70 through -80, defined elsewhere.
-Specifically: ZMIMIC_MAX_PLANE to (ZMIMIC_MAX_PLANE - ZMIMIC_MAX_DEPTH)
-*/
+
+#define ZMIMIC_MAX_PLANE -70
+
+#define ZMIMIC_MAX_DEPTH 10	//! The maximum depth of a single contiguous z-stack. Exceeding this will emit a warning and result in broken layering in the lower levels of that stack.
 
 #define HEAT_PLANE -12
 #define HEAT_RENDER_TARGET "*HEAT_RENDER_TARGET"
@@ -226,3 +226,24 @@ Specifically: ZMIMIC_MAX_PLANE to (ZMIMIC_MAX_PLANE - ZMIMIC_MAX_DEPTH)
 ///Plane master controller keys
 #define PLANE_MASTERS_GAME "plane_masters_game"
 #define PLANE_MASTERS_COLORBLIND "plane_masters_colorblind"
+
+/proc/generate_planemasters(datum/hud/owner, exclude_blackness = TRUE)
+	var/list/types = subtypesof(/atom/movable/screen/plane_master)
+	types -= /atom/movable/screen/plane_master/zmimic
+	if(exclude_blackness)
+		types -= /atom/movable/screen/plane_master/blackness
+
+	. = list()
+
+	for(var/atom/movable/screen/plane_master/path as anything in types)
+		if(isabstract(path))
+			continue
+
+		. += new path(null, owner)
+
+	for(var/i in ZMIMIC_MAX_PLANE to (ZMIMIC_MAX_PLANE - ZMIMIC_MAX_DEPTH) step -1)
+		var/atom/movable/screen/plane_master/zmimic/mimic_plane = new /atom/movable/screen/plane_master/zmimic(null, owner)
+		mimic_plane.name = "[mimic_plane.name] [i]"
+		mimic_plane.plane = i
+		. += mimic_plane
+

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -80,8 +80,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 
 	hand_slots = list()
 
-	for(var/mytype in subtypesof(/atom/movable/screen/plane_master)- /atom/movable/screen/plane_master/rendering_plate)
-		var/atom/movable/screen/plane_master/instance = new mytype(null, src)
+	for(var/atom/movable/screen/plane_master/instance as anything in generate_planemasters(src, FALSE))
 		plane_masters["[instance.plane]"] = instance
 		instance.backdrop(mymob)
 

--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -74,8 +74,7 @@
 	assigned_map = map_key || "byondui_[ref(src)]"
 	set_position(1, 1)
 
-	for (var/plane_master_type in subtypesof(/atom/movable/screen/plane_master) - /atom/movable/screen/plane_master/blackness)
-		var/atom/movable/screen/plane_master/plane_master = new plane_master_type()
+	for(var/atom/movable/screen/plane_master/plane_master as anything in generate_planemasters())
 		plane_master.assigned_map = assigned_map
 		if(plane_master.blend_mode_override)
 			plane_master.blend_mode = plane_master.blend_mode_override

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -141,6 +141,10 @@
 	name = "parallax whitifier plane master"
 	plane = PLANE_SPACE
 
+/atom/movable/screen/plane_master/zmimic
+	name = "zmimic plane master"
+	plane = ZMIMIC_MAX_PLANE
+
 /atom/movable/screen/plane_master/pipecrawl
 	name = "pipecrawl plane master"
 	plane = PIPECRAWL_IMAGES_PLANE

--- a/code/_onclick/hud/rendering/plane_master_controller.dm
+++ b/code/_onclick/hud/rendering/plane_master_controller.dm
@@ -92,6 +92,11 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 		LIGHTING_PLANE_ADDITIVE,
 	)
 
+/atom/movable/plane_master_controller/game/Initialize(mapload, datum/hud/hud)
+	. = ..()
+	for(var/plane in ZMIMIC_MAX_PLANE to ZMIMIC_MAX_PLANE - ZMIMIC_MAX_DEPTH)
+		controlled_planes += plane
+
 /// Controller of all planes we're ok with changing with colorblind logic
 /atom/movable/plane_master_controller/colorblind
 	name = PLANE_MASTERS_COLORBLIND
@@ -115,4 +120,10 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 		HUD_PLANE,
 		ABOVE_HUD_PLANE,
 	)
+
+/atom/movable/plane_master_controller/colorblind/Initialize(mapload, datum/hud/hud)
+	. = ..()
+	for(var/plane in ZMIMIC_MAX_PLANE to ZMIMIC_MAX_PLANE - ZMIMIC_MAX_DEPTH)
+		controlled_planes += plane
+
 

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -24,6 +24,7 @@
  * remember that once planes are unified on a render plate you cant change the layering of them!
  */
 /atom/movable/screen/plane_master/rendering_plate
+	abstract_type = /atom/movable/screen/plane_master/rendering_plate
 	name = "default rendering plate"
 
 

--- a/code/controllers/subsystem/zcopy.dm
+++ b/code/controllers/subsystem/zcopy.dm
@@ -2,9 +2,6 @@
  *! Here be dragons.
  */
 
-#define ZMIMIC_MAX_PLANE -70
-
-#define ZMIMIC_MAX_DEPTH 10	//! The maximum depth of a single contiguous z-stack. Exceeding this will emit a warning and result in broken layering in the lower levels of that stack.
 #define SHADOWER_DARKENING_FACTOR 0.6	//! The multiplication factor for openturf shadower darkness. Lighting will be multiplied by this.
 #define SHADOWER_DARKENING_COLOR "#999999"	//! The above, but as an RGB string for lighting-less turfs.
 #define READ_BASETURF(T) (islist(T.baseturfs) ? T.baseturfs[length(T.baseturfs)] : T.baseturfs)
@@ -276,8 +273,8 @@ SUBSYSTEM_DEF(zcopy)
 		if (below_turf.z_eventually_space)
 			T.z_eventually_space = TRUE
 			// This does not work due to the way TG handles space parallax and render plates.
-			// if ((below_turf.z_flags & Z_MIMIC_OVERWRITE) || isspaceturf(below_turf))
-			// 	t_target = PLANE_SPACE
+			if ((below_turf.z_flags & Z_MIMIC_OVERWRITE) || isspaceturf(below_turf))
+				t_target = PLANE_SPACE
 
 		var/list/underlay_copy
 		if (T.z_flags & Z_MIMIC_OVERWRITE)

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -72,8 +72,7 @@
 	// NOT apply to map popups. If there's ever a way to make planesmasters
 	// omnipresent, then this wouldn't be needed.
 	cam_plane_masters = list()
-	for(var/plane in subtypesof(/atom/movable/screen/plane_master) - /atom/movable/screen/plane_master/blackness)
-		var/atom/movable/screen/plane_master/instance = new plane()
+	for(var/atom/movable/screen/plane_master/instance as anything in generate_planemasters())
 		if(instance.blend_mode_override)
 			instance.blend_mode = instance.blend_mode_override
 		instance.assigned_map = "spypopup_map"

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -63,6 +63,9 @@ GLOBAL_REAL_VAR(space_appearances) = make_space_appearances()
 		overlays += global.fullbright_overlay
 		luminosity = TRUE
 
+	if (z_flags & Z_MIMIC_BELOW)
+		setup_zmimic(mapload)
+
 	return INITIALIZE_HINT_NORMAL
 
 /proc/make_space_appearances()
@@ -229,7 +232,7 @@ GLOBAL_REAL_VAR(space_appearances) = make_space_appearances()
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "invisible"
 	z_flags = Z_ATMOS_IN_DOWN | Z_ATMOS_IN_UP | Z_ATMOS_OUT_DOWN | Z_ATMOS_OUT_UP | Z_MIMIC_BELOW | Z_MIMIC_OVERWRITE | Z_MIMIC_NO_AO
-
+	z_eventually_space = FALSE
 
 /turf/open/space/CanZPass(atom/movable/A, direction, z_move_flags)
 	if(z == A.z) //moving FROM this turf

--- a/code/modules/admin/view_variables/color_matrix_editor.dm
+++ b/code/modules/admin/view_variables/color_matrix_editor.dm
@@ -37,8 +37,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/color_matrix_proxy_view)
 	if (!client)
 		return
 
-	for (var/plane_master_type in subtypesof(/atom/movable/screen/plane_master) - /atom/movable/screen/plane_master/blackness)
-		var/atom/movable/screen/plane_master/plane_master = new plane_master_type()
+	for(var/atom/movable/screen/plane_master/plane_master as anything in generate_planemasters())
 		plane_master.screen_loc = "[assigned_map]:CENTER"
 		client?.screen |= plane_master
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -477,8 +477,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/character_preview_view)
 	if (!client)
 		return
 
-	for (var/plane_master_type in subtypesof(/atom/movable/screen/plane_master) - /atom/movable/screen/plane_master/blackness)
-		var/atom/movable/screen/plane_master/plane_master = new plane_master_type()
+	for(var/atom/movable/screen/plane_master/plane_master as anything in generate_planemasters())
 		plane_master.screen_loc = "[assigned_map]:0,CENTER"
 		client?.screen |= plane_master
 

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -15,8 +15,8 @@
 	owner = newowner
 	assigned_map = "mech_view_[REF(owner)]"
 	set_position(1, 1)
-	for(var/plane_master_type in subtypesof(/atom/movable/screen/plane_master) - /atom/movable/screen/plane_master/blackness)
-		var/atom/movable/screen/plane_master/plane_master = new plane_master_type()
+
+	for(var/atom/movable/screen/plane_master/plane_master as anything in generate_planemasters())
 		plane_master.screen_loc = "[assigned_map]:CENTER"
 		plane_masters += plane_master
 

--- a/code/modules/zmimic/mimic_turf.dm
+++ b/code/modules/zmimic/mimic_turf.dm
@@ -19,13 +19,14 @@
 
 /turf/update_above()
 	if (TURF_IS_MIMICKING(above))
-		above.update_mimic()
+		return above.update_mimic()
 
 /turf/proc/update_mimic()
 	if(z_flags & Z_MIMIC_BELOW)
 		z_queued += 1
 		// This adds duplicates for a reason. Do not change this unless you understand how ZM queues work.
 		SSzcopy.queued_turfs += src
+		return TRUE
 
 /// Enables Z-mimic for a turf that didn't already have it enabled.
 /turf/proc/enable_zmimic(additional_flags = 0)


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Kapu1178, Lohikar
fix: On our zero multi-z maps, space renders more* correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
